### PR TITLE
feat(ci): run pnpm gates as CI's single step (ELEG-5)

### DIFF
--- a/.claude/commands/auto.md
+++ b/.claude/commands/auto.md
@@ -103,8 +103,8 @@ Announce the order and the split/skip intentions before starting, then work it.
   otherwise is the main risk of an unattended pass.** There are **six tests** covering
   two pure functions; the MQTT bridge, the state store, every REST route, `/mcp`, both
   compat layers, Telegram, the AI monitor and the entire frontend have **no test at
-  all**, and there is no browser check. CI runs the same tests, so it adds nothing here
-  — and it also does not run the service typecheck. Five items, seconds each:
+  all**, and there is no browser check. CI runs `pnpm gates` — the same gates you just
+  ran locally — so a green CI adds confirmation, not coverage. Five items, seconds each:
 
   1. **Break the invariant and watch the named test go red.** If no test covers it —
      which is the common case — **write that sentence in the closing comment** rather

--- a/.claude/commands/local/gates.md
+++ b/.claude/commands/local/gates.md
@@ -1,5 +1,5 @@
 ---
-description: LOCAL to elegoo-web — the gate command, the typecheck CI does not run, why green means very little here, the red main, and the printer boundary no gate can enforce.
+description: LOCAL to elegoo-web — the gate command (which is what CI runs), why green still means very little here, and the printer boundary no gate can enforce.
 ---
 
 # local: this repo's gates
