### PR TITLE
test(mcp): assert MCP.md matches the registered tools and resources (ELEG-7)

### DIFF
--- a/.agents/mcp.md
+++ b/.agents/mcp.md
@@ -28,12 +28,28 @@ claude mcp add --transport http elegoo http://localhost:8088/mcp
 
 ## Two rules
 
-**1. `MCP.md` and `mcp-server.ts` change in the same commit.** The doc is the contract:
-it is what an agent reads to decide what to call, and **nothing verifies it** — no test
-compares the registered tool list to the tables in `MCP.md`, so a renamed tool, a new
-parameter or a dropped resource is drift that no gate catches and no reviewer is likely
-to notice. Update both, and update the tool/resource counts in `MCP.md` and `README.md`
-when they change.
+**1. `MCP.md` and `mcp-server.ts` change in the same commit.** The doc is the contract —
+it is what an agent reads to decide what to call.
+
+**A test now enforces the name half of this** (ELEG-7):
+`src/server/__tests__/mcp-doc-parity.test.ts` stands the server up over an in-memory
+transport, asks it for its tools and resources exactly as a client would, and compares
+that against the tables in `MCP.md` **in both directions** — a tool missing from the doc
+fails, and a doc row with no tool behind it fails too. It also checks the counts quoted in
+`README.md` and in this file. So adding a tool without touching the doc is now a red gate
+rather than silent drift, and the counts cannot rot.
+
+It lives under `src/server/` deliberately: `tsconfig.json` excludes that directory, so a
+test importing server code from `src/__tests__/` would drag Node-only modules into the
+browser typecheck. Being there means it is typechecked by `pnpm service:check` rather than
+by `pnpm build`, which never sees `src/server`. Both run in `pnpm gates`, and since ELEG-5
+`pnpm gates` is what CI runs — so the test executes on every PR.
+
+**What the test still does not check: parameters, types and bounds.** It compares *names*.
+A changed clamp (`0-300°C`), a new optional parameter, a renamed argument or a wrong
+default is drift it will not catch, and that is the drift most likely to mislead an agent —
+a documented bound that is no longer enforced is worse than an undocumented one. Keep
+updating those by hand.
 
 **2. A tool that commands the printer is a physical action.** `set_temperature`, `fan`,
 `led`, `home`, `move`, `start_print`, `pause_print`, `resume_print`, `stop_print` and

--- a/.claude/commands/auto.md
+++ b/.claude/commands/auto.md
@@ -100,11 +100,13 @@ Announce the order and the split/skip intentions before starting, then work it.
   rewrites. Redirect the run to a file rather than piping it through `tail` — the
   evidence is the log, and a re-run destroys the only copy of it.
 - **Green gates are necessary and nowhere near sufficient in this repo — and pretending
-  otherwise is the main risk of an unattended pass.** There are **six tests** covering
-  two pure functions; the MQTT bridge, the state store, every REST route, `/mcp`, both
-  compat layers, Telegram, the AI monitor and the entire frontend have **no test at
-  all**, and there is no browser check. CI runs `pnpm gates` — the same gates you just
-  ran locally — so a green CI adds confirmation, not coverage. Five items, seconds each:
+  otherwise is the main risk of an unattended pass.** There are **eleven tests**: six over
+  two pure functions, and five asserting `MCP.md` matches the registered tools — a
+  documentation check, not a behavioural one. The MQTT bridge, the state store, every REST
+  route, `/mcp`'s behaviour, both compat layers, Telegram, the AI monitor and the entire
+  frontend have **no test at all**, and there is no browser check. CI runs `pnpm gates` —
+  the same gates you just ran locally — so a green CI adds confirmation, not coverage.
+  Five items, seconds each:
 
   1. **Break the invariant and watch the named test go red.** If no test covers it —
      which is the common case — **write that sentence in the closing comment** rather

--- a/.claude/commands/local/gates.md
+++ b/.claude/commands/local/gates.md
@@ -25,7 +25,7 @@ this table is CI's step list too. Add a gate here and CI picks it up with no wor
 | 2 | typecheck (browser) | `tsc` | `tsconfig.json` — **excludes `src/server`, `src/telegram`** |
 | 3 | typecheck (service) | `tsc -p tsconfig.server.json` | `tsconfig.server.json` — the other half. See below |
 | 4 | build | `vite build` | writes `dist/`, which is gitignored |
