### PR TITLE
fix(deploy): make the installer copy delete-consistent with rsync --delete (ELEG-11)

### DIFF
--- a/.agents/deployment.md
+++ b/.agents/deployment.md
@@ -29,19 +29,28 @@ here. Don't reason about this host's behaviour from the compose file.
 ## How a deploy happens
 
 `contrib/install.sh` (`sudo pnpm service:install`) is the mechanism: it creates the
-user and the directory, then **`cp -r`** of `src/`, `dist/`, `public/`,
-`package.json`, `pnpm-lock.yaml` and the tsconfigs, `pnpm install --prod`,
+user and the directory, then **`rsync -a --delete`** of `src/`, `dist/` and `public/`
+(one directory at a time) plus a plain copy of `package.json`, `pnpm-lock.yaml` and the
+tsconfigs, writes the build stamp, `pnpm install --prod`,
 `chown -R elegooweb:elegooweb`, install the unit, `systemctl enable` + restart. It
-preserves an existing `.env`.
+preserves an existing `.env`, and **requires `rsync`** — it exits rather than falling
+back to a copy that cannot delete.
 
 Three consequences that have already produced a real artefact:
 
-1. **`cp -r` never deletes.** A file removed from git stays in production forever.
-   Right now `/opt/elegooweb/src/ui/bed-mesh.ts` is live on disk although commit
-   `a8157a9` ("remove bed mesh feature") deleted it from the repo. It happens to be
-   unreferenced, so it is harmless today — but the same mechanism would keep serving a
-   retired route or an old module that something still imports. Verify a removal with
-   `ls`, not with the git diff.
+1. **The copy is delete-consistent, but only from the next install onwards.** It used to
+   be `cp -r`, which never deletes, so a file removed from git stayed in production
+   forever. `src/`, `dist/` and `public/` are now `rsync -a --delete`, **scoped one
+   directory at a time** — never a sweep over `$INSTALL_DIR`, because `.env`, `data/` and
+   `node_modules/` live at the install root beside them and must survive. The
+   `--exclude`s in the installer are a second layer, not the defence.
+
+   What that backlog looks like today, from a dry run against the live directory:
+   `/opt/elegooweb/src/ui/bed-mesh.ts` (deleted from the repo by `a8157a9`) plus **24
+   orphaned hashed bundles in `dist/assets/`**, one pair per build ever deployed. All
+   unreferenced, so harmless — but the same mechanism would just as happily keep serving
+   a retired route or a module something still imports. Until an install actually runs
+   they are all still there, so **verify a removal with `ls`, not with the git diff.**
 2. **The deployed tree still has no git metadata — but it does carry a stamp.** The
    installer writes `/opt/elegooweb/build-info.json` (commit, short commit,
    `git describe`, `package.json` version, install timestamp) and the service reports it
@@ -105,10 +114,18 @@ journalctl -u elegooweb -n 100 --no-pager        # or: pnpm service:logs
 diff -rq --exclude=node_modules --exclude=data --exclude=.env --exclude=dist \
   "$PWD/src" /opt/elegooweb/src
 
+# what would the deploy DELETE? read this before every install — it is the safety case
+for d in src dist public; do
+  rsync -n -v -a --delete --exclude=.env --exclude=data/ --exclude=node_modules/ \
+    "$PWD/$d/" "/opt/elegooweb/$d/" | grep '^deleting' || true
+done
+# -n writes nothing. The list must contain only files you meant to remove, and must
+# never mention .env, data/ or node_modules/ — if it does, stop and do not install.
+
 # deploy (from a clean, merged checkout on main)
 git switch main && git pull --ff-only
 pnpm install && pnpm gates && pnpm build        # dist/ must be current
-sudo pnpm service:install                       # cp + install --prod + restart
+sudo pnpm service:install                       # rsync --delete + install --prod + restart
 
 # restart / stop only
 sudo systemctl restart elegooweb

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -47,6 +47,18 @@ if ! command -v pnpm &> /dev/null; then
 fi
 log_info "pnpm version: $(pnpm -v)"
 
