### PR TITLE
fix(telegram): gate inbound bot commands on the sender id (ELEG-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ docker run -d -p 8088:8088 -p 7125:7125 -e PRINTER_IP=172.20.100.236 ghcr.io/run
 | `CAMERA_ENABLED` | `true` | Enable camera MJPEG proxy |
 | `CAMERA_URL` | `http://<PRINTER_IP>:8080` | Override camera URL |
 | `TELEGRAM_BOT_TOKEN` | — | Telegram bot token (enables notifications) |
-| `TELEGRAM_CHAT_ID` | — | Telegram chat ID |
+| `TELEGRAM_CHAT_ID` | — | Telegram chat ID — where notifications are **sent** |
+| `TELEGRAM_ALLOWED_CHAT_IDS` | `TELEGRAM_CHAT_ID` | Comma-separated numeric sender ids permitted to **issue** bot commands. Anyone else is ignored silently |
 | `PROGRESS_INTERVAL` | `25` | Notify every N% progress |
 | `DATA_DIR` | `./data` | Data directory for state, reports, logs |
 | `AI_ENABLED` | `false` | Enable AI print monitoring |

--- a/src/server/__tests__/telegram-allowlist.test.ts
+++ b/src/server/__tests__/telegram-allowlist.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Telegram sender allowlist (ELEG-3).
+ *
+ * Both bots registered `/start`, `/help`, `/status` and `/photo` with no check on who
+ * sent the message. `TELEGRAM_CHAT_ID` was only ever used for *outbound* notifications,
+ * so inbound was open to anyone who found the bot — printer status, and via `/photo` a
+ * live camera image of the room.
+ *
+ * This is a security boundary, so it is asserted in **both** directions: that an allowed
+ * id passes, and that everything else is refused. The middleware wiring in
+ * `src/server/telegram.ts` and `src/telegram/commands.ts` is not covered — nothing in
+ * this repo can stand up a grammy bot — so the `next()`-only-when-allowed shape is
+ * verified by reading. What is covered is every way the decision itself can go wrong.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isAllowedSender, parseAllowedChatIds } from '../../telegram/allowlist.js';
+
+describe('parseAllowedChatIds', () => {
+  it('falls back to TELEGRAM_CHAT_ID when no explicit list is set', () => {
+    expect(parseAllowedChatIds(undefined, '12345')).toEqual(['12345']);
+    expect(parseAllowedChatIds('', '12345')).toEqual(['12345']);
+    expect(parseAllowedChatIds('   ', '12345')).toEqual(['12345']);
+  });
+
+  it('parses a comma-separated list, tolerating whitespace', () => {
+    expect(parseAllowedChatIds(' 111 , 222,333 ', '999')).toEqual(['111', '222', '333']);
+  });
+
+  it('keeps negative ids — a Telegram channel id is negative', () => {
+    expect(parseAllowedChatIds('-1001234567890', '')).toEqual(['-1001234567890']);
+  });
+
+  it('keeps ids beyond Number.MAX_SAFE_INTEGER intact', () => {
+    // Parsing these as numbers would round them and let a near-miss id through.
+    const huge = '99999999999999999999';
+    expect(parseAllowedChatIds(huge, '')).toEqual([huge]);
+  });
+
+  it('drops malformed entries rather than widening the gate', () => {
+    expect(parseAllowedChatIds('111,notanid,,222, 1.5 ,0x10', '')).toEqual(['111', '222']);
+  });
+
+  it('deduplicates', () => {
+    expect(parseAllowedChatIds('111,111,222', '')).toEqual(['111', '222']);
+  });
+
+  it('returns empty when there is nothing usable at all', () => {
+    expect(parseAllowedChatIds(undefined, '')).toEqual([]);
+    expect(parseAllowedChatIds('garbage', '')).toEqual([]);
+  });
+});
+
+describe('isAllowedSender', () => {
+  const allowed = parseAllowedChatIds('111,-1002', '');
+
+  it('admits an id on the list', () => {
+    expect(isAllowedSender(allowed, 111)).toBe(true);
+    expect(isAllowedSender(allowed, -1002)).toBe(true);
+  });
+
+  it('refuses an id that is not on the list', () => {
+    expect(isAllowedSender(allowed, 112)).toBe(false);
+    expect(isAllowedSender(allowed, 1)).toBe(false);
+    expect(isAllowedSender(allowed, -111)).toBe(false);
+  });
+
+  it('refuses an update with no sender', () => {
+    // ctx.from is optional in grammy — channel posts have none.
+    expect(isAllowedSender(allowed, undefined)).toBe(false);
+  });
+
+  it('denies everyone when the allowlist is empty', () => {
+    // The safe direction. Treating empty as "allow all" would turn a missing env var
+    // back into the hole this closes.
+    expect(isAllowedSender([], 111)).toBe(false);
+    expect(isAllowedSender([], undefined)).toBe(false);
+  });
+
+  it('does not match on a prefix or a substring', () => {
+    expect(isAllowedSender(['1234'], 123)).toBe(false);
+    expect(isAllowedSender(['1234'], 12345)).toBe(false);
+  });
+});

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import { parseAllowedChatIds } from '../telegram/allowlist.js';
 
 export interface ServiceConfig {
   // Printer
@@ -16,6 +17,8 @@ export interface ServiceConfig {
   telegramEnabled: boolean;
   telegramToken: string;
   telegramChatId: string;
+  /** Numeric sender ids permitted to issue bot commands; empty denies everyone (ELEG-3) */
+  telegramAllowedChatIds: string[];
   progressInterval: number;
 
   // Data persistence
@@ -73,6 +76,18 @@ export function loadConfig(): ServiceConfig {
   if (telegramChatId && !/^-?\d+$/.test(telegramChatId)) {
     throw new Error(`Invalid TELEGRAM_CHAT_ID: "${telegramChatId}" (must be a numeric string)`);
   }
+  // Who may *send* commands. Defaults to TELEGRAM_CHAT_ID, so an existing deployment
+  // gains the gate without a new setting (ELEG-3).
+  const telegramAllowedChatIds = parseAllowedChatIds(
+    env('TELEGRAM_ALLOWED_CHAT_IDS'),
+    telegramChatId,
+  );
+  if (env('TELEGRAM_ALLOWED_CHAT_IDS') && telegramAllowedChatIds.length === 0) {
+    throw new Error(
+      'TELEGRAM_ALLOWED_CHAT_IDS is set but contains no valid numeric id — refusing to start ' +
+        'rather than fall back to a bot that answers everyone',
+    );
+  }
 
   return {
     printerIp,
@@ -83,6 +98,7 @@ export function loadConfig(): ServiceConfig {
     telegramEnabled: !!(telegramToken && telegramChatId),
     telegramToken,
     telegramChatId,
+    telegramAllowedChatIds,
     progressInterval: parseInt(env('PROGRESS_INTERVAL', '25'), 10) || 25,
     dataDir: env('DATA_DIR') || './data',
     moonrakerPort,

--- a/src/server/telegram.ts
+++ b/src/server/telegram.ts
@@ -10,6 +10,7 @@ import type { MqttBridge } from './mqtt-bridge.js';
 import type { ServiceConfig } from './config.js';
 import { getSnapshot } from './rest-api.js';
 import { CRITICAL_EXCEPTIONS } from '../types.js';
+import { isAllowedSender } from '../telegram/allowlist.js';
 import type { AIAlert } from './ai-monitor.js';
 import { getLogger } from './logger.js';
 
@@ -136,6 +137,19 @@ export class TelegramIntegration {
   }
 
   private registerCommands(): void {
+    // Sender gate, BEFORE any handler (ELEG-3). Middleware rather than a check inside
+    // each command, so a command added later is gated by construction instead of by
+    // somebody remembering. Drops silently: replying "unauthorised" confirms the bot
+    // exists and which chat it belongs to.
+    const allowed = this.config.telegramAllowedChatIds;
+    this.bot.use(async (ctx, next) => {
+      if (isAllowedSender(allowed, ctx.from?.id)) {
+        await next();
+        return;
+      }
+      log.warn(`Ignoring update from unauthorised sender ${ctx.from?.id ?? 'unknown'}`);
+    });
+
     this.bot.command('start', async (ctx) => {
       await ctx.reply(
         '🖨 *Elegoo CC2 Telegram Bot*\n\n' +

--- a/src/telegram/allowlist.ts
+++ b/src/telegram/allowlist.ts
@@ -1,0 +1,46 @@
+/**
+ * Who is allowed to talk to the bot (ELEG-3).
+ *
+ * Both Telegram entry points — `src/server/telegram.ts`, which is what the service runs,
+ * and the standalone `src/telegram/bot.ts` — registered `/start`, `/help`, `/status` and
+ * `/photo` with **no check on the sender**. `TELEGRAM_CHAT_ID` was only ever used for
+ * *outbound* messages, so inbound was open to anyone who found the bot: printer status,
+ * and via `/photo` a live camera image of the room.
+ *
+ * Kept here, pure and separate from grammy, so the boundary is unit-testable without a
+ * Telegram connection — see `src/server/__tests__/telegram-allowlist.test.ts`.
+ */
+
+/**
+ * Parse a comma-separated allowlist of numeric Telegram ids.
+ *
+ * Ids are matched as **strings** deliberately: Telegram ids can exceed
+ * `Number.MAX_SAFE_INTEGER`, and a channel id is negative. Anything that is not a
+ * well-formed id is dropped rather than silently widening the gate — a typo should cost
+ * you access, not hand it out.
+ */
+export function parseAllowedChatIds(raw: string | undefined, fallback = ''): string[] {
+  const source = raw?.trim() ? raw : fallback;
+  if (!source) return [];
+  return [
+    ...new Set(
+      source
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => /^-?\d+$/.test(s)),
+    ),
+  ];
+}
+
+/**
+ * Is this sender allowed?
+ *
+ * **An empty allowlist denies everyone.** That is the safe direction and it costs
+ * nothing: `telegramEnabled` already requires `TELEGRAM_CHAT_ID` to be set, so a
+ * correctly-configured bot always has at least one id. Treating empty as "allow all"
+ * would turn a missing variable back into the hole this closes.
+ */
+export function isAllowedSender(allowed: readonly string[], fromId: number | undefined): boolean {
+  if (fromId == null) return false;
+  return allowed.includes(String(fromId));
+}

--- a/src/telegram/commands.ts
+++ b/src/telegram/commands.ts
@@ -2,18 +2,34 @@
  * Telegram bot command handlers: /status, /photo, /help
  */
 
-import type { Context } from 'grammy';
+import type { Context, MiddlewareFn } from 'grammy';
 import { InputFile } from 'grammy';
 import type { MqttBridge } from './mqtt-bridge.js';
 import type { BotConfig } from './config.js';
 import { fetchSnapshot } from './camera.js';
 import { safeCaption } from './notifications.js';
+import { isAllowedSender } from './allowlist.js';
 
 export function registerCommands(
-  bot: { command: (cmd: string, handler: (ctx: Context) => Promise<void>) => void },
+  bot: {
+    command: (cmd: string, handler: (ctx: Context) => Promise<void>) => void;
+    use: (middleware: MiddlewareFn<Context>) => unknown;
+  },
   bridge: MqttBridge,
   config: BotConfig,
 ): void {
+  // Sender gate, BEFORE any handler (ELEG-3) — see src/server/telegram.ts for the
+  // reasoning. Silent drop; a reply would confirm the bot exists.
+  bot.use(async (ctx, next) => {
+    if (isAllowedSender(config.allowedChatIds, ctx.from?.id)) {
+      await next();
+      return;
+    }
+    console.warn(
+      `[Telegram] Ignoring update from unauthorised sender ${ctx.from?.id ?? 'unknown'}`,
+    );
+  });
+
   bot.command('start', async (ctx) => {
     await ctx.reply(
       '🖨 *Elegoo CC2 Telegram Bot*\n\n' +

--- a/src/telegram/config.ts
+++ b/src/telegram/config.ts
@@ -1,8 +1,11 @@
 import 'dotenv/config';
+import { parseAllowedChatIds } from './allowlist.js';
 
 export interface BotConfig {
   telegramToken: string;
   chatId: string;
+  /** Numeric sender ids permitted to issue bot commands; empty denies everyone (ELEG-3) */
+  allowedChatIds: string[];
   printerIp: string;
   printerPassword: string;
   cameraEnabled: boolean;
@@ -22,9 +25,13 @@ function requireEnv(key: string): string {
 
 export function loadConfig(): BotConfig {
   const printerIp = process.env['PRINTER_IP'] || '172.20.100.236';
+  const chatId = requireEnv('TELEGRAM_CHAT_ID');
   return {
     telegramToken: requireEnv('TELEGRAM_BOT_TOKEN'),
-    chatId: requireEnv('TELEGRAM_CHAT_ID'),
+    chatId,
+    // Defaults to TELEGRAM_CHAT_ID so an existing deployment gains the gate with no new
+    // setting (ELEG-3).
+    allowedChatIds: parseAllowedChatIds(process.env['TELEGRAM_ALLOWED_CHAT_IDS'], chatId),
     printerIp,
     printerPassword: process.env['PRINTER_PASSWORD'] || '123456',
     cameraEnabled: process.env['CAMERA_ENABLED'] !== 'false',


### PR DESCRIPTION
Fixes ELEG-3.

`/start`, `/help`, `/status` and `/photo` were registered with **no check on who sent the message**. `TELEGRAM_CHAT_ID` is only used for *outbound* notifications, so inbound was open to any Telegram user who found the bot — printer status, and via `/photo` a live camera image of the room.

## The issue understated the scope

It named `src/telegram/commands.ts`. **`src/server/telegram.ts` had the identical hole**, and that is the one the service actually runs — `src/server/index.ts` wires `TelegramIntegration`, while `src/telegram/**` is a standalone bot with no script, Dockerfile reference or unit pointing at it. Fixing only the file the issue named would have left production wide open. Both are gated here.

## The gate

A grammy middleware registered **before any handler**, so a command added later is gated by construction rather than by somebody remembering:

```ts
this.bot.use(async (ctx, next) => {
  if (isAllowedSender(allowed, ctx.from?.id)) { await next(); return; }
  log.warn(`Ignoring update from unauthorised sender ${ctx.from?.id ?? 'unknown'}`);
});
```

Unauthorised updates are dropped silently — a reply confirms the bot exists and which chat it belongs to.

The decision itself lives in `src/telegram/allowlist.ts`, pure and free of grammy, so the boundary is testable without a Telegram connection. Three choices worth flagging:

- **Ids compare as strings.** Telegram ids can exceed `Number.MAX_SAFE_INTEGER`, and parsing to a number would round them — letting a near-miss id through. Channel ids are also negative.
- **Malformed entries are dropped, not tolerated.** A typo costs you access rather than handing it out.
- **An empty allowlist denies everyone.** Treating empty as "allow all" would turn a missing env var straight back into this hole. `loadConfig` also refuses to start if `TELEGRAM_ALLOWED_CHAT_IDS` is set but yields no valid id, rather than silently falling back.

## Config

`TELEGRAM_ALLOWED_CHAT_IDS` (comma-separated) defaults to `TELEGRAM_CHAT_ID`, so **existing deployments gain the gate with no new setting**. README env table updated.

## Verification

`pnpm gates` green, 51 tests (12 new). The guard was checked in the failing direction with two separate mutations:

| Mutation | Tests that went red |
| --- | --- |
| empty allowlist means allow-all + prefix matching | `refuses an id that is not on the list`, `denies everyone when the allowlist is empty`, `does not match on a prefix or a substring` |
| accept any non-empty string as an id | `drops malformed entries rather than widening the gate`, `returns empty when there is nothing usable at all` |

**What is not covered:** the middleware *wiring*. Nothing in this repo can stand up a grammy bot, so "`next()` is called only when allowed" is verified by reading, not by a test. The decision function underneath it is covered exhaustively. I did not send a message to the real bot — that needs the live token.

**One gap I could not close:** `.env.example` is blocked by a permission rule in my session, so the new variable is documented in `README.md` but not there. It is optional with a safe default, so nothing breaks; worth a one-line follow-up edit by hand.

## Related

`src/telegram/**` being unreachable dead code that carries its **own MQTT client** — against this repo's one-connection rule — is filed separately rather than resolved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)