### PR TITLE
fix(ci): pin pnpm and move settings to pnpm-workspace.yaml (ELEG-4)

### DIFF
--- a/.claude/commands/local/gates.md
+++ b/.claude/commands/local/gates.md
@@ -50,14 +50,25 @@ and throws again.
 Two independent failures, both pre-existing. Check whether they still are before
 attributing a red check to your branch — the last CI run to be green was in July.
 
-1. **`pnpm install --frozen-lockfile` fails in CI**:
-   `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — "the current `overrides` configuration doesn't
-   match the value found in the lockfile". Newer pnpm no longer reads the `pnpm` field
-   from `package.json` (it warns: *"The `pnpm` field in package.json is no longer read …
-   the following keys were ignored: `pnpm.overrides`, `pnpm.onlyBuiltDependencies`,
-   `pnpm.updateConfig`"*), so the lockfile's recorded overrides and the effective config
-   disagree and the frozen install refuses. **CI therefore fails before it runs a single
-   gate.** Filed on the tracker; don't "fix" it by deleting the lockfile.
+1. ~~**`pnpm install --frozen-lockfile` fails in CI**~~ — **fixed in ELEG-4.** The cause
+   was never really the `overrides` block: it was that `ci.yml` asked
+   `pnpm/action-setup@v4` for `version: latest`, so **CI silently moved to pnpm 11 while
+   every developer here was on 10.x**. Two different reds came out of that one drift, and
+   the second masked the first:
+   `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` (pnpm 11 stopped reading the `pnpm` field in
+   `package.json`, so the effective overrides went empty while the lockfile still recorded
+   them), and later `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` (a **pnpm 11 default policy
+   that does not exist in 10.x** — `pnpm config get minimumReleaseAge` → `undefined`).
+
+   The fix was both halves: the settings moved to `pnpm-workspace.yaml` (their documented
+   new home, read by 10.x *and* 11.x), and the package manager is now pinned by
+   `packageManager` in `package.json` with **no `version:` in the workflow**, so CI runs
+   exactly what you run. **If you bump `packageManager` to 11.x, expect the release-age
+   policy to bite** — that move is its own issue.
+
+   The lasting lesson: `version: latest` on a package-manager action means CI drifts away
+   from every developer without a commit. Don't reintroduce it. And still don't "fix" a
+   lockfile complaint by deleting the lockfile — the `undici` override is a security pin.
 2. **A formatting violation in `src/styles/main.css`** made `biome ci src/` red
    (`pnpm format:check` too). Fixed by the commit that added this file — but the shape is
    worth knowing, because biome reports a formatting violation as `Found 1 error.` with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No `version:` on purpose — action-setup then reads `packageManager` from
+      # package.json, so CI uses the exact pnpm developers use. `version: latest`
+      # silently moved CI to pnpm 11 while everyone here was on 10.x, which broke
+      # the frozen install two different ways (ELEG-4).
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.1",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.33.3",
   "simple-git-hooks": {
     "pre-commit": "pnpm exec biome check --staged --write --no-errors-on-unmatched"
   },
@@ -62,22 +63,5 @@
     "winston": "^3.19.0",
     "ws": "^8.21.2",
     "zod": "^4.4.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "undici": ">=6.24.0"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "onnxruntime-node",
-      "protobufjs",
-      "sharp"
-    ],
-    "updateConfig": {
-      "ignoreDependencies": [
-        "three",
-        "@types/three"
-      ]
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,20 @@
+# pnpm settings. These lived in package.json's "pnpm" field until pnpm 11 stopped
+# reading it ("The `pnpm` field in package.json is no longer read by pnpm"), which
+# left the effective overrides empty while pnpm-lock.yaml still recorded them — and
+# --frozen-lockfile correctly refused the mismatch (ELEG-4). This file is the
+# documented new home and is read by both 10.x and 11.x.
+
+# Security pin, not a compatibility shim — keep it.
+overrides:
+  undici: '>=6.24.0'
+
+onlyBuiltDependencies:
+  - esbuild
+  - onnxruntime-node
+  - protobufjs
+  - sharp
+
+updateConfig:
+  ignoreDependencies:
+    - three
+    - '@types/three'


### PR DESCRIPTION
Fixes ELEG-4.

## The issue description is half-stale — read this first

`pnpm install --frozen-lockfile` **passes locally** (pnpm 10.33.3, exit 0). It only ever failed in CI, and the reason is the thing ELEG-4 mentioned in passing rather than the thing it led with: `ci.yml` asked `pnpm/action-setup@v4` for `version: latest`, and **`latest` is now 11.20.0**. CI has been running a different package manager from every developer, without a commit to show for it.

That single drift produced two different reds, and the newer one masked the older:

| Run | Supply-chain check | Then |
| --- | --- | --- |
| 31168374423 (quoted in the issue) | `✓ passes` | `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` |
| 31175843206 (latest on `main`) | `✗ fails` | `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — 4 entries inside the 24h cutoff |

`minimumReleaseAge` is a **pnpm 11 default policy that does not exist in 10.x** (`pnpm config get minimumReleaseAge` → `undefined` locally). So doing only what the issue described — moving the `overrides` block — would **not** have turned CI green; the install would still have died one step earlier. Both halves were needed, which is why the version pin is here rather than split out as the description suggested: without it ELEG-4's own "Verify" bullet ("the next CI run gets past install") is unreachable.

## Changes

- **`pnpm-workspace.yaml` (new)** — `overrides`, `onlyBuiltDependencies` and `updateConfig` move out of `package.json`'s `pnpm` field into their documented new home, read by 10.x and 11.x alike.
- **`packageManager: "pnpm@10.33.3"`** in `package.json`, and **`version:` dropped** from the workflow. `pnpm/action-setup@v4` reads `packageManager` when `version` is absent, so CI now runs exactly what developers run. 10.33.3 matches `AGENTS.md`'s stated "pnpm 10.x".
- **`local/gates.md`** — known-red #1 marked fixed, with the actual cause and the warning not to reintroduce `version: latest`.

**The lockfile is deliberately unchanged.** `pnpm-workspace.yaml` yields an identical override set, so there was nothing to regenerate — contrary to the issue's expectation. Not deleting the lockfile and not dropping `--frozen-lockfile`, as instructed.

## Verified

Measured in the failing direction, in an isolated copy so the lockfile could not be rewritten:

| Setup | Result |
| --- | --- |
| pnpm 10.33.3, frozen | **passes**, lockfile untouched — proves `pnpm-workspace.yaml` is read (an empty override set is precisely what fails) |
| pnpm 11.20.0, pin present | **self-switches to 10.33.3** — the pin works end to end |
| pnpm 11.20.0, pin stripped | no `[WARN] pnpm field`, **no `CONFIG_MISMATCH`** — the original bug is genuinely fixed and forward-compatible; only the pnpm 11 release-age policy remains, which the pin sidesteps |

- `pnpm gates` — all five green (biome, both typechecks, vite build, 6/6 vitest).
- `undici` security pin survives: resolves to `undici@8.10.0` (satisfies `>=6.24.0`).

**No test covers any of this** — it is build configuration, and the suite is six tests over two pure functions. The evidence is the install matrix above, not the test run.

## Note for the reviewer

The real CI verdict on this PR is the first honest signal in months. Follow-ups (deliberate pnpm 11 move) filed separately.