### PR TITLE
fix(state): sanitise a restored layer series at the boundary (ELEG-18)

### DIFF
--- a/src/printer-state.ts
+++ b/src/printer-state.ts
@@ -1,4 +1,5 @@
 import type { PrinterAttributes, PrinterStatus, CanvasInfo, FileEntry, ZoneState } from './types';
+import { trailingLayerRun } from './types';
 
 export type StateListener = () => void;
 
@@ -390,13 +391,19 @@ export class PrinterState {
     this.notify();
   }
 
-  /** Restore layer data from persistence (init snapshot from server) */
+  /**
+   * Restore layer data from persistence (init snapshot from server).
+   *
+   * Sanitised on the way in, the same way the server does it (ELEG-18) — an older service
+   * can still send a series carrying an entry from a previous print, and anything reading
+   * `layerTimes` directly rather than going through the chart would inherit it.
+   */
   restoreLayerData(
     layerTimes: Array<{ layer: number; duration: number; timestamp: number }>,
     _lastLayer: number,
     _lastLayerTime: number,
   ): void {
-    this.layerTimes = layerTimes;
+    this.layerTimes = trailingLayerRun(layerTimes);
   }
 
   /** Register callback to request full status refresh (method 1002) on auto-report gaps */

--- a/src/server/__tests__/layer-tracking.test.ts
+++ b/src/server/__tests__/layer-tracking.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { classifyLayerReport } from '../state-store.js';
+import { trailingLayerRun } from '../../types.js';
 
 const T0 = 1_786_110_795_370;
 
@@ -63,5 +64,36 @@ describe('classifyLayerReport', () => {
     ]) {
       expect(r.durationSec).toBe(0);
     }
+  });
+});
+
+describe('trailingLayerRun', () => {
+  const e = (layer: number, duration = 10) => ({ layer, duration, timestamp: T0 + layer });
+
+  it('leaves a healthy monotonic series alone', () => {
+    const series = [e(1), e(2), e(3)];
+    expect(trailingLayerRun(series)).toEqual(series);
+  });
+
+  it('drops a previous print left in front of the current one', () => {
+    // The live repro: one 155s cross-print entry ahead of L1.
+    const restored = [e(29, 155.259), e(1, 33), e(2, 24), e(3, 20)];
+    expect(trailingLayerRun(restored).map((x) => x.layer)).toEqual([1, 2, 3]);
+  });
+
+  it('never drops from the tail — the newest entry always survives', () => {
+    const restored = [e(29), e(1), e(2), e(3)];
+    const run = trailingLayerRun(restored);
+    expect(run[run.length - 1]).toEqual(restored[restored.length - 1]);
+  });
+
+  it('handles an empty series', () => {
+    expect(trailingLayerRun([])).toEqual([]);
+  });
+
+  it('keeps the newest run when several prints are stacked up', () => {
+    expect(trailingLayerRun([e(9), e(1), e(2), e(40), e(1), e(2)]).map((x) => x.layer)).toEqual([
+      1, 2,
+    ]);
   });
 });

--- a/src/server/__tests__/state-store-restore.test.ts
+++ b/src/server/__tests__/state-store-restore.test.ts
@@ -1,0 +1,76 @@
+/**
+ * StateStore.restoreLayerData sanitisation (ELEG-18).
+ *
+ * This is the first test in the repo that stands up a real `StateStore`. It needs no
+ * printer and opens no connection: the constructor only registers listeners on the bridge
+ * it is handed, so an EventEmitter stub satisfies it. It *does* start a chart-sampling
+ * interval, hence the `destroy()` in afterEach — without it vitest never exits.
+ *
+ * What is being pinned: a `data/state.json` written before ELEG-16 can carry an entry
+ * from a previous print, and `StatePersistence.load()` accepts a snapshot up to 24h old.
+ * Everything downstream reads `store.layerTimes` raw — `/api/metrics`' average, the MCP
+ * `layers` tool, `computeLayerStats` in the report collector — so if the corruption gets
+ * past this boundary it reaches all of them.
+ */
+
+import { EventEmitter } from 'events';
+import { describe, it, expect, afterEach } from 'vitest';
+import { StateStore } from '../state-store.js';
+import type { MqttBridge } from '../mqtt-bridge.js';
+
+const T0 = 1_786_110_795_370;
+const entry = (layer: number, duration: number) => ({
+  layer,
+  duration,
+  timestamp: T0 + layer * 1000,
+});
+
+let store: StateStore | null = null;
+
+function makeStore(): StateStore {
+  // The constructor only calls bridge.on(); nothing in the restore path touches it.
+  const bridge = new EventEmitter() as unknown as MqttBridge;
+  store = new StateStore(bridge, 25);
+  return store;
+}
+
+afterEach(() => {
+  store?.destroy();
+  store = null;
+});
+
+describe('StateStore.restoreLayerData', () => {
+  it('drops a previous print carried in by a stale state.json', () => {
+    // The live repro, verbatim: L29 from the finished job in front of L1–L3.
+    const s = makeStore();
+    s.restoreLayerData([entry(29, 155.259), entry(1, 33), entry(2, 24), entry(3, 20)], 4, T0);
+
+    expect(s.layerTimes.map((l) => l.layer)).toEqual([1, 2, 3]);
+    // The 155s cross-print duration is what skewed every consumer's average.
+    expect(Math.max(...s.layerTimes.map((l) => l.duration))).toBe(33);
+  });
+
+  it('leaves a healthy series untouched', () => {
+    const s = makeStore();
+    const series = [entry(1, 33), entry(2, 24), entry(3, 20)];
+    s.restoreLayerData(series, 4, T0);
+    expect(s.layerTimes).toEqual(series);
+  });
+
+  it('keeps the persisted baseline, which still describes the surviving tail', () => {
+    const s = makeStore();
+    s.restoreLayerData([entry(29, 155.259), entry(1, 33), entry(2, 24)], 3, T0 + 9999);
+    // Entries are only ever dropped from the front, so the layer in progress is unchanged.
+    expect(s.getLastLayer()).toBe(3);
+    expect(s.getLastLayerTime()).toBe(T0 + 9999);
+  });
+
+  it('ignores an empty restore rather than clobbering live data', () => {
+    const s = makeStore();
+    const series = [entry(1, 33), entry(2, 24)];
+    s.restoreLayerData(series, 3, T0);
+    s.restoreLayerData([], 0, 0);
+    expect(s.layerTimes).toEqual(series);
+    expect(s.getLastLayer()).toBe(3);
+  });
+});

