### PR TITLE
fix(chart): keep the layer-time chart inside its plot area (ELEG-16)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -1,14 +1,45 @@
 # Testing — what is covered, and what nothing covers
 
-Be honest about the starting point: **the suite is one file, six tests.**
-`src/__tests__/types.test.ts` covers two pure functions from `src/types.ts`
-(`detectZone`, `isFilamentChangeSubStatus`). Everything else in this repo — the MQTT
-bridge, the state store, every REST route, the MCP server, both compatibility layers,
-the Telegram bot, the AI monitor and the entire frontend — has **no test at all**.
+Be honest about the starting point: **the suite is six files, 39 tests**, all but three
+over pure functions.
 
-So `pnpm gates` green means: it compiles, it is formatted, and two pure functions still
-work. Read that sentence again before quoting a green run as evidence in a closing
-comment.
+- `src/__tests__/types.test.ts` — `detectZone`, `isFilamentChangeSubStatus`.
+- `src/__tests__/layer-chart.test.ts` — the layer chart's window selection and domain
+  arithmetic (ELEG-16).
+- `src/__tests__/layer-chart-render.test.ts` — the only tests that run drawing code, via
+  a recording 2D-context stub (ELEG-16). See below.
+- `src/server/__tests__/layer-tracking.test.ts` — the print-boundary rule for the
+  layer-time series (ELEG-16).
+- `src/server/__tests__/mcp-doc-parity.test.ts` — `MCP.md` matches the registered tools
+  and resources (ELEG-7). A *documentation* check.
+- `src/server/__tests__/build-info.test.ts` — the deployed-commit stamp (ELEG-6).
+
+Everything else in this repo — the MQTT bridge, the state store's wiring, every REST
+route, the MCP server's behaviour, both compatibility layers, the Telegram bot and the
+AI monitor — has **no test at all**.
+
+So `pnpm gates` green means: it compiles, it is formatted, some pure functions still
+work, and one chart still puts its ink inside its own axes. Read that sentence again
+before quoting a green run as evidence in a closing comment.
+
+## Testing canvas code without a browser
+
+`src/__tests__/layer-chart-render.test.ts` is the pattern, and it needs no new
+dependency: hand the render function a stub `getContext('2d')` that pushes every call
+into an array, stub `document.getElementById` and `window.devicePixelRatio`, then assert
+on the *operations*. It catches the things that are cheap to get wrong and invisible in a
+diff — a missing `ctx.clip()`, a coordinate outside the plot rect, a label drawn past the
+canvas edge (ELEG-16 had all three).
+
+What it cannot tell you is whether the result **looks** right: colour, font, overlap and
+layout need eyes on `pnpm dev:web`. Reach for jsdom only if you need real layout — it is
+a dependency and an environment switch, not a free upgrade.
+
+**Where a new test file goes is decided by the typechecks, not by taste.** A test that
+imports `src/server/**` belongs under `src/server/__tests__/` — `tsconfig.json` excludes
+that directory, so importing server code from `src/__tests__/` drags Node-only modules
+into the browser typecheck. Frontend tests go in `src/__tests__/`. `vitest.config.ts`
+picks up both.
 
 ```bash
 pnpm test              # vitest run
@@ -38,7 +69,7 @@ The high-value, low-friction targets are the pure and near-pure functions that a
 carry the protocol's hard-won knowledge:
 
 - **`src/types.ts`** — zone detection, status/sub-status classification, unit
-  conversions. Cheap to test, and the existing six tests are the pattern to copy.
+  conversions. Cheap to test, and `types.test.ts` is the pattern to copy.
 - **`src/server/state-store.ts` / `src/printer-state.ts`** — the delta **merge**. Feed
   it a sequence of captured status payloads and assert the merged result. This is the
   most bug-prone code in the repo (a field missing from a delta means *unchanged*, not

--- a/.claude/commands/local/gates.md
+++ b/.claude/commands/local/gates.md
@@ -25,7 +25,7 @@ this table is CI's step list too. Add a gate here and CI picks it up with no wor
 | 2 | typecheck (browser) | `tsc` | `tsconfig.json` — **excludes `src/server`, `src/telegram`** |
 | 3 | typecheck (service) | `tsc -p tsconfig.server.json` | `tsconfig.server.json` — the other half. See below |
 | 4 | build | `vite build` | writes `dist/`, which is gitignored |
-| 5 | tests | `vitest run` | 11 tests, ~300 ms |
+| 5 | tests | `vitest run` | 39 tests, ~350 ms |
 
 Grep the log for `✗` to get the failing gate, then read upward for that check's own
 output.
@@ -159,18 +159,33 @@ twice:
 
 ## Green gates prove very little here — the honest list
 
-The suite is **two files, eleven tests**, and neither file tests behaviour you are likely
-to break:
+The suite is **six files, 39 tests**. All but three cover a *pure function*; none
+exercises a connection or a route:
 
 - `src/__tests__/types.test.ts` — six tests over two pure functions.
 - `src/server/__tests__/mcp-doc-parity.test.ts` — five tests asserting `MCP.md` lists
   exactly the registered tools and resources (ELEG-7). That is a **documentation** check.
   It will catch you renaming a tool without touching the doc; it will not notice that the
   tool stopped working.
+- `src/server/__tests__/build-info.test.ts` — seven tests over the deployed-commit stamp
+  (ELEG-6).
+- `src/server/__tests__/layer-tracking.test.ts` + `src/__tests__/layer-chart.test.ts` —
+  eighteen tests over the layer-time series and the chart's domain arithmetic (ELEG-16):
+  the print-boundary rule, and that no point can map outside the plot rect.
+- `src/__tests__/layer-chart-render.test.ts` — three tests, and the **only** ones in the
+  repo that run drawing code. There is no jsdom and no canvas, so they hand the chart a
+  recording 2D-context stub and assert on the ops it emitted (is there a `clip()` around
+  the series, does any coordinate leave the plot rect, does the value label fit). Copy
+  this shape for another canvas card; it needs no new dependency.
 
-Nothing tests the MQTT bridge, the state store, any REST route, `/mcp`'s actual
-behaviour, the Moonraker/OctoPrint layers, Telegram, the AI monitor, or **any** frontend
-code. There is no browser test and no screenshot.
+Nothing tests the MQTT bridge, the state store's wiring, any REST route, `/mcp`'s actual
+behaviour, the Moonraker/OctoPrint layers, Telegram or the AI monitor. The one render
+test asserts *geometry*, not appearance — there is still no browser and no screenshot,
+so colour, font, overlap and layout are unchecked by any gate.
+
+Note the split those last two demonstrate: a test importing `src/server/**` belongs under
+`src/server/__tests__/`, because `tsconfig.json` excludes that directory and an import
+from `src/__tests__/` drags Node-only modules into the browser typecheck.
 
 So the load-bearing gates are the two typechecks, and the failing-direction check matters
 more here than in a repo with real coverage:

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -20,10 +20,11 @@
 # so an auto-fix you did not commit still fails CI's lint step — hence --fix runs the
 # writer first and then re-checks, and you commit what it rewrote.
 #
-# What this cannot check is in .claude/commands/local/gates.md: there are eleven tests
-# in this repo — six over two pure functions, five asserting MCP.md matches the
-# registered tools — no browser test at all, and no gate on earth can tell you whether
-# a change does the right thing to a physical printer.
+# What this cannot check is in .claude/commands/local/gates.md: there are 39 tests in
+# this repo, all but three over pure functions and those three driving one chart against
+# a stub canvas — nothing exercises a connection or a route, there is still no browser
+# and no screenshot, and no gate on earth can tell you whether a change does the right
+# thing to a physical printer.
 
 set -uo pipefail
 cd "$(dirname "$0")/.."
@@ -74,7 +75,7 @@ if [ "${#failed[@]}" -gt 0 ]; then
   exit 1
 fi
 printf '\n\033[32mAll gates green.\033[0m\n'
-printf '\033[2mEleven tests and no browser check — see .claude/commands/local/gates.md for what this does NOT prove.\033[0m\n'
+printf '\033[2mNo browser and no screenshot — see .claude/commands/local/gates.md for what this does NOT prove.\033[0m\n'
 if [ "$fix" = 0 ]; then
   echo 'Reminder: if you edit anything else, re-run `pnpm gates --fix` and commit what biome rewrites.'
 fi

--- a/src/__tests__/layer-chart-render.test.ts
+++ b/src/__tests__/layer-chart-render.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Layer-time chart render path (ELEG-16).
+ *
+ * This is the repo's only test that exercises drawing code, and it does it without a
+ * browser: there is no jsdom and no canvas here, so it hands `renderLayerTimeChart` a
+ * recording 2D-context stub and asserts on the *operations* it emitted. That covers the
+ * two things the pure-helper tests cannot — that the series is clipped to the plot rect,
+ * and that the rightmost value label stays on the canvas.
+ *
+ * It is not a substitute for looking at the page. Colours, fonts, overlap and anything
+ * about how it actually looks are still unverified by any gate.
+ *
+ * Both were real bugs: without the clip, an out-of-domain point painted over the Y-axis
+ * labels, and the value label was drawn at x=608 on a 554px-wide canvas, so all that
+ * survived of `L63: 15.0s` was the `L`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderLayerTimeChart } from '../ui/layer-chart';
+import type { PrinterState } from '../printer-state';
+
+const W = 554;
+const H = 160;
+/** Must match PADDING in layer-chart.ts */
+const PAD = { top: 10, right: 12, bottom: 28, left: 48 };
+const PLOT_W = W - PAD.left - PAD.right;
+const PLOT_H = H - PAD.top - PAD.bottom;
+/** The stub's stand-in for text metrics — 6px per character */
+const CHAR_W = 6;
+
+interface Op {
+  op: string;
+  args: unknown[];
+}
+
+type LayerTime = { layer: number; duration: number; timestamp: number };
+
+/**
+ * Render one series and return the ops the chart emitted.
+ *
+ * `renderLayerTimeChart` skips a redraw when the series length is unchanged, so each
+ * call here uses a series of a different length.
+ */
+function render(layerTimes: LayerTime[]): Op[] {
+  const ops: Op[] = [];
+  const record =
+    (op: string) =>
+    (...args: unknown[]) => {
+      ops.push({ op, args });
+    };
+
+  const ctx = {
+    setTransform: record('setTransform'),
+    clearRect: record('clearRect'),
+    beginPath: record('beginPath'),
+    closePath: record('closePath'),
+    moveTo: record('moveTo'),
+    lineTo: record('lineTo'),
+    arc: record('arc'),
+    rect: record('rect'),
+    roundRect: record('roundRect'),
+    clip: record('clip'),
+    save: record('save'),
+    restore: record('restore'),
+    stroke: record('stroke'),
+    fill: record('fill'),
+    setLineDash: record('setLineDash'),
+    measureText: (t: string) => ({ width: t.length * CHAR_W }),
+    fillText(t: string, x: number, y: number) {
+      // textAlign decides which side of x the text extends, so capture it per call.
+      ops.push({ op: 'fillText', args: [t, x, y, ctx.textAlign] });
+    },
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    lineJoin: '',
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+  };
+
+  const canvas = {
+    width: 0,
+    height: 0,
+    getBoundingClientRect: () => ({ width: W, height: H }),
+    getContext: () => ctx,
+    addEventListener: () => {},
+  };
+
+  const g = globalThis as unknown as { window: unknown; document: unknown };
+  g.window = { devicePixelRatio: 1 };
+  g.document = { getElementById: () => canvas };
+
+  renderLayerTimeChart({ layerTimes } as unknown as PrinterState);
+  return ops;
+}
+
+/** The ops emitted between `clip()` and the matching `restore()` */
+function clippedOps(ops: Op[]): Op[] {
+  const from = ops.findIndex((o) => o.op === 'clip');
+  expect(from).toBeGreaterThan(-1);
+  const to = ops.findIndex((o, i) => i > from && o.op === 'restore');
+  expect(to).toBeGreaterThan(from);
+  return ops.slice(from, to);
+}
+
+describe('layer chart render path', () => {
+  it('clips the series to the plot rect', () => {
+    // A previous print's L29 in front of the current one — the live ELEG-16 repro.
+    const series: LayerTime[] = [
+      { layer: 29, duration: 155.259, timestamp: 1 },
+      ...Array.from({ length: 63 }, (_, i) => ({
+        layer: i + 1,
+        duration: 14,
+        timestamp: i + 2,
+      })),
+    ];
+    const ops = render(series);
+
+    const clipIdx = ops.findIndex((o) => o.op === 'clip');
+    expect(ops[clipIdx - 1]).toEqual({
+      op: 'rect',
+      args: [PAD.left, PAD.top, PLOT_W, PLOT_H],
+    });
+  });
+
+  it('draws no series point outside the plot rect', () => {
+    const series: LayerTime[] = [
+      { layer: 29, duration: 155.259, timestamp: 1 },
+      ...Array.from({ length: 40 }, (_, i) => ({
+        layer: i + 1,
+        duration: 14,
+        timestamp: i + 2,
+      })),
+    ];
+
+    for (const o of clippedOps(render(series))) {
+      if (o.op !== 'moveTo' && o.op !== 'lineTo' && o.op !== 'arc') continue;
+      const [x, y] = o.args as number[];
+      expect(x).toBeGreaterThanOrEqual(PAD.left);
+      expect(x).toBeLessThanOrEqual(W - PAD.right);
+      expect(y).toBeGreaterThanOrEqual(PAD.top);
+      expect(y).toBeLessThanOrEqual(H - PAD.bottom);
+    }
+  });
+
+  it('keeps the rightmost value label on the canvas', () => {
+    const series: LayerTime[] = Array.from({ length: 30 }, (_, i) => ({
+      layer: i + 1,
+      duration: 14,
+      timestamp: i,
+    }));
+
+    const label = render(series)
+      .filter((o) => o.op === 'fillText')
+      .find((o) => String(o.args[0]).startsWith('L30: '));
+    expect(label).toBeDefined();
+
+    const [text, x, , align] = label!.args as [string, number, number, string];
+    const width = text.length * CHAR_W;
+    const [left, right] = align === 'right' ? [x - width, x] : [x, x + width];
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(right).toBeLessThanOrEqual(W);
+  });
+});