-| 5 | tests | `vitest run` | 6 tests, ~150 ms |
+| 5 | tests | `vitest run` | 11 tests, ~300 ms |
 
 Grep the log for `✗` to get the failing gate, then read upward for that check's own
 output.
@@ -159,9 +159,18 @@ twice:
 
 ## Green gates prove very little here — the honest list
 
-The suite is **one file, six tests**, covering two pure functions. Nothing tests the MQTT
-bridge, the state store, any REST route, `/mcp`, the Moonraker/OctoPrint layers, Telegram,
-the AI monitor, or **any** frontend code. There is no browser test and no screenshot.
+The suite is **two files, eleven tests**, and neither file tests behaviour you are likely
+to break:
+
+- `src/__tests__/types.test.ts` — six tests over two pure functions.
+- `src/server/__tests__/mcp-doc-parity.test.ts` — five tests asserting `MCP.md` lists
+  exactly the registered tools and resources (ELEG-7). That is a **documentation** check.
+  It will catch you renaming a tool without touching the doc; it will not notice that the
+  tool stopped working.
+
+Nothing tests the MQTT bridge, the state store, any REST route, `/mcp`'s actual
+behaviour, the Moonraker/OctoPrint layers, Telegram, the AI monitor, or **any** frontend
+code. There is no browser test and no screenshot.
 
 So the load-bearing gates are the two typechecks, and the failing-direction check matters
 more here than in a repo with real coverage:

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -20,9 +20,10 @@
 # so an auto-fix you did not commit still fails CI's lint step — hence --fix runs the
 # writer first and then re-checks, and you commit what it rewrote.
 #
-# What this cannot check is in .claude/commands/local/gates.md: there are six tests in
-# this repo, no browser test at all, and no gate on earth can tell you whether a
-# change does the right thing to a physical printer.
+# What this cannot check is in .claude/commands/local/gates.md: there are eleven tests
+# in this repo — six over two pure functions, five asserting MCP.md matches the
+# registered tools — no browser test at all, and no gate on earth can tell you whether
+# a change does the right thing to a physical printer.
 
 set -uo pipefail
 cd "$(dirname "$0")/.."
@@ -73,7 +74,7 @@ if [ "${#failed[@]}" -gt 0 ]; then
   exit 1
 fi
 printf '\n\033[32mAll gates green.\033[0m\n'
-printf '\033[2mSix tests and no browser check — see .claude/commands/local/gates.md for what this does NOT prove.\033[0m\n'
+printf '\033[2mEleven tests and no browser check — see .claude/commands/local/gates.md for what this does NOT prove.\033[0m\n'
 if [ "$fix" = 0 ]; then
   echo 'Reminder: if you edit anything else, re-run `pnpm gates --fix` and commit what biome rewrites.'
 fi

