### PR TITLE
docs(commands): stop telling agents CI is red before it runs a gate (ELEG-14)

### DIFF
--- a/.claude/commands/auto.md
+++ b/.claude/commands/auto.md
@@ -41,7 +41,7 @@ git rev-parse --abbrev-ref HEAD    # must be main — see below before you switc
 git status --porcelain             # whose changes are these?
 git worktree list                  # who else is in this repo right now?
 git switch main && git pull --ff-only
-pnpm install --frozen-lockfile     # see the note below — this currently fails
+pnpm install --frozen-lockfile     # works again as of ELEG-4 — see the note below
 gh pr list --state open            # anything already in flight?
 gh pr list --state merged --limit 10 --json number,baseRefName,mergeCommit
 ```
@@ -55,12 +55,16 @@ Same for overlap: a dirty file that one of the listed issues will touch is a rea
 stop. Unrelated dirt is fine and gets left alone. See
 [`shared/agent-isolation.md`](shared/agent-isolation.md).
 
-**`pnpm install --frozen-lockfile` fails on `main` today** —
-`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, because newer pnpm ignores the `pnpm` field in
-`package.json` and the lockfile's recorded `overrides` no longer match. Use a plain
-`pnpm install` locally, note it, and do not "fix" it by deleting the lockfile; it is
-filed as its own issue and it is also why **CI is red before it runs a single gate**.
-[`local/gates.md`](local/gates.md) has both known reds.
+**`main` is green, and that changes what a red check means.** `--frozen-lockfile` used to
+fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — newer pnpm ignores the `pnpm` field in
+`package.json`, so the lockfile's recorded `overrides` no longer matched — and that
+failed CI *before it ran a single gate*. **ELEG-4 fixed it**, so the install is clean and
+CI runs the gate set. Keep the lesson (CI can be red for a reason no gate would ever
+show you) and drop the licence that came with it: **a red check on your branch is yours
+until you have read which step failed and shown otherwise.** Never dismiss one on the
+strength of a note in a command file — this paragraph was that note, and it outlived the
+bug by a month. [`local/gates.md`](local/gates.md) keeps the history and the current
+gaps, and it is still true that green there proves very little.
 
 **Check that recently-merged PRs actually reached `main`.** A PR reading `MERGED` only
 means it merged into *its own base* — verify with
@@ -126,15 +130,14 @@ Announce the order and the split/skip intentions before starting, then work it.
 
 - **Merging as you go is part of this mode**, because later issues need the earlier work
   on `main`. List every merge in the final report. Check `gh pr checks` before merging —
-  but see the pre-flight: a red check on this repo is currently pre-existing and **not**
-  yours, so read which step failed rather than either dismissing it or blaming your
-  branch.
+  and since ELEG-4 landed there is **no standing pre-existing red to hide behind**, so
+  treat a failure as yours and read which step failed before concluding anything else.
 - **Read the two reference files on demand.** They are deliberately *not* inlined here:
 
   | Read | When |
   | --- | --- |
   | [`shared/gate-failures.md`](shared/gate-failures.md) | the **first time a gate goes red** in the pass, before you re-run anything |
-  | [`local/gates.md`](local/gates.md) | alongside it — this repo's exact commands, the two known reds, and why green means little |
+  | [`local/gates.md`](local/gates.md) | alongside it — this repo's exact commands, the reds that have since been fixed, and why green means little |
   | [`shared/pr-hygiene.md`](shared/pr-hygiene.md) | before opening the **first PR** of the pass, and again before any PR that only *partly* completes an issue |
 
   `shared/*` is byte-identical across the sibling repos and names no tool; `local/*` is

--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -132,11 +132,12 @@ open a PR (you do not need to ask). Never commit to `main`.
 8. **Check the PR landed clean — don't assume it did.**
    - **Merge conflicts:** `gh pr view <n> --json mergeable,mergeStateStatus`. If
      `CONFLICTING`/`DIRTY`, rebase on the latest `main`, resolve, re-verify, force-push.
-   - **CI status:** `gh pr checks <n>`. **`main` is currently red for two pre-existing
-     reasons** (a `--frozen-lockfile` config mismatch that fails CI before any gate
-     runs, and the formatting violation fixed by ELEG-1) — so read *which step* failed
-     before attributing it to your branch, and never dismiss a red check without
-     looking. `local/gates.md` has the detail.
+   - **CI status:** `gh pr checks <n>`. **`main` is green**, so a red check is yours
+     until you have read *which step* failed and shown otherwise. It has not always been:
+     a `--frozen-lockfile` config mismatch used to fail CI before any gate ran (ELEG-4)
+     and a formatting violation before that (ELEG-1). Both are fixed; the habit they
+     taught — read the failing step, never dismiss a red check without looking — is what
+     survives. `local/gates.md` has the detail.
    - **Merged ≠ on `main`.** A PR reading `MERGED` only merged into *its base*. Confirm:
      `git fetch origin && git merge-base --is-ancestor <sha> origin/main`.
    - **Offer to watch** pending checks rather than leaving the user to find out.

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -112,9 +112,9 @@ When both agents of a pair report back — never while one is still running:
 
 1. In each issue's worktree run `pnpm gates --fix` and **commit whatever biome
    rewrites**. On failure, bounce back to a `SendMessage`-resumed agent; don't open a PR