--- a/src/__tests__/layer-chart.test.ts
+++ b/src/__tests__/layer-chart.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Layer-time chart geometry (ELEG-16).
+ *
+ * The chart used to take its X domain from the **first and last** entries of the window,
+ * which silently assumes the series is sorted. It is not always: an entry from the
+ * previous print can sit in front of the current one (see
+ * `src/server/__tests__/layer-tracking.test.ts` for how it gets there). With a domain of
+ * 29..63, layer 1 mapped to x ≈ -358 and was drawn straight over the Y-axis labels and
+ * off the canvas, while its 155s duration flattened every real layer against the
+ * baseline.
+ *
+ * These cover the two pure helpers only. Nothing here paints: there is no jsdom or
+ * canvas in this suite, so the `ctx.clip()` that bounds the series to the plot rect is
+ * verified by eye, not by a test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeDomain, selectVisibleLayers, type LayerTimePoint } from '../ui/layer-chart';
+
+const pt = (layer: number, duration: number): LayerTimePoint => ({
+  layer,
+  duration,
+  timestamp: 1_786_110_795_370 + layer * 1000,
+});
+
+describe('selectVisibleLayers', () => {
+  it('keeps a healthy monotonic series intact', () => {
+    const series = [pt(1, 33), pt(2, 24), pt(3, 20)];
+    expect(selectVisibleLayers(series)).toEqual(series);
+  });
+
+  it('drops a previous print left sitting in front of the current one', () => {
+    const series = [pt(29, 155.259), pt(1, 33), pt(2, 24), pt(3, 20)];
+    expect(selectVisibleLayers(series).map((p) => p.layer)).toEqual([1, 2, 3]);
+  });
+
+  it('keeps only the run after the last decrease when there are several', () => {
+    const series = [pt(9, 5), pt(1, 5), pt(2, 5), pt(40, 5), pt(1, 5), pt(2, 5)];
+    expect(selectVisibleLayers(series).map((p) => p.layer)).toEqual([1, 2]);
+  });
+
+  it('treats a repeated layer as a boundary too', () => {
+    expect(
+      selectVisibleLayers([pt(1, 5), pt(2, 5), pt(2, 9), pt(3, 5)]).map((p) => p.layer),
+    ).toEqual([2, 3]);
+  });
+
+  it('caps the window at maxVisible, keeping the most recent layers', () => {
+    const series = Array.from({ length: 250 }, (_, i) => pt(i + 1, 10));
+    const visible = selectVisibleLayers(series);
+    expect(visible).toHaveLength(200);
+    expect(visible[0].layer).toBe(51);
+    expect(visible[199].layer).toBe(250);
+  });
+
+  it('handles an empty series', () => {
+    expect(selectVisibleLayers([])).toEqual([]);
+  });
+});
+
+describe('computeDomain', () => {
+  it('spans the real min and max, not the first and last entries', () => {
+    // Out of order on purpose. The endpoints alone give 29..63, which is what mapped
+    // layer 1 to a negative X and painted it over the axis gutter.
+    const d = computeDomain([pt(29, 155.259), pt(1, 33), pt(63, 15)]);
+    expect(d.xMin).toBe(1);
+    expect(d.xMax).toBe(63);
+    expect(d.xRange).toBe(62);
+  });
+
+  it('keeps every point inside the plot rect for an unsorted window', () => {
+    const visible = [pt(29, 155.259), pt(1, 33), pt(2, 24), pt(63, 15)];
+    const { xMin, xRange, yMax } = computeDomain(visible);
+    const [padLeft, padTop, plotW, plotH] = [48, 10, 500, 122];
+    const xMap = (layer: number) => padLeft + ((layer - xMin) / xRange) * plotW;
+    const yMap = (dur: number) => padTop + plotH - (dur / yMax) * plotH;
+    for (const p of visible) {
+      expect(xMap(p.layer)).toBeGreaterThanOrEqual(padLeft);
+      expect(xMap(p.layer)).toBeLessThanOrEqual(padLeft + plotW);
+      expect(yMap(p.duration)).toBeGreaterThanOrEqual(padTop);
+      expect(yMap(p.duration)).toBeLessThanOrEqual(padTop + plotH);
+    }
+  });
+
+  it('gives the Y axis 15% headroom above the tallest layer', () => {
+    expect(computeDomain([pt(1, 10), pt(2, 20)]).yMax).toBeCloseTo(23);
+  });
+
+  it('falls back to a usable scale for an empty or all-zero window', () => {
+    expect(computeDomain([]).yMax).toBe(10);
+    expect(computeDomain([]).xRange).toBe(1);
+    expect(computeDomain([pt(1, 0), pt(2, 0)]).yMax).toBe(10);
+  });
+
+  it('never collapses the X range to zero for a single-layer window', () => {
+    expect(computeDomain([pt(7, 12)]).xRange).toBe(1);
+  });
+});