+# Check for rsync — the deploy is delete-consistent and there is no safe fallback.
+# Falling back to `cp -r` here would silently reintroduce the exact bug this guards
+# against (a file deleted from git stays live in $INSTALL_DIR forever) while reporting
+# a successful install, so this exits rather than degrading.
+if ! command -v rsync &> /dev/null; then
+    log_error "rsync is not installed, and the deploy requires it."
+    log_error "  Install it (apt install rsync / dnf install rsync / pacman -S rsync) and re-run."
+    log_error "  Do not substitute 'cp -r': it never deletes, so files removed from the"
+    log_error "  repository would remain live in $INSTALL_DIR."
+    exit 1
+fi
+
 # Resolve source directory (repo root = parent of contrib/)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -61,15 +73,49 @@ log_info "Creating installation directory: $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR/data"
 
-# Copy source files
-log_info "Copying files..."
-cp -r "$SCRIPT_DIR/src" "$INSTALL_DIR/"
-cp -r "$SCRIPT_DIR/dist" "$INSTALL_DIR/" 2>/dev/null || true
+# Copy source files — delete-consistent, so a file removed from the repository is also
+# removed from the deploy.
+#
+# --delete is scoped to ONE DIRECTORY AT A TIME and is never run over $INSTALL_DIR
+# itself. That is the whole safety argument: src/, dist/ and public/ are wholly owned by
+# the repository, while the state that must survive an upgrade lives at the install root
+# beside them —
+#
+#   $INSTALL_DIR/.env           the only copy of PRINTER_PASSWORD, TELEGRAM_BOT_TOKEN,
+#                               AI_VLM_API_KEY. No backup anywhere.
+#   $INSTALL_DIR/data/          persisted runtime state (DATA_DIR), created above
+#   $INSTALL_DIR/node_modules/  installed deps, not present in the source tree
+#
+# — so none of them is inside the deletion scope at all. The --exclude list is a second
+# line of defence for the case where one of those ever moves inside a synced directory;
+# it is deliberately not the only one. Do not "simplify" this into a single
+# `rsync -a --delete "$SCRIPT_DIR/" "$INSTALL_DIR/"`, which would put all three back
+# under the excludes and one typo away from destroying production.
+#
+# Note the existing `if [[ ! -f "$INSTALL_DIR/.env" ]]` guard below protects against
+# *overwrite* only. It is not cover for --delete.
+#
+# Trailing slashes are load-bearing: `rsync -a src/ dest/src/` copies the contents,
+# `rsync -a src dest/src/` would nest the tree as dest/src/src.
+RSYNC_OPTS=(-a --delete --exclude=.env --exclude=data/ --exclude=node_modules/)
+
+log_info "Copying files (delete-consistent)..."
+rsync "${RSYNC_OPTS[@]}" "$SCRIPT_DIR/src/" "$INSTALL_DIR/src/"
+# dist/ and public/ may be absent from the source; skip rather than sync, because an
+# absent source with --delete would empty the deployed copy.
+if [[ -d "$SCRIPT_DIR/dist" ]]; then
+    rsync "${RSYNC_OPTS[@]}" "$SCRIPT_DIR/dist/" "$INSTALL_DIR/dist/"
+else
+    log_warn "  No dist/ in source — leaving the deployed frontend untouched"
+fi
+if [[ -d "$SCRIPT_DIR/public" ]]; then
+    rsync "${RSYNC_OPTS[@]}" "$SCRIPT_DIR/public/" "$INSTALL_DIR/public/"
+fi
+# Single files: no delete semantics to get right.
 cp "$SCRIPT_DIR/package.json" "$INSTALL_DIR/"
 cp "$SCRIPT_DIR/pnpm-lock.yaml" "$INSTALL_DIR/"
 cp "$SCRIPT_DIR/tsconfig.json" "$INSTALL_DIR/"
 cp "$SCRIPT_DIR/tsconfig.server.json" "$INSTALL_DIR/" 2>/dev/null || true
-cp -r "$SCRIPT_DIR/public" "$INSTALL_DIR/" 2>/dev/null || true
 
 # Stamp the deploy — $INSTALL_DIR is not a git checkout, so this file is the only way
 # to ask what is actually running. Read back by src/server/build-info.ts and reported