--- a/src/server/__tests__/mcp-doc-parity.test.ts
+++ b/src/server/__tests__/mcp-doc-parity.test.ts
@@ -1,0 +1,142 @@
+/**
+ * MCP.md ↔ mcp-server.ts drift test (ELEG-7).
+ *
+ * `MCP.md` is the contract an agent reads to decide what to call, and nothing used to
+ * check it against the code. A renamed tool or a dropped resource is drift no gate
+ * catches and no reviewer is likely to spot.
+ *
+ * This asserts against the **real registered surface** rather than a hand-maintained
+ * list: it stands the server up over an in-memory transport and asks it, exactly as a
+ * client would. A second list in the repo would be a third thing to keep in sync.
+ *
+ * No printer, no network, no MQTT connection — `createMcpServer` only stores the
+ * references it is given and registers closures; listing never invokes a handler. The
+ * stubs below are deliberately empty for that reason.
+ *
+ * This file lives under `src/server/` on purpose: `tsconfig.json` excludes that
+ * directory, so a test importing server code from `src/__tests__/` would drag Node-only
+ * modules into the browser typecheck. Here it is covered by `pnpm service:check`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { MqttBridge } from '../mqtt-bridge.js';
+import type { StateStore } from '../state-store.js';
+import { createMcpServer } from '../mcp-server.js';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+const read = (file: string) => readFileSync(join(REPO_ROOT, file), 'utf8');
+
+/** Registration never touches these; see the file header. */
+const stubStore = {} as unknown as StateStore;
+const stubBridge = {} as unknown as MqttBridge;
+
+/**
+ * Names in the first column of a markdown table, within `slice`.
+ *
+ * Skips the header and the `|---|` separator by requiring the cell to be a single
+ * backticked token — which every real row is and neither delimiter row is.
+ */
+function firstColumnNames(slice: string, pattern: RegExp): string[] {
+  const names: string[] = [];
+  for (const line of slice.split('\n')) {
+    if (!line.startsWith('|')) continue;
+    const cell = line.split('|')[1]?.trim() ?? '';
+    const m = cell.match(pattern);
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+/** Text between a `## heading` and the next `## ` heading (or end of file). */
+function section(md: string, heading: string): string {
+  const start = md.indexOf(`\n## ${heading}\n`);
+  if (start === -1) throw new Error(`MCP.md has no "## ${heading}" section`);
+  const after = start + 1;
+  const next = md.indexOf('\n## ', after);
+  return md.slice(after, next === -1 ? undefined : next);
+}
+
+let registeredTools: string[];
+let registeredResources: string[];
+
+beforeAll(async () => {
+  const server = createMcpServer(stubStore, stubBridge);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'doc-parity-test', version: '1.0.0' });
+
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  registeredTools = (await client.listTools()).tools.map((t) => t.name).sort();
+  registeredResources = (await client.listResources()).resources.map((r) => r.uri).sort();
+
+  await client.close();
+});
+
+describe('MCP.md documents exactly the registered tools', () => {
+  it('matches in both directions', () => {
+    const documented = firstColumnNames(section(read('MCP.md'), 'Tools'), /^`([a-z_]+)`$/).sort();
+
+    // Set equality, but asserted as two directed differences so a failure names the
+    // drifted tool instead of printing two 31-element arrays side by side.
+    const undocumented = registeredTools.filter((t) => !documented.includes(t));
+    const phantom = documented.filter((t) => !registeredTools.includes(t));
+
+    expect({ undocumented, phantom }).toEqual({ undocumented: [], phantom: [] });
+    expect(documented).toEqual(registeredTools);
+  });
+
+  it('lists each tool exactly once', () => {
+    const documented = firstColumnNames(section(read('MCP.md'), 'Tools'), /^`([a-z_]+)`$/);
+    const dupes = documented.filter((t, i) => documented.indexOf(t) !== i);
+    expect(dupes).toEqual([]);
+  });
+});
+
+describe('MCP.md documents exactly the registered resources', () => {
+  it('matches in both directions', () => {
+    const documented = firstColumnNames(
+      section(read('MCP.md'), 'Resources'),
+      /^`(printer:\/\/[a-z]+)`$/,
+    ).sort();
+
+    const undocumented = registeredResources.filter((r) => !documented.includes(r));
+    const phantom = documented.filter((r) => !registeredResources.includes(r));
+
+    expect({ undocumented, phantom }).toEqual({ undocumented: [], phantom: [] });
+    expect(documented).toEqual(registeredResources);
+  });
+});
+
+describe('the counts quoted in prose are the real ones', () => {
+  // These are what a reader trusts before reading any table, and they are the first
+  // thing to rot: they live in files nobody edits when adding a tool.
+  const quoted = [
+    { file: 'README.md', label: 'README.md' },
+    { file: '.agents/mcp.md', label: '.agents/mcp.md' },
+  ];
+
+  for (const { file, label } of quoted) {
+    it(`${label} quotes the real resource and tool counts`, () => {
+      const text = read(file);
+
+      const resourceCount = text.match(/\*{0,2}(\d+)\*{0,2} resources/)?.[1];
+      const toolCount = text.match(/\*{0,2}(\d+)\*{0,2}\s*\n?\s*tools/)?.[1];
+
+      expect(
+        resourceCount,
+        `${label} does not state a resource count — the assertion below would pass vacuously`,
+      ).toBeDefined();
+      expect(
+        toolCount,
+        `${label} does not state a tool count — the assertion below would pass vacuously`,
+      ).toBeDefined();
+
+      expect(Number(resourceCount)).toBe(registeredResources.length);
+      expect(Number(toolCount)).toBe(registeredTools.length);
+    });
+  }
+});