-   on a red build. Note that `pnpm install --frozen-lockfile` currently fails on `main`
-   (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`) — a fresh worktree needs a plain `pnpm install`.
-   See [`local/gates.md`](local/gates.md).
+   on a red build. A fresh worktree can use `pnpm install --frozen-lockfile` again — the
+   `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` that forced a plain `pnpm install` was fixed by
+   ELEG-4. See [`local/gates.md`](local/gates.md).
 2. **Re-run the verification yourself, and correct the subagent's account of what it
    proves.** Green gates in this repo mean "it compiles, it is formatted, and two pure
    functions still work" — six tests, no browser check, no server-side coverage at all. A
@@ -142,9 +142,9 @@ When both agents of a pair report back — never while one is still running:
    `🤖 Generated with [Claude Code](https://claude.com/claude-code)`).
 4. **Check the PR landed clean.** `gh pr view <n> --json mergeable,mergeStateStatus`: if
    `CONFLICTING`/`DIRTY`, rebase that branch on the latest `main`, resolve, re-verify,
-   force-push. `gh pr checks <n>`: read **which step** failed — CI on this repo is
-   currently red for two pre-existing reasons, so neither dismiss it nor attribute it to
-   the branch without looking.
+   force-push. `gh pr checks <n>`: read **which step** failed. CI on this repo is green
+   on `main` (since ELEG-1 and ELEG-4), so there is no standing red to attribute a
+   failure to — it is the branch's until reading the step says otherwise.
 5. Per issue: add a closing **verification comment** (what you ran, what it proves and
    what it cannot, surface recap, follow-up **issue keys**, **PR URL**, mergeable + CI
    status) and `issues_update_issue` → `IN_REVIEW` — which opening the PR already did, so


### PR DESCRIPTION
Closes ELEG-14. Found while running `/auto ELEG-6 ELEG-10 ELEG-11` — the pre-flight told me `pnpm install --frozen-lockfile` would fail, and it did not.

## The problem

ELEG-4 fixed the `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` and ELEG-1 the formatting violation, so `main` is green. Verified both directions during that pass:

```
$ pnpm install --frozen-lockfile
Done in 725ms using pnpm v10.33.3          # EXIT=0
$ gh pr checks 16 → ci pass 23s
$ gh pr checks 17 → ci pass 24s
```

`.claude/commands/local/gates.md` was already updated (it strikes the entry through and credits ELEG-4). Three command bodies were not.

## Why this is worth a PR rather than a shrug

It is not merely stale. `auto.md` and `fix.md` both drew a *licence* from the red: "a red check on this repo is currently pre-existing and **not** yours". That sentence existed so an agent would not burn a pass debugging someone else's breakage. With the underlying red gone, the same sentence trains an agent to **dismiss a genuine red that it caused** — and in `/auto`, which merges as it goes and runs unattended by design, that is the sentence standing between a broken build and `main`.

So the edit keeps the lesson and drops the licence. "CI can be red for a reason no gate would ever show you" is a good thing to know; "and therefore ignore it" no longer follows.

## Changed

| File | Change |
| --- | --- |
| `.claude/commands/auto.md` | Pre-flight comment, the whole known-reds paragraph, the reference table row, and the merge-step licence at line 133 |
| `.claude/commands/fix.md` | Step 8's "currently red for two pre-existing reasons" |
| `.claude/commands/sweep.md` | The worktree install note and the same claim at step 4 |

Untouched, deliberately:

- **`.claude/commands/shared/*.md`** — byte-identical across five sibling repos. `git status` shows them unmodified and `sha256sum` still matches `~/dev/respawn-control` for all three (`agent-isolation.md`, `gate-failures.md`, `pr-hygiene.md`).
- **`.claude/commands/local/gates.md`** — already correct, and it keeps the struck-through history the others now point at.

## Verified by

Reading, and `grep -rn "frozen-lockfile" .claude/commands/` returning only the five intended mentions, all past-tense or historical. **No gate covers `.claude/**`** — biome is scoped to `src/**` here precisely so a formatter cannot rewrite the byte-identical shared files — so `pnpm gates` staying green (it does) says only that nothing a gate looks at was touched.