--- a/src/server/__tests__/layer-tracking.test.ts
+++ b/src/server/__tests__/layer-tracking.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Layer-report classification (ELEG-16).
+ *
+ * The repro these are built from is real. The running service returned 64 layer entries
+ * whose **first** element was `{layer: 29, duration: 155.259}` — the previous job's last
+ * layer, timed across the gap before the new job reached layer 1. The printer keeps
+ * reporting the finished job's `current_layer` for a moment after a print ends, so the
+ * new job's first report arrives as a *drop*, and timing that drop invents an entry that
+ * belongs to neither print. It sits in front of the new series, leaving `layerTimes`
+ * non-monotonic — which is what made the layer chart paint outside its own axes.
+ *
+ * This file lives under `src/server/` for the same reason as `mcp-doc-parity.test.ts`:
+ * `tsconfig.json` excludes that directory, so importing server code from
+ * `src/__tests__/` would drag Node-only modules into the browser typecheck. Here it is
+ * covered by `pnpm service:check`. The chart half is tested separately, in
+ * `src/__tests__/layer-chart.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyLayerReport } from '../state-store.js';
+
+const T0 = 1_786_110_795_370;
+
+describe('classifyLayerReport', () => {
+  it('records a layer that genuinely completed', () => {
+    const r = classifyLayerReport(4, T0, 5, T0 + 13_000);
+    expect(r.action).toBe('record');
+    expect(r.durationSec).toBe(13);
+  });
+
+  it('ignores a repeat of the layer already being tracked', () => {
+    expect(classifyLayerReport(5, T0, 5, T0 + 13_000).action).toBe('ignore');
+  });
+
+  it('only starts the clock when there is nothing to time against', () => {
+    expect(classifyLayerReport(0, 0, 29, T0).action).toBe('baseline');
+    expect(classifyLayerReport(29, 0, 30, T0).action).toBe('baseline');
+  });
+
+  it('treats a layer going backwards as a print boundary, not a completed layer', () => {
+    // The exact live repro: L29 was still being reported from the finished job when the
+    // new job's first real report arrived, 155s later, as L1.
+    const r = classifyLayerReport(29, T0, 1, T0 + 155_259);
+    expect(r.action).toBe('boundary');
+    // The cross-print gap must not survive as a duration.
+    expect(r.durationSec).toBe(0);
+  });
+
+  it('treats any decrease as a boundary, not just a drop to layer 1', () => {
+    expect(classifyLayerReport(120, T0, 119, T0 + 15_000).action).toBe('boundary');
+  });
+
+  it('discards an implausible duration rather than plotting it', () => {
+    expect(classifyLayerReport(4, T0, 5, T0 + 601_000).action).toBe('discard');
+    expect(classifyLayerReport(4, T0, 5, T0 + 599_000).action).toBe('record');
+  });
+
+  it('never reports a duration for anything it did not record', () => {
+    for (const r of [
+      classifyLayerReport(5, T0, 5, T0 + 13_000),
+      classifyLayerReport(0, 0, 29, T0),
+      classifyLayerReport(29, T0, 1, T0 + 155_259),
+    ]) {
+      expect(r.durationSec).toBe(0);
+    }
+  });
+});

--- a/src/server/state-store.ts
+++ b/src/server/state-store.ts
@@ -56,6 +56,46 @@ const FILAMENT_RADIUS_MM = 1.75 / 2;
 const CROSS_SECTION_MM2 = Math.PI * FILAMENT_RADIUS_MM * FILAMENT_RADIUS_MM; // ~2.405 mm²
 const CROSS_SECTION_CM2 = Math.PI * (0.175 / 2) ** 2; // in cm² for g/cm³ density
 
+/** Ring-buffer cap on the layer-time series (a very tall print, not a real limit) */
+const MAX_LAYER_ENTRIES = 50_000;
+/** A single layer taking longer than this is a stale timestamp, not a slow layer */
+const MAX_PLAUSIBLE_LAYER_SEC = 600;
+
+/** What a `current_layer` report means, given the layer we were tracking before it. */
+export type LayerReportAction =
+  | 'ignore' // same layer as before — nothing has completed
+  | 'baseline' // no previous layer to time against; just start the clock
+  | 'boundary' // layer went backwards: a different print, discard the pending entry
+  | 'discard' // implausible duration, almost certainly a stale timestamp
+  | 'record'; // a layer genuinely finished
+
+/**
+ * Decide what to do with a `current_layer` report. Pure, so the print-boundary rule can
+ * be tested without an MQTT bridge — see `src/server/__tests__/layer-tracking.test.ts`.
+ *
+ * The boundary case is the one that matters (ELEG-16): the printer keeps reporting the
+ * *previous* job's `current_layer` for a moment after it ends, so the new job's first
+ * report arrives as a drop (L29 → L1). Timing that gap produces an entry belonging to
+ * neither print, and it lands in front of the new series — leaving `layerTimes`
+ * non-monotonic and the layer chart drawing outside its own axes.
+ */
+export function classifyLayerReport(
+  prevLayer: number,
+  prevLayerTime: number,
+  nextLayer: number,
+  now: number,
+): { action: LayerReportAction; durationSec: number } {
+  if (nextLayer === prevLayer) return { action: 'ignore', durationSec: 0 };
+  if (prevLayer <= 0 || prevLayerTime <= 0) return { action: 'baseline', durationSec: 0 };
+  if (nextLayer < prevLayer) return { action: 'boundary', durationSec: 0 };
+
+  const durationSec = (now - prevLayerTime) / 1000;
+  return {
+    action: durationSec > MAX_PLAUSIBLE_LAYER_SEC ? 'discard' : 'record',
+    durationSec,
+  };
+}
+
 /** Per-spool filament usage tracking */
 export interface FilamentUsage {
   trayKey: string; // 'mono' or 'canvas_<canvasId>_tray_<trayId>'
@@ -939,44 +979,58 @@ export class StateStore extends EventEmitter {
   private trackLayerChange(layer: number | undefined): void {
     if (layer == null || layer <= 0) return;
     const now = Date.now();
-    if (layer !== this._lastLayer) {
-      if (this._lastLayer > 0 && this._lastLayerTime > 0) {
-        const durationSec = (now - this._lastLayerTime) / 1000;
-        // Sanity check: reject bogus durations (> 10 min per layer is implausible,
-        // likely caused by stale timestamp across restart or print boundary)
-        if (durationSec > 600) {
-          log.warn(
-            `Discarding bogus layer duration: L${this._lastLayer} = ${durationSec.toFixed(0)}s`,
-          );
-        } else {
-          const entry = { layer: this._lastLayer, duration: durationSec, timestamp: now };
-          this.layerTimes.push(entry);
-          if (this.layerTimes.length > 50_000) this.layerTimes.shift();
-          // Broadcast to WS clients
-          this.emit('layer_time', entry);
-        }
-        // Emit first_layer_complete when layer 1 finishes
-        if (this.baselineReady && this._lastLayer === 1) {
-          this.emit('print_event', {
-            type: 'first_layer_complete',
-            filename: this.status?.print_status?.filename || '',
-            totalLayers: this.totalLayers || 0,
-            durationSec,
-          } satisfies PrintEvent);
-        }
-        // Emit layer_change event for milestone layers (every 10 layers)
-        if (this.baselineReady && layer % 10 === 0) {
-          this.emit('print_event', {
-            type: 'layer_change',
-            layer,
-            totalLayers: this.totalLayers || 0,
-            durationSec,
-          } satisfies PrintEvent);
-        }
-      }
-      this._lastLayer = layer;
-      this._lastLayerTime = now;
+
+    const report = classifyLayerReport(this._lastLayer, this._lastLayerTime, layer, now);
+    if (report.action === 'ignore') return;
+
+    if (report.action === 'boundary') {
+      // The printer keeps reporting the finished job's current_layer for a moment
+      // after a print ends, so the first report of the new job arrives as a *drop*.
+      // Recording it would append a cross-print entry (ELEG-16) and leave the series
+      // non-monotonic, which is what painted the layer chart outside its plot area.
+      log.info(
+        `Layer went backwards (L${this._lastLayer} → L${layer}) — treating as a print boundary, resetting layer data`,
+      );
+      this.clearLayerData();
+    } else if (report.action === 'discard') {
+      log.warn(
+        `Discarding bogus layer duration: L${this._lastLayer} = ${report.durationSec.toFixed(0)}s`,
+      );
+    } else if (report.action === 'record') {
+      const entry = { layer: this._lastLayer, duration: report.durationSec, timestamp: now };
+      this.layerTimes.push(entry);
+      if (this.layerTimes.length > MAX_LAYER_ENTRIES) this.layerTimes.shift();
+      // Broadcast to WS clients
+      this.emit('layer_time', entry);
     }
+
+    // Milestone events describe a layer that genuinely completed, so they are skipped
+    // for a boundary (the duration spans two prints) and for the first report after a
+    // reset (there is no previous layer to have finished).
+    if (report.action === 'record' || report.action === 'discard') {
+      // Emit first_layer_complete when layer 1 finishes
+      if (this.baselineReady && this._lastLayer === 1) {
+        this.emit('print_event', {
+          type: 'first_layer_complete',
+          filename: this.status?.print_status?.filename || '',
+          totalLayers: this.totalLayers || 0,
+          durationSec: report.durationSec,
+        } satisfies PrintEvent);
+      }
+      // Emit layer_change event for milestone layers (every 10 layers)
+      if (this.baselineReady && layer % 10 === 0) {
+        this.emit('print_event', {
+          type: 'layer_change',
+          layer,
+          totalLayers: this.totalLayers || 0,
+          durationSec: report.durationSec,
+        } satisfies PrintEvent);
+      }
+    }
+
+    // Set the baseline last: clearLayerData() above zeroes both fields.
+    this._lastLayer = layer;
+    this._lastLayerTime = now;
   }
 
   /** Get human-readable status summary (used by Telegram) */

--- a/src/ui/layer-chart.ts
+++ b/src/ui/layer-chart.ts
@@ -8,6 +8,69 @@ const GRID_COLOR = 'rgba(160, 160, 184, 0.12)';
 const LABEL_COLOR = '#a0a0b8';
 const LABEL_FONT = '10px -apple-system, BlinkMacSystemFont, sans-serif';
 const SERIES_COLOR = '#ab47bc';
+const MAX_VISIBLE = 200;
+
+/** One entry of the layer-time series, as the server sends it over `/ws`. */
+export interface LayerTimePoint {
+  layer: number;
+  duration: number;
+  timestamp: number;
+}
+
+/**
+ * Pick the window to plot: the last `maxVisible` entries of the **trailing
+ * strictly-increasing run**.
+ *
+ * The series is not guaranteed monotonic. The printer reports the finished job's
+ * `current_layer` for a moment after a print ends, so an entry belonging to the previous
+ * print can sit in front of the new one (ELEG-16 — the server no longer creates those,
+ * but a persisted series from before the fix still has one). Anything at or before the
+ * last decrease belongs to a different print, so plotting it would mix two jobs on one
+ * axis — and its duration spans the gap between them, which flattens every real layer
+ * against the baseline.
+ */
+export function selectVisibleLayers(
+  layerTimes: readonly LayerTimePoint[],
+  maxVisible = MAX_VISIBLE,
+): LayerTimePoint[] {
+  let start = 0;
+  for (let i = 1; i < layerTimes.length; i++) {
+    if (layerTimes[i].layer <= layerTimes[i - 1].layer) start = i;
+  }
+  const run = layerTimes.slice(start);
+  return run.length > maxVisible ? run.slice(-maxVisible) : run;
+}
+
+/**
+ * The plot's domain, from the **actual** min/max rather than the first and last entries.
+ * Taking the endpoints assumes the window is sorted; when it is not, out-of-domain points
+ * map to negative X and paint over the axis gutter instead of staying in the plot.
+ */
+export function computeDomain(visible: readonly LayerTimePoint[]): {
+  xMin: number;
+  xMax: number;
+  xRange: number;
+  yMax: number;
+} {
+  let xMin = Number.POSITIVE_INFINITY;
+  let xMax = Number.NEGATIVE_INFINITY;
+  let peak = 0;
+  for (const lt of visible) {
+    if (lt.layer < xMin) xMin = lt.layer;
+    if (lt.layer > xMax) xMax = lt.layer;
+    if (lt.duration > peak) peak = lt.duration;
+  }
+  if (!Number.isFinite(xMin)) {
+    xMin = 0;
+    xMax = 0;
+  }
+  return {
+    xMin,
+    xMax,
+    xRange: Math.max(1, xMax - xMin),
+    yMax: peak * 1.15 || 10, // 15% headroom
+  };
+}
 
 let lastDataLen = -1;
 let hoverX = -1; // CSS pixels relative to canvas, -1 = not hovering
@@ -63,7 +126,9 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, w, h);
 
-  if (layerTimes.length < 2) {
+  // Determine visible range — the current print's last N layers
+  const visible = selectVisibleLayers(layerTimes);
+  if (visible.length < 2) {
     ctx.fillStyle = LABEL_COLOR;
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
@@ -72,24 +137,10 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
     return;
   }
 
-  // Determine visible range — show last N layers that fit, or all
-  const maxVisible = Math.min(layerTimes.length, 200);
-  const visible = layerTimes.slice(-maxVisible);
-
   const plotW = w - PADDING.left - PADDING.right;
   const plotH = h - PADDING.top - PADDING.bottom;
 
-  // X: layer numbers
-  const xMin = visible[0].layer;
-  const xMax = visible[visible.length - 1].layer;
-  const xRange = Math.max(1, xMax - xMin);
-
-  // Y: duration in seconds
-  let yMax = 0;
-  for (const lt of visible) {
-    if (lt.duration > yMax) yMax = lt.duration;
-  }
-  yMax = yMax * 1.15 || 10; // 15% headroom
+  const { xMin, xRange, yMax } = computeDomain(visible);
 
   const xMap = (layer: number) => PADDING.left + ((layer - xMin) / xRange) * plotW;
   const yMap = (dur: number) => PADDING.top + plotH - (dur / yMax) * plotH;
@@ -129,6 +180,14 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
     ctx.fillText(`L${layer}`, x, PADDING.top + plotH + 4);
   }
 
+  // Series, fill and dots are clipped to the plot rect — the domain above keeps every
+  // point inside it, and this keeps that true for any data shape we have not thought of
+  // rather than letting a stray point paint over the axis labels.
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(PADDING.left, PADDING.top, plotW, plotH);
+  ctx.clip();
+
   // Draw line
   ctx.strokeStyle = SERIES_COLOR;
   ctx.lineWidth = 1.5;
@@ -146,17 +205,15 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   ctx.stroke();
 
   // Fill area under the curve
-  if (visible.length >= 2) {
-    ctx.fillStyle = 'rgba(171, 71, 188, 0.12)';
-    ctx.beginPath();
-    ctx.moveTo(xMap(visible[0].layer), yMap(0));
-    for (const lt of visible) {
-      ctx.lineTo(xMap(lt.layer), yMap(lt.duration));
-    }
-    ctx.lineTo(xMap(visible[visible.length - 1].layer), yMap(0));
-    ctx.closePath();
-    ctx.fill();
+  ctx.fillStyle = 'rgba(171, 71, 188, 0.12)';
+  ctx.beginPath();
+  ctx.moveTo(xMap(visible[0].layer), yMap(0));
+  for (const lt of visible) {
+    ctx.lineTo(xMap(lt.layer), yMap(lt.duration));
   }
+  ctx.lineTo(xMap(visible[visible.length - 1].layer), yMap(0));
+  ctx.closePath();
+  ctx.fill();
 
   // Draw dots on data points (only if not too many)
   if (visible.length <= 80) {
@@ -170,17 +227,23 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
     }
   }
 
-  // Current value label at rightmost point
+  ctx.restore();
+
+  // Current value label at rightmost point. The last point sits on the plot's right
+  // edge, so the label only ever fits to its left.
   const last = visible[visible.length - 1];
   ctx.fillStyle = SERIES_COLOR;
   ctx.font = 'bold 11px -apple-system, BlinkMacSystemFont, sans-serif';
-  ctx.textAlign = 'left';
   ctx.textBaseline = 'middle';
-  ctx.fillText(
-    `L${last.layer}: ${last.duration.toFixed(1)}s`,
-    xMap(last.layer) + 6,
-    yMap(last.duration),
-  );
+  const lastLabel = `L${last.layer}: ${last.duration.toFixed(1)}s`;
+  const lastX = xMap(last.layer);
+  if (lastX + 6 + ctx.measureText(lastLabel).width <= w) {
+    ctx.textAlign = 'left';
+    ctx.fillText(lastLabel, lastX + 6, yMap(last.duration));
+  } else {
+    ctx.textAlign = 'right';
+    ctx.fillText(lastLabel, lastX - 6, yMap(last.duration));
+  }
 
   // Average line
   const avgDuration = visible.reduce((s, lt) => s + lt.duration, 0) / visible.length;


### PR DESCRIPTION
Fixes ELEG-16.

## The symptom

The layer-time chart under the GCODE PREVIEW card drew its line and area fill **to the left of the Y axis**, over the tick-label gutter and off the canvas edge; the real data was squashed into the bottom ~8% of the plot; the X axis started at `L29`; and a stray `L` was clipped against the right edge.

## One stale point caused nearly all of it

The printer keeps reporting the finished job's `current_layer` for a moment after a print ends, so the new job's first report arrives as a **drop** (L29 → L1). `trackLayerChange()` timed that drop and recorded an entry belonging to neither print — 155s among 14s layers, which slipped under the existing 600s sanity cutoff — and it landed *in front of* the new series.

Confirmed read-only against the running service: the MCP `layers` tool returned 64 entries with exactly one non-increasing step, at index 0.

```json
[{"layer": 29, "duration": 155.259, ...},   ← previous print
 {"layer": 1,  "duration": 33.002,  ...},   ← current print starts here
 ... L2 … L63]