--- a/src/server/state-store.ts
+++ b/src/server/state-store.ts
@@ -18,6 +18,7 @@ import {
   EXCEPTION_NAMES,
   isFilamentChangeSubStatus,
   detectZone,
+  trailingLayerRun,
   ZONE_MAX_HISTORY,
 } from '../types.js';
 import type { ZoneState } from '../types.js';
@@ -496,17 +497,36 @@ export class StateStore extends EventEmitter {
     }
   }
 
-  /** Restore layer data from persistence */
+  /**
+   * Restore layer data from persistence.
+   *
+   * Sanitised on the way in (ELEG-18). `data/state.json` is accepted up to 24h old and is
+   * not necessarily written by code that had the ELEG-16 fix, so a persisted series can
+   * still carry an entry from a previous print. Everything downstream — `/api/metrics`,
+   * the MCP `layers` tool, `computeLayerStats` in the report collector — reads the raw
+   * array and would average a cross-print duration into its numbers. Cleaning here means
+   * none of them has to know.
+   */
   restoreLayerData(
     layerTimes: Array<{ layer: number; duration: number; timestamp: number }>,
     lastLayer: number,
     lastLayerTime: number,
   ): void {
-    if (layerTimes && layerTimes.length > 0) {
-      this.layerTimes = layerTimes;
-      this._lastLayer = lastLayer;
-      this._lastLayerTime = lastLayerTime;
+    if (!layerTimes || layerTimes.length === 0) return;
+
+    const clean = trailingLayerRun(layerTimes);
+    const dropped = layerTimes.length - clean.length;
+    if (dropped > 0) {
+      log.warn(
+        `Restored layer data was not monotonic — dropped ${dropped} entr${dropped === 1 ? 'y' : 'ies'} from a previous print, kept ${clean.length} from L${clean[0].layer}`,
+      );
     }
+
+    this.layerTimes = clean;
+    // The persisted baseline still describes the tail: entries are only ever dropped from
+    // the front, so the last entry — and the layer in progress after it — is unchanged.
+    this._lastLayer = lastLayer;
+    this._lastLayerTime = lastLayerTime;
   }
 
   getLastLayer(): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,3 +380,38 @@ export function detectZone(x: number, y: number): ZoneName {
   }
   return 'outside';
 }
+
+// ── Layer-time series ────────────────────────────────────────────────
+
+/** One completed layer: how long it took, and when it finished. */
+export interface LayerTimeEntry {
+  layer: number;
+  duration: number;
+  timestamp: number;
+}
+
+/**
+ * Keep only the trailing strictly-increasing run of a layer-time series.
+ *
+ * The series is supposed to be monotonic in `layer` within a print, and since ELEG-16 the
+ * store no longer produces one that is not. But a series can still arrive non-monotonic
+ * from *outside* that guarantee — `data/state.json` written before that fix, or any
+ * future path that gets it wrong — and a cross-print entry then skews `/api/metrics`, the
+ * MCP `layers` tool and the print-report stats, none of which look at anything but the
+ * raw array (ELEG-18).
+ *
+ * Anything at or before the last decrease belongs to a previous print, so it goes. Its
+ * duration spans the gap *between* two prints, which is why leaving it in is worse than
+ * dropping it: on the live repro one 155s phantom sat among 14s layers.
+ *
+ * Lives in `types.ts` because both halves need the identical rule — the server sanitising
+ * at the restore boundary, the chart choosing what to plot — and two copies would be free
+ * to disagree. Pure, and covered by `src/__tests__/layer-chart.test.ts`.
+ */
+export function trailingLayerRun<T extends LayerTimeEntry>(entries: readonly T[]): T[] {
+  let start = 0;
+  for (let i = 1; i < entries.length; i++) {
+    if (entries[i].layer <= entries[i - 1].layer) start = i;
+  }
+  return entries.slice(start);
+}

