### PR TITLE
fix(server): default to same-origin instead of Access-Control-Allow-Origin: * (ELEG-24)

### DIFF
--- a/.agents/security.md
+++ b/.agents/security.md
@@ -28,15 +28,28 @@ Three things make this sharper than a typical "no auth" note:
 
 1. **The consequences are physical.** A request can heat a nozzle, drive the toolhead,
    start a job or abort a 14-hour print. There is no undo.
-2. **`Access-Control-Allow-Origin: *`** is set on `/mcp`, `/octoprint/*` and
-   `/moonraker/*`. With no credentials to withhold, that means **any web page a browser
-   visits can issue those requests** from inside the network the browser is on. A
-   `SameSite` cookie does not help, because there is no cookie.
+2. **`Access-Control-Allow-Origin: *` — fixed in ELEG-24, and worth understanding anyway.**
+   It used to be set on **five** surfaces: `/mcp`, `/octoprint/*`, `/moonraker/*`, and the
+   two the original note missed — **`/api/*`** (the snapshot, stream and control routes)
+   and **the dedicated `:7125` server**. With no credentials to withhold, that meant **any
+   web page a browser visits could issue those requests** from inside the network the
+   browser is on. A `SameSite` cookie does not help, because there is no cookie.
 
-   This is the one that survives a LAN-only deployment intact, and it is easy to
+   This is the one that survived a LAN-only deployment intact, and it is easy to
    under-rate: the attacker does not need to reach the network, only to get someone who is
    already on it to load a page. "It is not exposed" is an answer about inbound routing,
    not about this.
+
+   The default is now **same-origin** — no `Access-Control-Allow-Origin` at all unless
+   `CORS_ALLOWED_ORIGINS` names one. The SPA is served by the origin it calls, so it needs
+   none. A browser-based compat client on another origin (Mainsail, Fluidd) now needs that
+   variable set; `*` still works as an explicit opt-in, which is the point — the dangerous
+   setting should be something a person chose.
+
+   All five surfaces go through `src/server/cors.ts`. **Add a new surface and you get the
+   policy for free only if you route through it** — the `:7125` server is the cautionary
+   example: it sets the headers once in `handleHttp` precisely because ~100
+   `jsonResult`/`jsonError` call sites could each have forgotten.
 3. **The compat layers advertise auth they do not have.** `octoprint-compat.ts` returns
    a fixed `apikey: 'elegoo-cc2-compat'` and the Moonraker layer answers
    `access.get_api_key` — so a client shows "connected, authenticated" while nothing was

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -114,7 +114,7 @@ motors into whatever is on the bed, or abort a job that has been running for hou
 Verifying one of those is operator work: give the exact command, ask for the output,
 interpret it. See [`AGENTS.md`](../AGENTS.md).
 
-## `pnpm dev` on this host collides with production — twice
+## `pnpm dev` on this host collides with production — three ways
 
 Production runs on this same machine (see [deployment.md](deployment.md)), and it holds
 **both** service ports:
@@ -130,12 +130,43 @@ MQTT broker means **two registrations for one printer**. The broker is small and
 two clients fight — which looks like flapping state or dropped updates in *production*,
 not in your dev window.
 