### PR DESCRIPTION
Fixes ELEG-7. Rebased onto `main` after ELEG-4 (#13) and ELEG-5 (#14) merged.

## What it does

`MCP.md` is the contract an agent reads to decide what to call, and nothing compared it to `mcp-server.ts`. `AGENTS.md` made "edit both in the same commit" a rule, but as the issue put it, a rule with no test is a rule that decays.

`src/server/__tests__/mcp-doc-parity.test.ts` (5 tests):

- **Both directions.** A tool missing from the doc fails; a doc row with no tool behind it fails too. Failures are reported as two directed diffs (`{undocumented, phantom}`) so the message names the drifted tool instead of printing two 31-element arrays.
- **No duplicate rows** in the doc.
- **The counts in prose** — `README.md` and `.agents/mcp.md` both say "6 resources, 31 tools". Those are what a reader trusts before reading any table, and they live in files nobody edits when adding a tool.

## Design departure from the issue, deliberately

The issue suggested extracting a registration table from `mcp-server.ts` so the test "imports data rather than parsing source", and called that "the more valuable half".

**I did neither.** The test stands the server up over the SDK's `InMemoryTransport` and calls `listTools()` / `listResources()` — it asks the server, exactly as a client would. Reasons:

1. A hand-maintained export would be a **third** thing to keep in sync. If someone registers a tool and forgets the table, the test passes and the doc is still wrong — the exact failure mode this issue exists to prevent.
2. It asserts the surface a client actually sees, which is what `MCP.md` claims to describe.
3. It needs no refactor of 31 inline `registerTool` call sites in a 723-line file — a large, risky diff for a test.

No printer, no network, no MQTT connection: registration only stores the references it is given, so the store/bridge stubs are empty objects and no handler is ever invoked.

## Placement is load-bearing

Under `src/server/`, not `src/__tests__/`. `tsconfig.json` **excludes `src/server`**, so a test importing server code from `src/__tests__/` would drag Node-only modules into the browser typecheck and break `tsc`. There it is covered by `service:check` — which, as of ELEG-5, CI now runs.

## Verified in the failing direction

Five mutations, each **asserted to have applied** (a `sed` one-liner that matches nothing exits 0 and proves nothing) and each reverted by inverse patch, never `git checkout`:

| Mutation | Result |
| --- | --- |
| baseline, unmutated | **PASS** |
| rename `zones` → `zonez` in `mcp-server.ts` | **FAIL** |
| rename a tool row in `MCP.md` | **FAIL** |
| rename a resource row in `MCP.md` | **FAIL** |
| wrong tool count in `README.md` | **FAIL** |
| wrong resource count in `.agents/mcp.md` | **FAIL** |

Working tree verified clean afterwards. The count assertions also anchor the absolute numbers (6/31), so the set comparison cannot pass vacuously.

- `pnpm gates` green: 11 tests across 2 files, both typechecks, build.

## Docs updated in the same commit

- `.agents/mcp.md` — rule 1 rewritten: the test now enforces the name half, **and states plainly what it still does not check** (parameters, types, clamps like `0-300°C`, defaults). A documented bound that is no longer enforced is worse than an undocumented one, so that gap is called out rather than left for someone to assume away.
- `scripts/gates.sh`, `local/gates.md`, `auto.md` — test count 6 → 11, with the honest characterisation: the five new tests are a **documentation** check, not a behavioural one. They will catch a renamed tool; they will not notice the tool stopped working. `local/gates.md`'s "green gates prove very little" section is updated to say exactly that, so the higher number does not read as new coverage.

No `.claude/commands/shared/*` file was touched.