### PR TITLE
docs(agents): correct the exposure claim — a curl from the host proves nothing (ELEG-8)

### DIFF
--- a/.agents/deployment.md
+++ b/.agents/deployment.md
@@ -57,14 +57,25 @@ Three consequences that have already produced a real artefact:
 ## Exposure is decided outside this repo
 
 The service binds `0.0.0.0` and has **no authentication of any kind** (see
-[security.md](security.md)). Whether it is reachable beyond the LAN is decided by a
-reverse proxy / tunnel configured in the **`~/ansible` (ANS)** repo, not here — so a
-change to *who can reach it* is an ANS issue, and the specifics of how this particular
-host is exposed are recorded in the **ELEG tracker**, deliberately not in this public
-repository.
+[security.md](security.md)), so what limits who can reach it is entirely the network
+around it: a reverse-proxy vhost and DNS, both configured in the **`~/ansible` (ANS)**
+repo rather than here. A change to *who can reach it* is therefore an ANS issue, and the
+specifics for a given deployment belong in the **ELEG tracker**, deliberately not in this
+public repository.
 
-Read [security.md](security.md) before adding an endpoint: on this deployment, "internal
-only" is not a safe assumption to design against.
+Two consequences for anyone testing this:
+
+- **A request from the host itself proves nothing about reachability.** `curl` and any
+  local fetch tool resolve and route from inside the network, so a `200` says only that
+  the service is up — not that anyone else can get to it. Answering "is this exposed?"
+  needs a resolver check (what does public DNS return — a routable address or an RFC1918
+  one?) and, for reachability, a client genuinely off the network.
+- **The proxy is not the only door.** Because the bind is `0.0.0.0`, ports 8088 and 7125
+  are directly reachable from anything routed to the host, bypassing whatever vhost or
+  auth the proxy might add.
+
+Read [security.md](security.md) before adding an endpoint: what protects this service is
+network position, not code.
 
 ## Operator commands
 

--- a/.agents/security.md
+++ b/.agents/security.md
@@ -32,6 +32,11 @@ Three things make this sharper than a typical "no auth" note:
    `/moonraker/*`. With no credentials to withhold, that means **any web page a browser
    visits can issue those requests** from inside the network the browser is on. A
    `SameSite` cookie does not help, because there is no cookie.
+
+   This is the one that survives a LAN-only deployment intact, and it is easy to
+   under-rate: the attacker does not need to reach the network, only to get someone who is
+   already on it to load a page. "It is not exposed" is an answer about inbound routing,
+   not about this.
 3. **The compat layers advertise auth they do not have.** `octoprint-compat.ts` returns
    a fixed `apikey: 'elegoo-cc2-compat'` and the Moonraker layer answers
    `access.get_api_key` — so a client shows "connected, authenticated" while nothing was
@@ -41,6 +46,13 @@ Three things make this sharper than a typical "no auth" note:
 never add one that widens the write surface without saying so on the issue. Adding an
 authentication layer is a *feature* someone has to decide on — file it, don't smuggle it
 in, and don't design new endpoints as though it were already there.
+
+**And before claiming this service is or is not exposed, measure it properly.** A `curl`
+from the host resolves and routes from inside the network, so a `200` proves the service is
+up and nothing else — that mistake was made while writing these docs (2026-08-07) and
+produced two URGENT issues on a false premise. The honest check is: what does a *public*
+resolver return for the name (a routable address, or an RFC1918 one?), and does a client
+genuinely off the network reach it? See [deployment.md](deployment.md).
 
 ## The camera and the print data are not neutral either
 


### PR DESCRIPTION
Fixes the exposure framing that merged in #11. The `.agents/` docs asserted this service was reachable from the public internet; that was wrong, and the *way* it was wrong is the part worth writing down.

## What actually happened

Both of my "from outside" checks — a WebFetch and a `curl` — run **on the host**, so they resolved and routed inside the network. A `200` from there proves the service is up and nothing about who else can reach it. I then compounded it by reading three `nginx_vhosts` entries in the ansible repo as cloudflare-tunnel routes, and their `authorization: null` field as "no Cloudflare Access policy".

Measured properly:

```
$ for r in 1.1.1.1 8.8.8.8 9.9.9.9; do dig +short @$r <this service's hostname>; done
172.20.100.6        # ×3 — RFC1918: resolvable by anyone, routable by nobody outside

$ dig +short @1.1.1.1 <a genuinely published hostname in the same estate>
104.21.95.86
172.67.170.59       # Cloudflare anycast — this is what "public" looks like here
```

No `cfargotunnel` CNAME, and no tunnel route for this service anywhere in the ansible repo.

## Changes

- **`deployment.md`** — exposure is network position, decided outside this repo; a request from the host is not evidence about reachability; and because the bind is `0.0.0.0`, the reverse proxy is not the only door (8088/7125 are directly reachable from anything routed to the host).
- **`security.md`** — the no-auth posture is unchanged, because that part was accurate. Two additions: the `Access-Control-Allow-Origin: *` drive-by is promoted to *the* risk that survives a LAN-only deployment (it needs a browser already on the network, not inbound routing), and a measurement rule with this mistake attached to it.

## Why this is a separate PR

The correction was pushed as `0fe6f8c` **after** #11 had already merged, stranding it on a merged branch. ELEG-1 is `MERGED` and one issue gets one PR, so this is ELEG-8 with its own.

## Verification

`pnpm gates` — 5/5 green. Docs-only change; no source touched.

The two issues filed on the false premise are corrected: **ELEG-2** URGENT → MEDIUM (rewritten around the CORS finding, which survives) and **ANS-372** URGENT → LOW (rewritten as removing a vhost that points at a vite dev server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)