--- a/src/ui/layer-chart.ts
+++ b/src/ui/layer-chart.ts
@@ -1,6 +1,7 @@
 /** Layer time chart — plots duration per layer with layer numbers on X-axis */
 
 import type { PrinterState } from '../printer-state';
+import { type LayerTimeEntry, trailingLayerRun } from '../types';
 import { $ } from './helpers';
 
 const PADDING = { top: 10, right: 12, bottom: 28, left: 48 };
@@ -11,11 +12,7 @@ const SERIES_COLOR = '#ab47bc';
 const MAX_VISIBLE = 200;
 
 /** One entry of the layer-time series, as the server sends it over `/ws`. */
-export interface LayerTimePoint {
-  layer: number;
-  duration: number;
-  timestamp: number;
-}
+export type LayerTimePoint = LayerTimeEntry;
 
 /**
  * Pick the window to plot: the last `maxVisible` entries of the **trailing
@@ -33,11 +30,7 @@ export function selectVisibleLayers(
   layerTimes: readonly LayerTimePoint[],
   maxVisible = MAX_VISIBLE,
 ): LayerTimePoint[] {
-  let start = 0;
-  for (let i = 1; i < layerTimes.length; i++) {
-    if (layerTimes[i].layer <= layerTimes[i - 1].layer) start = i;
-  }
-  const run = layerTimes.slice(start);
+  const run = trailingLayerRun(layerTimes);
   return run.length > maxVisible ? run.slice(-maxVisible) : run;
 }
 


### PR DESCRIPTION
Fixes ELEG-18. Follow-up to ELEG-16.

ELEG-16 fixed where a cross-print layer entry was **produced** and where it was **displayed**. It did not touch where one gets **reloaded**: `restoreLayerData()` assigned `data/state.json` straight through, and `StatePersistence.load()` accepts a snapshot up to 24h old. Confirmed live after that deploy — the phantom `L29` came straight back across the restart.

Only the chart was protected, because it filters for itself. Everything reading `store.layerTimes` raw still saw it:

- `rest-api.ts` — `avgLayerDur` is a plain mean, so one 155s entry among 14s layers moves it by ~2s
- `mcp-server.ts` — the `layers` tool and `printer://metrics`; this is how ELEG-16 was diagnosed in the first place
- `print-report-collector.ts` — `computeLayerStats` reports the phantom as the slowest layer

## The rule now lives once

`trailingLayerRun()` in `src/types.ts`, which **both** tsconfigs include. Three call sites use it:

| Where | Why |
| --- | --- |
| `StateStore.restoreLayerData` | the actual fix — sanitise on the way in, log what was dropped |
| `PrinterState.restoreLayerData` | same shape on the browser side, fed by the WS init snapshot |
| `selectVisibleLayers` (chart) | was carrying its own copy of the rule since ELEG-16 |

Sanitising at the boundary rather than teaching each consumer to filter means none of them has to know. Two copies of the rule would have been free to drift.

Entries are only ever dropped from the **front**, so the persisted `lastLayer`/`lastLayerTime` still describe the surviving tail — the timing baseline is deliberately left alone.

## Verification

`pnpm gates` green, 60 tests (9 new).

`src/server/__tests__/state-store-restore.test.ts` is **the first test in this repo that stands up a real `StateStore`**. It needs no printer and opens no connection — the constructor only registers listeners on the bridge it is handed, so an `EventEmitter` stub satisfies it. It does start a chart-sampling interval, hence `destroy()` in `afterEach`; without that vitest never exits. That pattern is worth reusing: the state store is the most bug-prone code in the repo and had no tests at all.

Load-bearing check — replacing `trailingLayerRun(layerTimes)` with `layerTimes` in the restore path turns `drops a previous print carried in by a stale state.json` red, and nothing else. That is the failing direction confirmed at the boundary that matters, not just on the helper.

Not covered: nothing asserts the downstream consumers themselves. The argument that they are fixed is that they read `store.layerTimes` and that is now clean — verified by reading, not by a test.

## Operator note

This does not clean `/opt/elegooweb/data/state.json`. The next restore will drop the phantom in memory, so the effect is the same from the outside; ELEG-17's `DELETE /api/layer-data` is still the way to clear it at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)