### PR DESCRIPTION
Closes ELEG-11 (child of ELEG-6). Follows PR #16 (ELEG-10), which is on `main` — the build stamp is what makes this verifiable at the receiver.

`cp -r` never deletes, so a file removed from the repository stayed live in `/opt/elegooweb` forever. `src/`, `dist/` and `public/` are now `rsync -a --delete`.

## The safety argument, which is the actual deliverable

`--delete` is **scoped to one directory at a time** and never runs over `$INSTALL_DIR`. Those three directories are wholly owned by the repository; the state that must survive an upgrade — `.env` (the only copy of `PRINTER_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `AI_VLM_API_KEY`), `data/`, `node_modules/` — lives at the install root *beside* them, so it is never inside the deletion scope at all. `--exclude=.env --exclude=data/ --exclude=node_modules/` goes on anyway as a second layer for the day one of those moves inside a synced directory. The issue argued for exactly this shape and it is right: the excludes are cheap, and not being the only defence is the point.

`build-info.json` from ELEG-10 is at the install root too, so it survives by the same construction.

Two behaviours worth reviewing as decisions rather than details:

- **Missing `rsync` is a hard exit, not a fallback to `cp -r`.** A silent fallback reintroduces precisely this bug while reporting a successful install. The script already exits hard on a missing `node` or `pnpm`, so this is consistent.
- **An absent `dist/` or `public/` in the source is skipped, not synced.** The old `cp … || true` tolerated it harmlessly; with `--delete`, syncing from a directory that does not exist would *empty the deployed copy*. This is the one place where preserving the old tolerance verbatim would have been a data-loss bug.

## Verified by

`pnpm gates` is green, and **that proves nothing here** — this is a shell change plus a doc change, and no gate in this repo executes `contrib/install.sh`. The real evidence:

**1. Dry run against the live `/opt/elegooweb`** (`-n`, writes nothing — a read, which is what an agent is allowed to do against production):

```
-- src/ --     deleting ui/bed-mesh.ts
-- dist/ --    deleting assets/index-_-fNWSPN.js
               deleting assets/index-DsV9Po0O.js
               … 24 orphaned bundles in total …
-- public/ --  (nothing)
```

and, grepping the whole dry run for the three things that must never appear:

```
$ … | grep -E "\.env|node_modules|(^|/)data/"
NO — not one mention.
```

**The `dist/` result was not known before this change.** The issue and the epic both tracked one stale file, `src/ui/bed-mesh.ts`. Production is in fact also carrying **24 orphaned hashed asset bundles** in `dist/assets/`, one pair per build ever deployed since the install directory was created. All unreferenced by the current `index.html`, so harmless — but it is a larger first deletion than ELEG-12 was written to expect, and that issue has been updated.

**2. A synthetic tree exercising the excludes as well as the scoping.** `.env` and a `data/` directory were planted *inside* `src/` — i.e. inside the deletion scope, the case the excludes exist for. Both survived, as did the root-level `.env`, `data/`, `node_modules/` and `build-info.json`, while `bed-mesh.ts` and a stale `dist/` asset were removed and a new one added.

**3. The real bytes of the new copy block**, extracted from `contrib/install.sh` with `sed` rather than retyped, run twice against a throwaway directory:
- against an *empty* dir (fresh install): `src/` created correctly, `diff -rq` against the checkout reports IDENTICAL, and no `src/src` nesting — the trailing-slash trap the issue flagged;
- against the populated dir with production state planted (upgrade): `.env` SURVIVED, `data/` SURVIVED, `node_modules/` SURVIVED, stale file DELETED.

**4. `bash -n` clean.** shellcheck is not installed on this machine, so this change is unlinted — worth noting given it is almost entirely shell.

## What is NOT verified

- **Nothing ran the installer**, and nothing here can: that is ELEG-12, an `OPERATOR:` issue, updated with the dry-run command and the revised expectation about `dist/`.
- No gate covers `contrib/install.sh` at all — there is no shell test and no shellcheck in `pnpm gates`.
- The dry run reflects `/opt/elegooweb` as it is **now**. Anything deployed between this merge and the install changes the deletion list, which is why the dry run is documented as a per-deploy step in `.agents/deployment.md` rather than as a one-off result recorded here.