### PR TITLE
chore(deploy): stop the installer printing warnings on a healthy deploy (ELEG-19)

### DIFF
--- a/.agents/deployment.md
+++ b/.agents/deployment.md
@@ -36,6 +36,16 @@ tsconfigs, writes the build stamp, `pnpm install --prod`,
 preserves an existing `.env`, and **requires `rsync`** — it exits rather than falling
 back to a copy that cannot delete.
 
+**`/opt/elegooweb` never gets devDependencies.** The install there is `--prod` and only
+`--prod`; if the source tree has no `dist/`, the installer builds it in the *checkout*
+(dropping to `$SUDO_USER`, so root does not leave artefacts in your working tree) and
+rsyncs the result. It used to run a full `pnpm install` + `pnpm build` inside
+`/opt/elegooweb` on first install, which put vite, vitest, typescript and release-it
+into production and left every later `--prod` run pruning them back out — the source of
+the `Failed to create bin … ENOENT` warnings that made a healthy deploy read as broken
+(ELEG-19). The runbook below builds before installing anyway, so that path was only ever
+reached on a first install.
+
 Three consequences that have already produced a real artefact:
 
 1. **The copy is delete-consistent, but only from the next install onwards.** It used to

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -68,6 +68,27 @@ if ! id "$SERVICE_USER" &>/dev/null; then
     useradd --system --no-create-home --shell /usr/sbin/nologin "$SERVICE_USER"
 fi
 
+# Build the frontend if the source tree has none.
+#
+# This builds in $SCRIPT_DIR — the checkout — and NOT in $INSTALL_DIR. Building in the
+# install directory is what used to drag the entire dev toolchain (vite, vitest,
+# typescript, release-it) into production, which every later `pnpm install --prod` then
+# had to prune back out, emitting the "Failed to create bin ... ENOENT" warnings that
+# made a healthy deploy look broken (ELEG-19). $INSTALL_DIR gets runtime dependencies
+# and nothing else.
+#
+# It also drops to $SUDO_USER: this script runs as root, and a root-owned dist/ and
+# node_modules/ left behind in someone's working tree is a nasty parting gift.
+if [[ ! -d "$SCRIPT_DIR/dist" ]]; then
+    log_info "No dist/ in source — building the frontend..."
+    if [[ -n "${SUDO_USER:-}" ]]; then
+        sudo -u "$SUDO_USER" bash -c "cd $(printf '%q' "$SCRIPT_DIR") && pnpm install && pnpm build"
+    else
+        log_warn "  No SUDO_USER — building as root, which will leave root-owned files in $SCRIPT_DIR"
+        (cd "$SCRIPT_DIR" && pnpm install && pnpm build)
+    fi
+fi
+
 # Create installation directory
 log_info "Creating installation directory: $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
@@ -203,18 +224,13 @@ else
     log_info "Keeping existing .env configuration"
 fi
 
-# Build frontend if dist/ doesn't exist
-if [[ ! -d "$INSTALL_DIR/dist" ]]; then
-    log_info "Building frontend..."
-    cd "$INSTALL_DIR"
-    pnpm install
-    pnpm build
-else
-    # Production install for server deps only
-    log_info "Installing dependencies..."
-    cd "$INSTALL_DIR"
-    pnpm install --prod
-fi
+# Runtime dependencies only. Never a plain `pnpm install` here: devDependencies in
+# $INSTALL_DIR are a larger production surface than the service needs, and the next
+# --prod run has to prune them again (ELEG-19). The frontend is built in the source
+# checkout above and arrives via rsync, so nothing in this directory needs a toolchain.
+log_info "Installing production dependencies..."
+cd "$INSTALL_DIR"
+pnpm install --prod
 
 # Set ownership
 log_info "Setting permissions..."

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "check": "biome check --write src/",
-    "prepare": "simple-git-hooks || true"
+    "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1 && simple-git-hooks >/dev/null 2>&1 || true"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",


### PR DESCRIPTION
Fixes ELEG-19.

`pnpm service:install` succeeded but ended on output that reads like failure:

```
 WARN  Failed to create bin at /opt/elegooweb/node_modules/.bin/conventional-commits-parser. ENOENT: ...
 WARN  Failed to create bin at /opt/elegooweb/node_modules/.bin/yaml. ENOENT: ...
 WARN  Failed to create bin at /opt/elegooweb/node_modules/.bin/jiti. ENOENT: ...
> simple-git-hooks || true
sh: simple-git-hooks: command not found
```

Nothing was broken — verified against the live install — but an installer whose normal output contains `WARN`, `ENOENT` and `command not found` trains everyone to stop reading it, which undoes the legibility ELEG-6 and ELEG-10 were for.

## `simple-git-hooks: command not found`

`prepare` ran on every install including `--prod`, where `simple-git-hooks` is correctly absent as a devDependency — and where it would be pointless regardless, since `/opt/elegooweb` is not a git checkout. `|| true` swallowed the exit code but not the message, which `sh` writes itself.

Now guarded on actually being in a git checkout, and on `git` existing at all (an unguarded `git rev-parse` would just trade one `command not found` for another on a host without git).

## The bin warnings

Those three packages are devDependency transitives, and the warnings were pnpm pruning them. They were there to prune because the installer used to run a **full** `pnpm install` + `pnpm build` *inside* `/opt/elegooweb` whenever `dist/` was missing — so production accumulated vite, vitest, typescript and release-it, and every later `--prod` run had to remove them again.

The frontend is now built in the **source checkout** and rsynced across (the rsync for `dist/` already existed), dropping to `$SUDO_USER` so root does not leave a root-owned `dist/` and `node_modules/` in someone's working tree. `$INSTALL_DIR` gets `pnpm install --prod` unconditionally. Smaller production surface as well as a quieter one.

## Verification

`pnpm gates` green, and `bash -n contrib/install.sh` clean — but be clear about what that is worth: **no gate in this repo lints or executes shell**, so the installer change is verified by reading plus a syntax check, and nothing more.

What I did test directly is the `prepare` guard, in both directions:

- **Developer path** — deleted `.git/hooks/pre-commit`, ran `pnpm run prepare`, confirmed the hook was reinstalled and that the run was silent. (Testing it with a bare `sh -c` would have been misleading: that does not put `node_modules/.bin` on PATH, so it "passes" by failing to find the binary.)
- **Production path** — ran the same script in a non-git directory: silent, exit 0.

**I have not run the installer.** It restarts the live service, which is operator work under this repo's rules. The real confirmation is the next deploy printing no `WARN`, no `ENOENT` and no `command not found`, with `ls /opt/elegooweb/node_modules` still showing only runtime dependencies — added to ELEG-17, which already covers the next operator deploy.

## Related

While diagnosing this I found that `/opt/elegooweb` and its `.env` are mode `777` — filed as **ELEG-20** (installer never sets modes) and **ELEG-21** (`OPERATOR:` fix the live install now). Not touched here; different concern, and the live half should not wait on a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)