-To run the service locally, override both ports in your checkout's `.env`
-(e.g. `SERVICE_PORT=8188`, `MOONRAKER_PORT=7225`) and accept that you are still opening
-a second MQTT connection — so keep it short, and prefer `pnpm dev:web` (vite on :5173,
-frontend only) whenever the change is frontend-only. `vite.config.ts` proxies the API
-to the running service, which means **the dev frontend can be pointed at production
-state without a second connection at all.** That is the safest way to work here.
+**The third collision is the Telegram bot, and it bites even on free ports.** Your
+checkout's `.env` holds the **production** `TELEGRAM_BOT_TOKEN`, and a bot token supports
+exactly one long-poller. Start the service locally and grammy dies with:
+
+```
+GrammyError: Call to 'getUpdates' failed! (409: Conflict: terminated by other getUpdates
+request; make sure that only one bot instance is running)
+```
+
+— but not before *your* poller has kicked the production one off the token. The live
+service recovers (`Restart=always`, and grammy retries), so the damage is a gap in
+notifications rather than anything lasting. It also takes your dev process down, which is
+how you find out. Measured while verifying ELEG-24.
+
+So when you must run the service locally, blank the integrations rather than only moving
+the ports:
+
+```bash
+TELEGRAM_BOT_TOKEN= TELEGRAM_CHAT_ID= AI_ENABLED=false CAMERA_ENABLED=false \
+  SERVICE_PORT=18096 MOONRAKER_PORT=17122 PRINTER_IP=192.0.2.99 DATA_DIR=/tmp/probe \
+  pnpm exec tsx src/server/index.ts
+```
+
+`PRINTER_IP` on TEST-NET (`192.0.2.0/24`) is the important part: it means the MQTT
+connection attempt goes nowhere instead of becoming the second registration described
+above. The service starts and serves HTTP happily without a printer, which is enough to
+probe headers, routes and status codes.
+
+Prefer `pnpm dev:web` (vite on :5173, frontend only) whenever the change is frontend-only.
+`vite.config.ts` proxies the API to the running service, which means **the dev frontend
+can be pointed at production state without a second connection at all.** That is the
+safest way to work here.
+
+**When you do probe a local server, prove the request landed.** `curl … | grep -i
+'^access-control-allow-origin'` printing nothing means "header absent" *or* "server never
+came up", and those look identical. Print the status line too — a check that passes
+because nothing answered is worse than no check.
 
 ## What nothing checks — say so instead of implying otherwise
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ docker run -d -p 8088:8088 -p 7125:7125 -e PRINTER_IP=172.20.100.236 ghcr.io/run
 | `MOONRAKER_PORT` | `7125` | Moonraker compatibility API port |
 | `CAMERA_ENABLED` | `true` | Enable camera MJPEG proxy |
 | `CAMERA_URL` | `http://<PRINTER_IP>:8080` | Override camera URL |
+| `CORS_ALLOWED_ORIGINS` | — (same-origin) | Comma-separated origins allowed to make cross-origin requests to `/api/*`, `/mcp`, `/moonraker/*`, `/octoprint/*` and `:7125`. Unset means **no cross-origin access**. `*` restores the old allow-everything behaviour |
 | `TELEGRAM_BOT_TOKEN` | — | Telegram bot token (enables notifications) |
 | `TELEGRAM_CHAT_ID` | — | Telegram chat ID — where notifications are **sent** |
 | `TELEGRAM_ALLOWED_CHAT_IDS` | `TELEGRAM_CHAT_ID` | Comma-separated numeric sender ids permitted to **issue** bot commands. Anyone else is ignored silently |