```

That one entry explains the wrong domain (`visible[0].layer = 29`), the wrong scale (155.259 × 1.15 ≈ 178.5 — precisely the `0s/36s/71s/107s/143s/179s` ladder in the report), and the X axis starting at L29.

## What changed

**Server — `src/server/state-store.ts`.** A decreasing layer number is now treated as a print boundary: the pending entry is dropped rather than recorded, the series is reset, and the milestone events that would have carried the cross-print duration are skipped. The decision moved into a pure `classifyLayerReport()` so the rule is testable without standing up an MQTT bridge.

**Chart — `src/ui/layer-chart.ts`.**
- `computeDomain()` takes the **real min/max**, not the first and last entries. The old code assumed a sorted window; with a domain of 29..63, `xMap(1) ≈ -358`.
- The series, fill and dots are `ctx.clip()`ed to the plot rect, so no future data shape can paint over the axes.
- `selectVisibleLayers()` plots the trailing strictly-increasing run, so a series persisted *before* this fix still renders correctly instead of waiting on a manual reset.
- The rightmost value label flips to the left of its point when it would overflow. This was an independent bug — the last point always sits on the plot's right edge, so `xMap(last) + 6` was always past it, on good data too. Measured: x=608 on a 554px canvas.

## Verification

`pnpm gates` green — biome, both typechecks, vite build, 39 tests.

Adds 21 tests, and **each new guard was proven load-bearing** by breaking it and watching the named tests go red:

| Guard removed | Tests that failed |
| --- | --- |
| the `nextLayer < prevLayer` boundary rule | 3 in `layer-tracking.test.ts` |
| min/max domain → endpoints | 2 in `layer-chart.test.ts` |
| trailing-run selection | 3 in `layer-chart.test.ts` |
| the whole chart change (vs. this branch's parent) | 3 in `layer-chart-render.test.ts` |

`src/__tests__/layer-chart-render.test.ts` is the repo's **first test that runs drawing code**: no jsdom, no canvas dependency, just a recording 2D-context stub that the chart draws into, asserting on the ops emitted. It catches a missing `clip()`, a coordinate outside the plot rect, and a label past the canvas edge.

**What none of this proves:** no gate here opens a browser or takes a screenshot, and no browser automation was available in the session, so I have **not looked at the rendered page**. The render test asserts geometry, not appearance — colour, font, overlap and layout are unverified. No printer command was issued; the whole diagnosis was reads (`/api/health`, the MCP `layers` tool).

Docs updated for the new suite size and shape: `.agents/testing.md`, `.claude/commands/local/gates.md`, `scripts/gates.sh` (their test counts were already stale by one file before this change).

## Follow-ups

- **ELEG-17** — OPERATOR: deploy this, and clear the contaminated series already stored on the running service. The chart will look right without it, but `/api/metrics`, MCP `layers` and the print-report stats still average across the phantom entry.
- **ELEG-18** — `restoreLayerData()` accepts a non-monotonic persisted series, so a pre-fix `state.json` re-feeds it to those same consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)