### PR TITLE
fix(ui): surface printer-busy rejections instead of failing silently (ELEG-40)

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { detectZone, isFilamentChangeSubStatus } from '../types';
+import {
+  detectZone,
+  isFilamentChangeSubStatus,
+  classifyCommandOutcome,
+  describeCommandError,
+  COMMAND_METHOD_NAMES,
+  ERROR_CODE_NAMES,
+  BUSY_ERROR_CODES,
+  REJECTED_ERROR_CODES,
+} from '../types';
 
 describe('detectZone', () => {
   it('returns cutter_area for cutter coordinates', () => {
@@ -35,5 +44,75 @@ describe('isFilamentChangeSubStatus', () => {
     expect(isFilamentChangeSubStatus(0)).toBe(false);
     expect(isFilamentChangeSubStatus(1000)).toBe(false);
     expect(isFilamentChangeSubStatus(2075)).toBe(false);
+  });
+});
+
+describe('classifyCommandOutcome', () => {
+  it('treats 0 as success', () => {
+    expect(classifyCommandOutcome(0)).toBe('ok');
+  });
+
+  it('treats an absent code as success', () => {
+    // Several methods answer with no error_code at all; classifying that as a failure
+    // would toast an error on every one of them.
+    expect(classifyCommandOutcome(undefined)).toBe('ok');
+    expect(classifyCommandOutcome(null)).toBe('ok');
+  });
+
+  it('classifies 1009 as busy rather than as an error', () => {
+    // The whole point of ELEG-40: "busy" is transient and must not read as a failure.
+    expect(classifyCommandOutcome(1009)).toBe('busy');
+  });
+
+  it('classifies understood-but-refused codes as rejected', () => {
+    expect(classifyCommandOutcome(1003)).toBe('rejected'); // invalid parameter
+    expect(classifyCommandOutcome(1010)).toBe('rejected'); // not currently printing
+    expect(classifyCommandOutcome(1021)).toBe('rejected'); // file not found
+    expect(classifyCommandOutcome(1026)).toBe('rejected'); // needs levelling first
+  });
+
+  it('classifies genuine failures as errors', () => {
+    expect(classifyCommandOutcome(1004)).toBe('error'); // file write failed
+    expect(classifyCommandOutcome(1013)).toBe('error'); // database failure
+    expect(classifyCommandOutcome(9999)).toBe('error');
+  });
+
+  it('falls back to error for a code the table has never seen', () => {
+    expect(classifyCommandOutcome(4242)).toBe('error');
+  });
+});
+
+describe('describeCommandError', () => {
+  it('names a known code', () => {
+    expect(describeCommandError(1009)).toBe('Printer busy');
+    expect(describeCommandError(1021)).toBe('File not found');
+  });
+
+  it('falls back to the raw number for an unknown code', () => {
+    expect(describeCommandError(4242)).toBe('error 4242');
+  });
+
+  it('describes an absent code without rendering "undefined"', () => {
+    expect(describeCommandError(undefined)).toBe('unknown error');
+  });
+});
+
+describe('command tables', () => {
+  it('names every busy/rejected code it classifies', () => {
+    // A code classified but unnamed would surface to the user as a bare number, which
+    // is the thing describeCommandError exists to avoid. Derived from the sets rather
+    // than a second copy of them, so adding a code cannot pass this by omission.
+    for (const code of [...BUSY_ERROR_CODES, ...REJECTED_ERROR_CODES]) {
+      expect(ERROR_CODE_NAMES[code], `code ${code} has no name`).toBeTruthy();
+    }
+  });
+
+  it('lists only writes, never the polled reads', () => {
+    // A read that comes back busy is re-polled seconds later; toasting it is noise.
+    for (const readMethod of [1002, 1036, 1044, 1045, 1046, 1048, 1050, 1062]) {
+      expect(COMMAND_METHOD_NAMES[readMethod], `read ${readMethod} must not toast`).toBeUndefined();
+    }
+    expect(COMMAND_METHOD_NAMES[1027]).toBe('Move');
+    expect(COMMAND_METHOD_NAMES[1032]).toBe('Auto-level');
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,12 @@ import {
 } from './ui/dashboard';
 import { renderLog, bindLogControls } from './ui/log';
 import type { PrinterStatus, PrinterAttributes, CanvasInfo, FileEntry } from './types';
+import {
+  COMMAND_METHOD_NAMES,
+  classifyCommandOutcome,
+  describeCommandError,
+  type CommandOutcome,
+} from './types';
 
 const state = new PrinterState();
 const logStore = new LogStore();
@@ -308,6 +314,36 @@ function onPrinterConnected(sn: string): void {
   requestHistory();
 }
 
+/**
+ * Toast the outcome of a write command, and hand the classification back so a caller
+ * with something more specific to say on success can branch on it.
+ *
+ * Before ELEG-40 a refused command produced nothing at all: `guardedSend` re-enabled the
+ * button on its timer and the user reasonably concluded it had worked. `busy` is a
+ * warning rather than an error because it is not a failure — the printer simply could
+ * not take the command this instant.
+ *
+ * **Nothing is retried automatically, deliberately.** These are writes to a physical
+ * machine, and a re-sent `move` that lands thirty seconds later — after the user has
+ * given up and put a hand on the bed — is worse than one that visibly did nothing. The
+ * user is told they can press it again; pressing it is theirs to decide.
+ */
+function reportCommandOutcome(method: number, data: unknown): CommandOutcome {
+  const result = (data as Record<string, unknown>).result as Record<string, unknown> | undefined;
+  const code = result?.error_code as number | undefined;
+  const outcome = classifyCommandOutcome(code);
+  const label = COMMAND_METHOD_NAMES[method] ?? `Command ${method}`;
+
+  if (outcome === 'busy') {
+    toast(`${label}: printer is busy — try again in a moment`, 'warning');
+  } else if (outcome === 'rejected') {
+    toast(`${label} refused: ${describeCommandError(code)}`, 'warning');
+  } else if (outcome === 'error') {
+    toast(`${label} failed: ${describeCommandError(code)}`, 'error');
+  }
+  return outcome;
+}
+
 function connectToService(): void {
   // Build WS URL relative to current page (works with Vite proxy and production)
   const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -432,6 +468,13 @@ function connectToService(): void {
     onMessage(method, data) {
       state.handleResponse(method, data as Record<string, unknown>);
       onCommandResponse(method);
+
+      // Writes report their own failures; reads do not (a poll that comes back busy is
+      // re-polled seconds later and is not worth a toast). `ok` for anything unlisted,
+      // so the success paths below read the same either way.
+      const outcome =
+        COMMAND_METHOD_NAMES[method] !== undefined ? reportCommandOutcome(method, data) : 'ok';
+
       if (method === 1044 && client) {
         requestAnimationFrame(() => renderFiles(state, client!));
       }
@@ -443,15 +486,10 @@ function connectToService(): void {
         const errorCode = result?.error_code as number | undefined;
         if (errorCode === 0) {
           toast('File deleted', 'success');
+        } else if (classifyCommandOutcome(errorCode) === 'busy') {
+          toast('Cannot delete — printer is busy. Try again in a moment.', 'warning');
         } else {
-          const ERROR_NAMES: Record<number, string> = {
-            1003: 'Invalid parameter',
-            1007: 'Cannot delete file',
-            1009: 'Printer busy',
-            1021: 'File not found',
-          };
-          const msg = ERROR_NAMES[errorCode ?? -1] ?? `Error ${errorCode ?? 'unknown'}`;
-          toast(`Delete failed: ${msg}`, 'error');
+          toast(`Delete failed: ${describeCommandError(errorCode)}`, 'error');
         }
         client.sendCommand(1044, {
           storage_media: currentFileSource(),
@@ -477,7 +515,7 @@ function connectToService(): void {
         handleFileDetailForPrint(state);
       }
       // After move/home, request fresh status and flash position
-      if ((method === 1026 || method === 1027) && client) {
+      if ((method === 1026 || method === 1027) && client && outcome === 'ok') {
         client.sendCommand(1002, {});
         const pos = state.status?.gcode_move;
         if (pos) {
@@ -507,28 +545,32 @@ function connectToService(): void {
           } else {
             toast('Timelapse export started — video will be generated', 'info');
           }
-        } else if (err1051 === 1009) {
+        } else if (classifyCommandOutcome(err1051) === 'busy') {
           toast('Cannot export timelapse — printer is busy. Try when idle.', 'warning');
           requestAnimationFrame(() => renderTimelapse(state));
         } else {
-          toast(`Timelapse export failed (error ${err1051})`, 'error');
+          toast(`Timelapse export failed: ${describeCommandError(err1051)}`, 'error');
           requestAnimationFrame(() => renderTimelapse(state));
         }
       }
       if (method === 1050 && state.videoUrl) {
         showTimelapsePlayer(state.videoUrl);
       }
-      if (method === 1032) {
-        toast('Auto-level started', 'success');
-      }
-      if (method === 1033) {
-        toast('Vibration optimization started', 'success');
-      }
-      if (method === 1034) {
-        toast('PID calibration started', 'success');
-      }
-      if (method === 1035) {
-        toast('Self-check started', 'success');
+      // Only on success. These used to toast "started" whatever came back, so a
+      // calibration the printer had refused as busy still read as under way (ELEG-40).
+      if (outcome === 'ok') {
+        if (method === 1032) {
+          toast('Auto-level started', 'success');
+        }
+        if (method === 1033) {
+          toast('Vibration optimization started', 'success');
+        }
+        if (method === 1034) {
+          toast('PID calibration started', 'success');
+        }
+        if (method === 1035) {
+          toast('Self-check started', 'success');
+        }
       }
       if (method === 1036) {
         requestAnimationFrame(() => renderPrintHistory(state));
@@ -542,10 +584,10 @@ function connectToService(): void {
         if (errorCode === 0) {
           toast('Filament saved', 'success');
           if (client) client.sendCommand(2005, {});
-        } else if (errorCode === 1009) {
-          toast('Cannot edit filament while printing — printer is busy', 'error');
+        } else if (classifyCommandOutcome(errorCode) === 'busy') {
+          toast('Cannot edit filament while printing — printer is busy', 'warning');
         } else {
-          toast(`Filament save failed (error ${errorCode ?? '?'})`, 'error');
+          toast(`Filament save failed: ${describeCommandError(errorCode)}`, 'error');
         }
       }
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,113 @@ export function isFilamentChangeSubStatus(subStatus: number): boolean {
   return false;
 }
 
+// ─── Command result codes (`error_code` on a method response) ────────
+//
+// Distinct from EXCEPTION_NAMES below: an *exception* is a hardware fault the printer
+// reports about itself, while these come back on the response to a command we sent and
+// say what happened to that command. Names and numbers are from the official app's `hh`
+// enum, transcribed in `data/CC2_PROTOCOL_REFERENCE.md` §4.
+export const ERROR_CODE_NAMES: Record<number, string> = {
+  0: 'Success',
+  109: 'Filament runout',
+  1000: 'Auth token invalid',
+  1001: 'Unknown method',
+  1002: 'Cannot open folder',
+  1003: 'Invalid parameter',
+  1004: 'File write failed',
+  1005: 'Token update failed',
+  1006: 'Failed to send update to MCU',
+  1007: 'Cannot delete file',
+  1008: 'Empty response',
+  1009: 'Printer busy',
+  1010: 'Not currently printing',
+  1011: 'File copy failed',
+  1012: 'Task not found',
+  1013: 'Database operation failed',
+  1014: 'Invalid gcode file',
+  1015: 'No thumbnail available',
+  1016: 'Thumbnail parse failed',
+  1017: 'USB drive not detected',
+  1018: 'USB drive removed',
+  1019: 'Timelapse generation failed',
+  1020: 'Timelapse video does not exist',
+  1021: 'File not found',
+  1026: 'No bed mesh data — run auto-levelling first',
+  9999: 'Unknown error',
+};
+
+/**
+ * What happened to a command, as far as the UI needs to care.
+ *
+ * The split that matters is `busy` vs the rest. The printer returns 1009 whenever it
+ * cannot accept a command *right now* — mid-filament-change, during calibration, with
+ * another command in flight — and that is not a failure: the same command will work in
+ * a moment. Showing it as an error trains people to ignore real errors, and showing
+ * nothing at all (which is what happened before ELEG-40) lets them conclude the command
+ * worked.
+ */
+export type CommandOutcome = 'ok' | 'busy' | 'rejected' | 'error';
+
+/** Transient — the identical command is expected to succeed once the printer is free. */
+export const BUSY_ERROR_CODES = new Set([1009]);
+
+/**
+ * The command was understood and refused, and repeating it unchanged will be refused
+ * again until something else changes. Worth telling the user *what* to change, which is
+ * why these are not lumped in with `error`.
+ */
+export const REJECTED_ERROR_CODES = new Set([
+  1001, 1003, 1010, 1012, 1014, 1015, 1017, 1018, 1020, 1021, 1026,
+]);
+
+/**
+ * Classify a response's `error_code`.
+ *
+ * A missing code counts as `ok`: several methods answer with no `error_code` at all on
+ * success, so treating absent as failure would toast an error on every one of them.
+ */
+export function classifyCommandOutcome(code: number | undefined | null): CommandOutcome {
+  if (code === undefined || code === null || code === 0) return 'ok';
+  if (BUSY_ERROR_CODES.has(code)) return 'busy';
+  if (REJECTED_ERROR_CODES.has(code)) return 'rejected';
+  return 'error';
+}
+
+/** Human-readable reason for a non-zero `error_code`, falling back to the number. */
+export function describeCommandError(code: number | undefined | null): string {
+  if (code === undefined || code === null) return 'unknown error';
+  return ERROR_CODE_NAMES[code] ?? `error ${code}`;
+}
+
+/**
+ * Commands whose failure is worth a toast, and what to call them in one.
+ *
+ * Only *writes* are listed. A poll that comes back busy is noise — it will be re-polled
+ * seconds later — whereas a button press that silently did nothing is the whole
+ * complaint behind ELEG-40. Methods handled individually elsewhere (1047 delete, 1051
+ * timelapse export, 2003 filament save) are deliberately absent so they keep their more
+ * specific wording.
+ */
+export const COMMAND_METHOD_NAMES: Record<number, string> = {
+  1007: 'Emergency stop',
+  1020: 'Start print',
+  1021: 'Pause print',
+  1022: 'Stop print',
+  1023: 'Resume print',
+  1024: 'Load filament',
+  1025: 'Unload filament',
+  1026: 'Home',
+  1027: 'Move',
+  1028: 'Set temperature',
+  1029: 'Light switch',
+  1030: 'Fan control',
+  1031: 'Speed mode',
+  1032: 'Auto-level',
+  1033: 'Vibration optimization',
+  1034: 'PID calibration',
+  1035: 'Self-check',
+};
+
 // Exception codes from the CC2 protocol
 export const EXCEPTION_NAMES: Record<number, string> = {
   101: 'Bed Heat Failed',


### PR DESCRIPTION
Closes ELEG-40.

## The bug

A command the printer refused produced **no UI at all**. `guardedSend` in `src/ui/controls.ts` re-enables the button on its own timeout, so the user reasonably concluded the command had worked.

Worse, and concretely: the four calibration handlers in `src/main.ts` toasted `"Auto-level started"` / `"PID calibration started"` / etc. **without ever looking at `error_code`**. A 1032 the printer had refused as busy still read as one under way.

## The codes, verified rather than guessed

The issue asked for the actual codes rather than a guess. They are in `data/CC2_PROTOCOL_REFERENCE.md` §4 (the official app's `hh` enum), and the printer **does** distinguish "busy, try later" from "rejected, will never work as asked":

| Code | Meaning | Class |
| --- | --- | --- |
| 1009 | `PrinterBusy` | **busy** — transient |
| 1001, 1003, 1010, 1012, 1014, 1015, 1017, 1018, 1020, 1021, 1026 | understood and refused | **rejected** |
| everything else non-zero | genuine failure | **error** |

## What changed

`src/types.ts` gains the shared classification — pure, in the shape of `isFilamentChangeSubStatus`:

- `ERROR_CODE_NAMES`, `classifyCommandOutcome`, `describeCommandError`
- `COMMAND_METHOD_NAMES` — **writes only**. A read that comes back busy is re-polled seconds later; toasting it would be noise.

`src/main.ts` reports the outcome generically for every write, guards the calibration and position toasts on success, and folds two ad-hoc error tables (the 1047 one and the 1051/2003 `=== 1009` checks) into the shared one.

## On queue-and-retry — deliberately not done

The issue flagged this as the part to be careful about, and the conclusion is **no automatic retry for writes**. A re-sent `move` that lands thirty seconds later, after the user has given up and put a hand on the bed, is worse than one that visibly did nothing. The user is told the printer was busy and that they can press it again; pressing it stays their decision. Reasoning is recorded in the docstring so it is not "fixed" later by accident.

Busy re-enables the control (so a retry is one click away) and shows a **warning**, not an error.

## Verification

- `pnpm gates` green.
- **Covered by tests**: the classifier and both tables — `src/__tests__/types.test.ts`, 17 tests. The table test derives from `BUSY_ERROR_CODES`/`REJECTED_ERROR_CODES` rather than restating them, so adding a code cannot pass by omission.
- **Proved load-bearing**: flipping `classifyCommandOutcome` to return `error` for 1009 turns the named test red; reverted with an inverse patch.
- **Nothing covers** the toast rendering itself — there is no browser test in this repo. The wiring in `main.ts` was verified by reading.
- **No printer was commanded.** This change only classifies responses; it sends nothing new.