--- a/src/server/__tests__/cors.test.ts
+++ b/src/server/__tests__/cors.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Cross-origin policy (ELEG-24).
+ *
+ * A CORS check that is wrong in the *permissive* direction looks completely fine from the
+ * outside — the app works, nothing errors, and the hole is invisible until someone goes
+ * looking. So these assert refusal at least as hard as they assert admission.
+ *
+ * What was there before: `Access-Control-Allow-Origin: *` on all five surfaces, with no
+ * credential to withhold, in front of `set_temperature`, `move`, `start_print`,
+ * `emergency_stop`, `/api/snapshot` and `/api/stream`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { allowOriginFor, corsHeaders, parseCorsPolicy } from '../cors.js';
+
+describe('parseCorsPolicy', () => {
+  it('defaults to same-origin when unset or empty', () => {
+    expect(parseCorsPolicy(undefined)).toEqual({ kind: 'none' });
+    expect(parseCorsPolicy('')).toEqual({ kind: 'none' });
+    expect(parseCorsPolicy('   ')).toEqual({ kind: 'none' });
+  });
+
+  it('treats a bare * as the explicit opt-in', () => {
+    expect(parseCorsPolicy('*')).toEqual({ kind: 'any' });
+  });
+
+  it('parses a list, trimming whitespace and trailing slashes', () => {
+    expect(parseCorsPolicy(' https://a.test/ , https://b.test ')).toEqual({
+      kind: 'list',
+      origins: ['https://a.test', 'https://b.test'],
+    });
+  });
+
+  it('deduplicates', () => {
+    expect(parseCorsPolicy('https://a.test,https://a.test')).toEqual({
+      kind: 'list',
+      origins: ['https://a.test'],
+    });
+  });
+});
+
+describe('allowOriginFor', () => {
+  const list = parseCorsPolicy('https://mainsail.test,https://fluidd.test');
+
+  it('reflects a configured origin back', () => {
+    expect(allowOriginFor(list, 'https://mainsail.test')).toBe('https://mainsail.test');
+  });
+
+  it('refuses an origin that is not configured', () => {
+    expect(allowOriginFor(list, 'https://evil.example')).toBeNull();
+  });
+
+  it('does not admit a prefix or suffix near-miss', () => {
+    // The bug this is here to prevent: substring or startsWith matching would hand
+    // https://mainsail.test.evil.example the keys.
+    expect(allowOriginFor(list, 'https://mainsail.test.evil.example')).toBeNull();
+    expect(allowOriginFor(list, 'https://evil.example/https://mainsail.test')).toBeNull();
+    expect(allowOriginFor(list, 'mainsail.test')).toBeNull();
+  });
+
+  it('sends nothing when the policy is same-origin, whatever the request claims', () => {
+    const none = parseCorsPolicy(undefined);
+    expect(allowOriginFor(none, 'https://mainsail.test')).toBeNull();
+    expect(allowOriginFor(none, undefined)).toBeNull();
+  });
+
+  it('sends nothing for a request with no Origin under a list policy', () => {
+    // Not a cross-origin request; it needs no header.
+    expect(allowOriginFor(list, undefined)).toBeNull();
+  });
+
+  it('still allows everything under the explicit * opt-in', () => {
+    const any = parseCorsPolicy('*');
+    expect(allowOriginFor(any, 'https://evil.example')).toBe('*');
+    expect(allowOriginFor(any, undefined)).toBe('*');
+  });
+});
+
+describe('corsHeaders', () => {
+  it('emits no headers at all under the default policy', () => {
+    const h = corsHeaders(
+      parseCorsPolicy(undefined),
+      'https://evil.example',
+      'GET',
+      'Content-Type',
+    );
+    expect(h).toEqual({});
+  });
+
+  it('emits the full set for an allowed origin, and Vary: Origin with it', () => {
+    const h = corsHeaders(
+      parseCorsPolicy('https://mainsail.test'),
+      'https://mainsail.test',
+      'GET, POST',
+      'Content-Type',
+    );
+    expect(h['Access-Control-Allow-Origin']).toBe('https://mainsail.test');
+    expect(h['Access-Control-Allow-Methods']).toBe('GET, POST');
+    // Without Vary, a shared cache could serve one origin's response to another.
+    expect(h.Vary).toBe('Origin');
+  });
+
+  it('emits nothing for a disallowed origin even when a list is configured', () => {
+    expect(
+      corsHeaders(parseCorsPolicy('https://mainsail.test'), 'https://evil.example', 'GET', 'X'),
+    ).toEqual({});
+  });
+
+  it('includes expose-headers only when asked', () => {
+    const policy = parseCorsPolicy('*');
+    expect(
+      corsHeaders(policy, undefined, 'GET', 'X')['Access-Control-Expose-Headers'],
+    ).toBeUndefined();
+    expect(
+      corsHeaders(policy, undefined, 'GET', 'X', 'mcp-session-id')['Access-Control-Expose-Headers'],
+    ).toBe('mcp-session-id');
+  });
+});

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { parseAllowedChatIds } from '../telegram/allowlist.js';
+import { type CorsPolicy, parseCorsPolicy } from './cors.js';
 
 export interface ServiceConfig {
   // Printer
@@ -12,6 +13,9 @@ export interface ServiceConfig {
   // Camera
   cameraEnabled: boolean;
   cameraUrl: string;
+
+  /** Cross-origin policy for every HTTP surface; defaults to same-origin (ELEG-24) */
+  corsPolicy: CorsPolicy;
 
   // Telegram (optional)
   telegramEnabled: boolean;
@@ -95,6 +99,7 @@ export function loadConfig(): ServiceConfig {
     servicePort,
     cameraEnabled: env('CAMERA_ENABLED') !== 'false',
     cameraUrl: env('CAMERA_URL') || `http://${printerIp}:8080`,
+    corsPolicy: parseCorsPolicy(env('CORS_ALLOWED_ORIGINS')),
     telegramEnabled: !!(telegramToken && telegramChatId),
     telegramToken,
     telegramChatId,

--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -1,0 +1,99 @@
+/**
+ * Cross-origin policy for every HTTP surface (ELEG-24).
+ *
+ * All five of them used to answer `Access-Control-Allow-Origin: *`. With **no credential
+ * to withhold**, that is not a minor misconfiguration: any web page a browser on this
+ * network loads could issue cross-origin requests and read the responses. The attacker
+ * never had to reach the network — only get someone already on it to open a page.
+ * `SameSite` is irrelevant, because there is no cookie to protect.
+ *
+ * Reachable that way: `set_temperature`, `move`, `home`, `start_print`, `stop_print` and
+ * `emergency_stop` — physical consequences on a machine with heaters and motors — plus
+ * `/api/snapshot` and `/api/stream`, a live camera image of the room.
+ *
+ * The default is now **same-origin**: no header at all unless an origin is configured.
+ * The SPA is served by the origin it calls, so it needs none of this.
+ */
+
+/** Parsed `CORS_ALLOWED_ORIGINS`. `'*'` is the explicit, opt-in escape hatch. */
+export type CorsPolicy = { kind: 'none' } | { kind: 'any' } | { kind: 'list'; origins: string[] };
+
+/**
+ * Parse the configured origin list.
+ *
+ * Unset or empty means `none` — same-origin only. A bare `*` restores the old
+ * everyone-welcome behaviour, but now somebody has to type it, which is the point:
+ * the dangerous setting should be a deliberate act, not a default nobody chose.
+ *
+ * Origins are compared exactly, after stripping a trailing slash. No wildcard subdomains
+ * and no prefix matching — `https://evil.example` must not be admitted by a rule meant
+ * for `https://evil.example.good.test`, and prefix logic is how that happens.
+ */
+export function parseCorsPolicy(raw: string | undefined): CorsPolicy {
+  const value = raw?.trim();
+  if (!value) return { kind: 'none' };
+  if (value === '*') return { kind: 'any' };
+
+  const origins = [
+    ...new Set(
+      value
+        .split(',')
+        .map((s) => s.trim().replace(/\/+$/, ''))
+        .filter(Boolean),
+    ),
+  ];
+  return origins.length > 0 ? { kind: 'list', origins } : { kind: 'none' };
+}
+
+/**
+ * The value for `Access-Control-Allow-Origin`, or `null` to send no header at all.
+ *
+ * Returning the *request's* origin rather than the configured list is deliberate — a
+ * browser rejects a header naming several origins — and it is why the match has to be
+ * exact. A request with no `Origin` is not a cross-origin request and needs no header.
+ */
+export function allowOriginFor(
+  policy: CorsPolicy,
+  requestOrigin: string | undefined,
+): string | null {
+  if (policy.kind === 'none') return null;
+  if (policy.kind === 'any') return '*';
+  if (!requestOrigin) return null;
+  return policy.origins.includes(requestOrigin.replace(/\/+$/, '')) ? requestOrigin : null;
+}
+
+/** Minimal shape of what `applyCors` writes to — keeps this module free of node:http. */
+interface HeaderSink {
+  setHeader(name: string, value: string): void;
+}
+
+/** Set the computed headers, if any. An empty map means: send nothing. */
+export function applyCors(res: HeaderSink, headers: Record<string, string>): void {
+  for (const [name, value] of Object.entries(headers)) {
+    res.setHeader(name, value);
+  }
+}
+
+/** Header name → value pairs to set, given the policy and the request's Origin. */
+export function corsHeaders(
+  policy: CorsPolicy,
+  requestOrigin: string | undefined,
+  methods: string,
+  headers: string,
+  exposeHeaders?: string,
+): Record<string, string> {
+  const allow = allowOriginFor(policy, requestOrigin);
+  if (allow === null) return {};
+
+  const out: Record<string, string> = {
+    'Access-Control-Allow-Origin': allow,
+    'Access-Control-Allow-Methods': methods,
+    'Access-Control-Allow-Headers': headers,
+    'Access-Control-Max-Age': '86400',
+  };
+  if (exposeHeaders) out['Access-Control-Expose-Headers'] = exposeHeaders;
+  // Responses differ by Origin, so a shared cache must not serve one origin's response
+  // to another. Omitted when the policy is 'any', where the answer is the same for all.
+  if (policy.kind === 'list') out.Vary = 'Origin';
+  return out;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,6 +24,7 @@ import { StatePersistence } from './state-persistence.js';
 import { AIMonitor, type AIAlert } from './ai-monitor.js';
 import { PrintReportCollector } from './print-report-collector.js';
 import { getBuildInfo } from './build-info.js';
+import { applyCors, corsHeaders } from './cors.js';
 import { initLogger, getLogger } from './logger.js';
 
 const config = loadConfig();
@@ -92,12 +93,17 @@ const moonrakerServer = new MoonrakerServer(store, bridge, config);
 const httpServer = createServer((req, res) => {
   const url = req.url || '';
   if (url === '/mcp' || url.startsWith('/mcp?')) {
-    // CORS for MCP endpoint
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id');
-    res.setHeader('Access-Control-Expose-Headers', 'mcp-session-id');
-    res.setHeader('Access-Control-Max-Age', '86400');
+    // CORS for MCP endpoint — same-origin unless CORS_ALLOWED_ORIGINS says otherwise
+    applyCors(
+      res,
+      corsHeaders(
+        config.corsPolicy,
+        req.headers.origin,
+        'GET, POST, DELETE, OPTIONS',
+        'Content-Type, mcp-session-id',
+        'mcp-session-id',
+      ),
+    );
     if (req.method === 'OPTIONS') {
       res.writeHead(204);
       res.end();
@@ -115,10 +121,15 @@ const httpServer = createServer((req, res) => {
 
   // OctoPrint compatibility API
   if (url === '/octoprint' || url.startsWith('/octoprint/') || url.startsWith('/octoprint?')) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key, Authorization');
-    res.setHeader('Access-Control-Max-Age', '86400');
+    applyCors(
+      res,
+      corsHeaders(
+        config.corsPolicy,
+        req.headers.origin,
+        'GET, POST, OPTIONS',
+        'Content-Type, X-Api-Key, Authorization',
+      ),
+    );
     if (req.method === 'OPTIONS') {
       res.writeHead(204);
       res.end();
@@ -129,10 +140,15 @@ const httpServer = createServer((req, res) => {
 
   // Moonraker compatibility API
   if (url === '/moonraker' || url.startsWith('/moonraker/') || url.startsWith('/moonraker?')) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    res.setHeader('Access-Control-Max-Age', '86400');
+    applyCors(
+      res,
+      corsHeaders(
+        config.corsPolicy,
+        req.headers.origin,
+        'GET, POST, DELETE, OPTIONS',
+        'Content-Type, Authorization',
+      ),
+    );
     if (req.method === 'OPTIONS') {
       res.writeHead(204);
       res.end();

--- a/src/server/moonraker-server.ts
+++ b/src/server/moonraker-server.ts
@@ -39,6 +39,7 @@ import { execSync } from 'child_process';
 import type { StateStore } from './state-store.js';
 import type { MqttBridge } from './mqtt-bridge.js';
 import type { ServiceConfig } from './config.js';
+import { applyCors, corsHeaders } from './cors.js';
 import type { FanInfo } from '../types.js';
 import { MOONRAKER_VERSION, AVAILABLE_OBJECTS, queryObjects } from './moonraker-compat.js';
 import { createOctoPrintRouter } from './octoprint-compat.js';
@@ -53,9 +54,6 @@ function jsonResult(res: ServerResponse, data: unknown, status = 200): void {
   const body = JSON.stringify({ result: data });
   res.writeHead(status, {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Api-Key',
   });
   res.end(body);
 }
@@ -63,7 +61,6 @@ function jsonResult(res: ServerResponse, data: unknown, status = 200): void {
 function jsonError(res: ServerResponse, message: string, code = 400): void {
   res.writeHead(code, {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
   });
   res.end(JSON.stringify({ error: { code, message } }));
 }
@@ -1236,14 +1233,23 @@ export class MoonrakerServer {
     const [urlPath] = fullUrl.split('?');
     const query = parseQuery(fullUrl);
 
+    // Cross-origin policy, set ONCE for this response (ELEG-24). setHeader persists and
+    // writeHead merges over it, so the ~100 jsonResult/jsonError call sites below do not
+    // each have to know about CORS — and cannot each forget it, which is how this
+    // surface kept its wildcard when the others were reviewed.
+    applyCors(
+      res,
+      corsHeaders(
+        this.config.corsPolicy,
+        req.headers.origin,
+        'GET, POST, DELETE, OPTIONS',
+        'Content-Type, Authorization, X-Api-Key',
+      ),
+    );
+
     // CORS preflight
     if (method === 'OPTIONS') {
-      res.writeHead(204, {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Api-Key',
-        'Access-Control-Max-Age': '86400',
-      });
+      res.writeHead(204);
       res.end();
       return;
     }
@@ -2059,7 +2065,6 @@ export class MoonrakerServer {
       const target = `http://${hostHeader}:${this.config.servicePort}/`;
       res.writeHead(302, {
         Location: target,
-        'Access-Control-Allow-Origin': '*',
       });
       res.end();
       return;
@@ -2069,7 +2074,6 @@ export class MoonrakerServer {
     if (urlPath === '/info' && method === 'GET') {
       res.writeHead(200, {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
       });
       res.end(
         JSON.stringify({
@@ -2246,7 +2250,6 @@ export class MoonrakerServer {
         res.writeHead(200, {
           'Content-Type': 'application/octet-stream',
           'Content-Disposition': `attachment; filename="${baseName}"`,
-          'Access-Control-Allow-Origin': '*',
           ...(proxyRes.headers['content-length']
             ? { 'Content-Length': proxyRes.headers['content-length'] }
             : {}),

--- a/src/server/rest-api.ts
+++ b/src/server/rest-api.ts
@@ -28,6 +28,7 @@ import type { PrintReportCollector } from './print-report-collector.js';
 import type { MqttBridge } from './mqtt-bridge.js';
 import { generateReportPDF } from './print-report-pdf.js';
 import { getBuildInfo } from './build-info.js';
+import { applyCors, corsHeaders } from './cors.js';
 import { getLogger } from './logger.js';
 import { STATUS_NAMES, SUB_STATUS_NAMES, SPEED_MODE_NAMES, EXCEPTION_NAMES } from '../types.js';
 import type { FanInfo } from '../types.js';
@@ -718,12 +719,14 @@ export function createRestRouter(
   return (req: IncomingMessage, res: ServerResponse) => {
     const url = req.url || '';
 
-    // CORS headers for API routes
+    // CORS headers for API routes — same-origin unless CORS_ALLOWED_ORIGINS says
+    // otherwise (ELEG-24). This is the surface that serves /api/snapshot, /api/stream
+    // and the control routes, so the wildcard mattered most here.
     if (url.startsWith('/api/')) {
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-      res.setHeader('Access-Control-Max-Age', '86400');
+      applyCors(
+        res,
+        corsHeaders(config.corsPolicy, req.headers.origin, 'GET, POST, OPTIONS', 'Content-Type'),
+      );
       if (req.method === 'OPTIONS') {
         res.writeHead(204);
         res.end();


### PR DESCRIPTION
Fixes ELEG-24. Child of ELEG-2 — the half that needed no design decision.

All five HTTP surfaces answered `Access-Control-Allow-Origin: *`. With **no credential to withhold**, that meant any web page a browser on this network loads could issue cross-origin requests and read the responses. The attacker never had to reach the network; only get someone already on it to open a page. `SameSite` is irrelevant — there is no cookie.

Reachable that way: `set_temperature`, `move`, `home`, `start_print`, `stop_print`, `emergency_stop`, plus `/api/snapshot` and `/api/stream` — a live camera image of the room.

## ELEG-2 listed three surfaces; there were five

`/api/*` (the snapshot, stream and control routes) and the dedicated `:7125` server were both missing from it. `/api/*` is arguably the one that mattered most.

## The change

Default is **same-origin**: no header unless `CORS_ALLOWED_ORIGINS` names an origin, which is then reflected back after an **exact** match (no prefix or wildcard-subdomain logic — that is how `https://mainsail.test.evil.example` gets admitted by a rule meant for `https://mainsail.test`). `Vary: Origin` goes with it so a shared cache cannot serve one origin's response to another. A bare `*` still restores the old behaviour, but somebody now has to type it.

The SPA is served by the origin it calls, so this costs the app nothing.

The `:7125` server sets the headers **once** in `handleHttp` rather than at each of the ~100 `jsonResult`/`jsonError` call sites — `setHeader` persists and `writeHead` merges over it. Those call sites could each have forgotten, which is roughly how that surface kept its wildcard while the others were reviewed.

## Behaviour change

A browser-based compat client on another origin (Mainsail, Fluidd) now needs `CORS_ALLOWED_ORIGINS` set. That is intended. Documented in `README.md`'s env table and `.agents/security.md`, not left in a commit message.

## Verification

`pnpm gates` green, 74 tests (14 new). Guard checked in the failing direction twice:

| Mutation | Named tests that went red |
| --- | --- |
| exact match → `startsWith` | `does not admit a prefix or suffix near-miss` |
| unset means allow-all | `defaults to same-origin when unset or empty`, `sends nothing when the policy is same-origin…`, `emits no headers at all under the default policy` |

The unit tests only cover the pure half, so I also ran a **real server** (TEST-NET printer IP so no MQTT connection, integrations blanked):

```
http://127.0.0.1:18094/api/health   http=[HTTP/1.1 204 No Content]  ACAO=0
http://127.0.0.1:18094/mcp          http=[HTTP/1.1 204 No Content]  ACAO=0
http://127.0.0.1:17120/info         http=[HTTP/1.1 204 No Content]  ACAO=0
```

and with `CORS_ALLOWED_ORIGINS=https://mainsail.test`, that origin is reflected and `https://evil.example` gets nothing — so this is a policy, not just "always deny".

**Two process notes, because they matter more than the result:**

1. My first probe was **worthless and looked like a pass**. `curl … | grep -i '^access-control-allow-origin'` printing nothing means "header absent" *or* "server never came up". The status line is in the output above for that reason.
2. Getting there, I started the service locally with the checkout's `.env` — which holds the **production** `TELEGRAM_BOT_TOKEN`. A token supports one long-poller, so my process kicked the live bot off `getUpdates` (409) before dying. The live service recovered on its own and `/api/health` is green; the cost was a brief gap in Telegram notifications. Recorded in `.agents/testing.md`, which described the port and MQTT collisions but not this one.

No printer command was sent at any point.

## Siblings, filed not deferred

ELEG-25 (the auth decision), ELEG-26 (compat layers advertising auth they never check), ELEG-27 (the `0.0.0.0` bind). ELEG-2 stays open as the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)