@@ -16,39 +16,55 @@ pnpm gates          # scripts/gates.sh — the whole set, with a ✓/✗ summary
 pnpm gates --fix    # biome check --write first; commit what it rewrites
 ```
 
-Five checks, in CI's order, plus one CI does not run:
+Five checks — and since ELEG-5, **`ci.yml` runs this exact script as its only step**, so
+this table is CI's step list too. Add a gate here and CI picks it up with no workflow edit.
 
 | # | Check | Command | Notes |
 | --- | --- | --- | --- |
-| 1 | lint | `biome ci src/` | **non-writing**, as CI does it |
+| 1 | lint | `biome ci src/` | **non-writing**, as CI does it; covers formatting as well as lint |
 | 2 | typecheck (browser) | `tsc` | `tsconfig.json` — **excludes `src/server`, `src/telegram`** |
-| 3 | typecheck (service) | `tsc -p tsconfig.server.json` | **CI does not run this.** See below |
+| 3 | typecheck (service) | `tsc -p tsconfig.server.json` | `tsconfig.server.json` — the other half. See below |
 | 4 | build | `vite build` | writes `dist/`, which is gitignored |
 | 5 | tests | `vitest run` | 6 tests, ~150 ms |
 
 Grep the log for `✗` to get the failing gate, then read upward for that check's own
 output.
 
-## The whole backend is outside the typecheck CI runs
+## There are two typechecks, and `pnpm build` is only one of them
 
-`tsconfig.json` **excludes `src/server` and `src/telegram`**, and `pnpm build` runs only
-that config. CI runs `lint`, `format:check`, `build`, `test` — so **`src/server/**` and
-`src/telegram/**` are typechecked by nothing in CI at all**, and a type-broken service
-merges green.
+`tsconfig.json` **excludes `src/server` and `src/telegram`**, and `pnpm build` (`tsc &&
+vite build`) runs only that config. So `pnpm build` passing says **nothing** about the
+backend. Measured, by appending `const __probe: number = "not a number"` to
+`src/server/config.ts`:
 
-That is why `pnpm gates` runs `service:check` even though CI does not: a green CI on a
-backend change is close to meaningless without it. If you are running single checks by
-hand rather than `pnpm gates`, run both typechecks.
+```
+pnpm exec tsc        -> PASS   (the browser config never sees src/server)
+pnpm build           -> PASS   (same config, so also blind)
+pnpm service:check   -> FAIL   caught
+pnpm gates           -> FAIL   caught
+```
 
-Production makes this worse rather than better: the service runs the TypeScript
-**directly** under `node --import tsx`, so there is no compile step between a type error
-and the running service — the process just throws at runtime, restarts (`Restart=always`),
-and throws again.
+**This used to be a hole in CI and is not any more** (ELEG-5): CI ran `lint`,
+`format:check`, `build`, `test`, so the entire backend was typechecked by nothing and a
+type-broken service merged green. `ci.yml` now runs `pnpm gates`, which includes
+`service:check`.
 
-## `main` is red right now, and not because of you
+The trap that remains is the one the table above encodes: **`pnpm build` is not a
+typecheck of the backend.** If you are running single checks by hand rather than
+`pnpm gates`, run both typechecks — the second is the one that matters for
+`src/server/**` and `src/telegram/**`.
 
-Two independent failures, both pre-existing. Check whether they still are before
-attributing a red check to your branch — the last CI run to be green was in July.
+Production is why this bites: the service runs the TypeScript **directly** under
+`node --import tsx`, so there is no compile step between a type error and the running
+service — the process just throws at runtime, restarts (`Restart=always`), and throws
+again.
+
+## `main` is green again — the two reds that used to be here are both fixed
+
+**As of ELEG-4, CI passes on `main` for the first time since July** (run 31176229965,
+`✓ ci in 8m57s`). So the old advice — "a red check is probably not yours" — no longer
+applies by default: **a red check on your branch is now most likely yours.** Both
+historical reds are kept below because their shapes recur, not because they are live.
 
 1. ~~**`pnpm install --frozen-lockfile` fails in CI**~~ — **fixed in ELEG-4.** The cause
    was never really the `overrides` block: it was that `ci.yml` asked
@@ -75,9 +91,13 @@ attributing a red check to your branch — the last CI run to be green was in Ju
    **no `✖` marker and no rule name**, which reads like a crash. `--reporter=summary`
    names the file.
 
-So on this repo, right now: **a red CI check is not evidence about your change** until
-you have looked at *which* step failed. And a green local `pnpm gates` is the substantive
-evidence — say so explicitly in the closing comment rather than implying CI ran.
+Either way the habit stands: **read which step failed before attributing a red check** to
+your branch or dismissing it. What has changed is the prior — a red check is now evidence
+about your change rather than background noise.
+
+One thing that did **not** change: the install step takes **~9 minutes** on a cold cache,
+because `onlyBuiltDependencies` lets `onnxruntime-node`, `sharp`, `protobufjs` and
+`esbuild` run native build scripts. A long-running install is not a hang.
 
 ## CI works here, unlike in the private siblings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm lint
-      - run: pnpm format:check
-      - run: pnpm build
-      - run: pnpm test
+      # One step, not four. `scripts/gates.sh` is the single list of what has to pass,
+      # so a gate can no longer exist in the repo but be missing from CI — which is
+      # exactly how the backend went unchecked (ELEG-5).
+      #
+      # It is a strict superset of the four steps it replaced: `biome ci src/` covers
+      # both `lint` and `format:check`, `tsc` + `vite build` is `build`, `vitest run`
+      # is `test` — PLUS `service:check`, the typecheck of src/server and src/telegram
+      # that tsconfig.json excludes and CI therefore never ran.
+      #
+      # It also reports every failing gate in one run rather than stopping at the first.
+      - run: pnpm gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,15 +51,21 @@ Node ≥ 22, pnpm 10.x. There is no database and no container needed for develop
 ## Build / test / lint (run before finishing any change)
 
 ```bash
-pnpm gates          # ⭐ everything, in CI's order (scripts/gates.sh)
+pnpm gates          # ⭐ everything (scripts/gates.sh) — and this is literally what CI runs
 pnpm gates --fix    # biome --write first, then the gates — commit what it rewrites
 ```
 
 `pnpm gates` is the one to run: `biome ci src/` (**non-writing**, as CI does it),
-`tsc` (the browser half), **`pnpm service:check`** (the server + telegram half —
-the typecheck CI does *not* run), `vite build`, and `vitest run`. The individual
-scripts still exist for a tight inner loop; details, traps and the known gaps are in
+`tsc` (the browser half), **`pnpm service:check`** (the server + telegram half),
+`vite build`, and `vitest run`. The individual scripts still exist for a tight inner
+loop; details, traps and the known gaps are in
 [`.claude/commands/local/gates.md`](.claude/commands/local/gates.md).
+
+**`ci.yml` runs `pnpm gates` as a single step** (ELEG-5), so the gate list lives in one
+place and CI cannot fall behind it — adding a gate to `scripts/gates.sh` needs no
+workflow edit. It used to be four hand-listed steps, which is precisely how the backend
+came to be typechecked by nothing in CI. A green CI now means the same thing a green
+local run means; what that still does *not* prove is in `local/gates.md`.
 
 CI is [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on `ubuntu-latest` —
 which works here because **this repo is public** and public repos get free hosted

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -4,12 +4,17 @@
 #   pnpm gates          # everything
 #   pnpm gates --fix    # `biome check --write` first, then everything
 #
-# These are the checks .github/workflows/ci.yml runs, in the same order, PLUS ONE:
-# `service:check`. That is not an accident — tsconfig.json excludes src/server and
-# src/telegram, and CI only ever runs the build (which uses that config), so the
-# entire backend is typechecked by nothing in CI. Production runs the TypeScript
-# directly under `node --import tsx`, so a type error there reaches the running
-# service without a compile step in between.
+# THIS FILE IS WHAT CI RUNS (ELEG-5). .github/workflows/ci.yml is one step,
+# `pnpm gates`, so this script is the single list of what has to pass and the two
+# cannot drift apart. Add a gate here and CI picks it up with no workflow edit.
+#
+# It used to be four hand-listed steps in ci.yml, which is how `service:check` came
+# to be missing from them: tsconfig.json excludes src/server and src/telegram, CI only
+# ran the build (which uses that config), and so the entire backend was typechecked by
+# nothing in CI. Measured at the time — a deliberate type error in src/server/config.ts
+# left `pnpm build` PASSING and only `service:check` caught it. Production runs the
+# TypeScript directly under `node --import tsx`, so such an error reaches the running
+# service with no compile step in between.
 #
 # On biome: CI runs the NON-writing `biome ci`. `pnpm check` auto-fixes and exits 0,
 # so an auto-fix you did not commit still fails CI's lint step — hence --fix runs the
@@ -55,7 +60,7 @@ fi
 # Order mirrors ci.yml: cheapest signal first.
 run 'biome ci (non-writing, as CI runs it)' pnpm exec biome ci src/
 run 'typecheck: browser half (tsconfig.json)' pnpm exec tsc
-run 'typecheck: service + telegram (NOT run by CI)' pnpm run service:check
+run 'typecheck: service + telegram' pnpm run service:check
 run 'build (vite)' pnpm exec vite build
 run 'unit tests (vitest)' pnpm exec vitest run
 


### PR DESCRIPTION
Fixes ELEG-5. Depends on ELEG-4 (#13), which is merged — CI is green again, so this PR's check is a real signal.

## The hole, re-measured rather than trusted

`tsconfig.json` excludes `src/server` and `src/telegram`; `ci.yml` ran `lint`, `format:check`, `build`, `test`, where `build` is `tsc && vite build` against that config. So the whole backend was typechecked by nothing in CI.

The issue asserted this with a measurement. I re-ran it before changing anything — appending `const __probe: number = "not a number"` to `src/server/config.ts`:

| Command | Result |
| --- | --- |
| `pnpm exec tsc` | **PASS** — the browser config never sees `src/server` |
| `pnpm build` (the actual CI step) | **PASS** — same config, so the CI step was blind too |
| `pnpm service:check` | **FAIL** — caught |
| `pnpm gates` (proposed step) | **FAIL** — caught |

The claim holds, and the second row is the sharpest statement of it: **the step CI ran passed on a deliberately type-broken backend.**

## The change

Four steps become one:

```yaml
      - run: pnpm install --frozen-lockfile
      - run: pnpm gates
```

That fixes the instance *and* the class the issue names — a gate that exists in the repo but is missing from one of the places that lists them. `scripts/gates.sh` is now the single list; adding a gate needs no workflow edit.

**It is a strict superset of what it replaced**, checked rather than assumed:

| Old step | Covered by |
| --- | --- |
| `pnpm lint` | `biome ci src/` |
| `pnpm format:check` | `biome ci src/` (biome's `ci` does lint **and** format) |
| `pnpm build` | `tsc` + `vite build`, run separately |
| `pnpm test` | `vitest run` |
| — | **`pnpm service:check`** ← the addition |

It also reports every failing gate in one run rather than stopping at the first, which is better in CI than locally.

## Docs corrected in the same commit

Four files asserted the hole this PR closes; leaving them would have been drift of exactly the kind ELEG-5 is about:

- `AGENTS.md` — "the typecheck CI does *not* run"
- `.claude/commands/local/gates.md` — the gate table, the "whole backend is outside the typecheck CI runs" section, and the front-matter description
- `.claude/commands/auto.md` — "CI ... does not run the service typecheck"
- `scripts/gates.sh` — its own header comment

`local/gates.md` also still described `main` as red, which ELEG-4 fixed; it now says `main` is green and that **a red check is therefore most likely yours** — the opposite of the prior advice. I added the measured `__probe` table there too, and a note that a ~9-minute install is native build scripts rather than a hang.

Only `.claude/commands/local/*` and command bodies were touched — **no `.claude/commands/shared/*` file was modified**, so byte-identity with the sibling repos is intact.

## Verified

- `pnpm gates` green locally (biome, both typechecks, vite build, 6/6 vitest).
- The failing-direction check above is the substantive evidence: it shows the *old* CI step passing where the new one fails.
- **No test covers the workflow file itself** — nothing could. The real proof is this PR's own CI run executing `pnpm gates` and reporting the five gates.