### PR TITLE
fix(ui): show a placeholder for a thumbnail that will not decode (ELEG-42)

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
           <div id="print-status-bar" class="card print-status-card">
             <div class="print-status-top">
               <div id="print-thumbnail-wrap" class="print-thumbnail-wrap">
-                <img id="print-thumbnail" class="print-thumbnail hidden" alt="">
+                <img id="print-thumbnail" class="print-thumbnail thumb-img hidden" alt="">
                 <div id="print-thumbnail-placeholder" class="print-thumbnail-placeholder">🖨️</div>
               </div>
               <div class="print-info">

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ import {
   trackStateChanges,
 } from './ui/dashboard';
 import { renderLog, bindLogControls } from './ui/log';
+import { installThumbnailFallback } from './ui/helpers';
 import type { PrinterStatus, PrinterAttributes, CanvasInfo, FileEntry } from './types';
 import {
   COMMAND_METHOD_NAMES,
@@ -674,6 +675,11 @@ function connectToService(): void {
 $('connect-btn').addEventListener('click', () => {
   connectToService();
 });
+
+// A corrupt or truncated thumbnail otherwise renders as the browser's broken-image
+// icon. One delegated listener covers every thumbnail, including the ones built as
+// HTML strings (ELEG-42).
+installThumbnailFallback();
 
 // Auto-connect on page load
 connectToService();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1608,6 +1608,17 @@ body {
   object-fit: cover;
   border-radius: var(--radius-sm);
 }
+/*
+ * A thumbnail the browser could not decode, swapped for the placeholder by the
+ * delegated handler in ui/helpers.ts (ELEG-42). `contain` rather than the `cover` above
+ * so the placeholder glyph is not cropped, and dimmed so it reads as "no preview" and
+ * not as artwork.
+ */
+.thumb-img-fallback {
+  object-fit: contain;
+  opacity: 0.55;
+  padding: 2px;
+}
 .file-details {
   flex: 1;
   min-width: 0;

--- a/src/ui/files.ts
+++ b/src/ui/files.ts
@@ -1,7 +1,15 @@
 import type { PrinterState } from '../printer-state';
 import type { CommandSender } from '../ws-client';
 import type { FileEntry } from '../types';
-import { $, escapeHtml, escapeAttr, formatTime, applyDarkThumbnailCheck } from './helpers';
+import {
+  $,
+  escapeHtml,
+  escapeAttr,
+  formatTime,
+  applyDarkThumbnailCheck,
+  THUMBNAIL_CLASS,
+  THUMBNAIL_PLACEHOLDER_SRC,
+} from './helpers';
 import { requestPrintDialog } from './print-dialog';
 
 let currentSource: 'local' | 'u-disk' = 'local';
@@ -107,11 +115,16 @@ export function handleInlineThumbnail(base64: string | null): void {
       const fp = currentDir === '/' ? fn : currentDir.replace(/^\//, '') + '/' + fn;
       if (fp !== fullPath) return;
       const iconEl = el.querySelector('.file-icon');
-      if (iconEl && !iconEl.querySelector('img')) {
+      // The guard skips a slot that already holds a *real* thumbnail. The placeholder
+      // is not one, and must be replaced when the genuine preview arrives — treating it
+      // as "already done" would leave every gcode file showing the placeholder forever
+      // (ELEG-42).
+      const existing = iconEl?.querySelector('img');
+      if (iconEl && (!existing || existing.classList.contains('thumb-img-fallback'))) {
         const img = document.createElement('img');
         img.src = `data:image/png;base64,${base64}`;
         img.alt = 'Thumbnail';
-        img.className = 'file-inline-thumb';
+        img.className = `file-inline-thumb ${THUMBNAIL_CLASS}`;
         applyDarkThumbnailCheck(img, iconEl as HTMLElement);
         iconEl.textContent = '';
         iconEl.appendChild(img);
@@ -166,7 +179,7 @@ function showFilePopover(file: FileEntry, anchor: HTMLElement): void {
 
   let html = '<div class="file-popover-inner">';
   if (thumb) {
-    html += `<img class="file-popover-thumb" src="data:image/png;base64,${thumb}" alt="Preview">`;
+    html += `<img class="file-popover-thumb ${THUMBNAIL_CLASS}" src="data:image/png;base64,${thumb}" alt="Preview">`;
   }
   html += '<div class="file-popover-details">';
   html += `<div class="file-popover-name">${escapeHtml(file.filename)}</div>`;
@@ -449,6 +462,7 @@ function showThumbnailPopup(base64: string, anchor: HTMLElement): void {
   const img = document.createElement('img');
   img.src = `data:image/png;base64,${base64}`;
   img.alt = 'Thumbnail';
+  img.className = THUMBNAIL_CLASS;
   popup.appendChild(img);
   applyDarkThumbnailCheck(img, popup);
   document.body.appendChild(popup);
@@ -542,7 +556,13 @@ export function renderFiles(state: PrinterState, client: CommandSender): void {
     if (isFolder) {
       iconHtml = '📁';
     } else if (cachedThumb) {
-      iconHtml = `<img src="data:image/png;base64,${cachedThumb}" alt="Thumb" class="file-inline-thumb">`;
+      iconHtml = `<img src="data:image/png;base64,${cachedThumb}" alt="Thumb" class="file-inline-thumb ${THUMBNAIL_CLASS}">`;
+    } else if (file.filename.toLowerCase().endsWith('.gcode')) {
+      // A gcode file whose thumbnail is queued, absent or unusable. Same placeholder
+      // the error handler swaps in, so "no thumbnail" and "bad thumbnail" look alike
+      // and deliberate rather than one being a mismatched emoji in a grid of previews
+      // (ELEG-42). Replaced in place by handleInlineThumbnail when one arrives.
+      iconHtml = `<img src="${THUMBNAIL_PLACEHOLDER_SRC}" alt="No preview" class="file-inline-thumb thumb-img-fallback">`;
     } else {
       iconHtml = '📄';
     }

--- a/src/ui/helpers.ts
+++ b/src/ui/helpers.ts
@@ -44,9 +44,73 @@ export function escapeAttr(s: string): string {
     .replace(/>/g, '&gt;');
 }
 
+// ─── Thumbnail placeholder ───────────────────────────────────────────
+//
+// Thumbnails arrive from the printer as base64 PNG (method 1045). A truncated or
+// corrupt one used to fall back to the browser's broken-image icon, which reads as
+// "this app is broken" rather than "this one file has no usable preview" (ELEG-42).
+
+/**
+ * Neutral stand-in for a thumbnail that is missing or will not decode.
+ *
+ * Stroke-only on a transparent background deliberately: a data-URI SVG cannot read the
+ * stylesheet's custom properties, so anything with a filled background would have to
+ * hardcode one and would then be wrong in whichever theme it was not picked for.
+ */
+const PLACEHOLDER_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none" ' +
+  'stroke="#8a8a9e" stroke-width="2" stroke-linejoin="round">' +
+  '<rect x="6" y="9" width="36" height="30" rx="3"/>' +
+  '<circle cx="17" cy="20" r="3.5"/>' +
+  '<path d="M9 34l10-9 7 6 5-4 8 7"/></svg>';
+
+export const THUMBNAIL_PLACEHOLDER_SRC = `data:image/svg+xml,${encodeURIComponent(PLACEHOLDER_SVG)}`;
+
+/**
+ * Marks an `<img>` as a printer thumbnail, so the delegated handler below recognises it.
+ * Thumbnails render from several places, some as HTML strings with no element handle at
+ * render time, so a marker class plus one listener beats threading a handler through
+ * each call site — and it covers any thumbnail added later for free.
+ */
+export const THUMBNAIL_CLASS = 'thumb-img';
+
+/** Swap a failed thumbnail for the placeholder. Idempotent. */
+function useThumbnailPlaceholder(img: HTMLImageElement): void {
+  // Without this guard a placeholder that itself failed would re-enter forever.
+  if (img.dataset.thumbFallback === '1') return;
+  img.dataset.thumbFallback = '1';
+  img.src = THUMBNAIL_PLACEHOLDER_SRC;
+  img.classList.add('thumb-img-fallback');
+}
+
+/**
+ * Install the one delegated thumbnail-error handler. Call once, at startup.
+ *
+ * Capture phase is required: `error` on an `<img>` does not bubble, so a listener on
+ * `document` only sees it on the way down.
+ */
+export function installThumbnailFallback(): void {
+  document.addEventListener(
+    'error',
+    (e) => {
+      const el = e.target;
+      if (!(el instanceof HTMLImageElement)) return;
+      if (!el.classList.contains(THUMBNAIL_CLASS)) return;
+      useThumbnailPlaceholder(el);
+    },
+    true,
+  );
+}
+
 /** Analyze thumbnail brightness and toggle a CSS class for dark images */
 export function applyDarkThumbnailCheck(img: HTMLImageElement, container: HTMLElement): void {
   const check = () => {
+    // The placeholder is a stroke-only SVG: sampling it would read as "dark" on its
+    // transparent pixels and dim the container for a file that simply has no preview.
+    if (img.dataset.thumbFallback === '1') {
+      container.classList.remove('thumbnail-dark');
+      return;
+    }
     const canvas = document.createElement('canvas');
     const size = 32;
     canvas.width = size;

--- a/src/ui/print-dialog.ts
+++ b/src/ui/print-dialog.ts
@@ -17,6 +17,7 @@ import {
   formatTime,
   fetchTimeout,
   applyDarkThumbnailCheck,
+  THUMBNAIL_CLASS,
 } from './helpers';
 import { toast } from './toast';
 import { currentFileSource } from './files';
@@ -243,7 +244,7 @@ function showDialog(
           <div class="print-dialog-thumbnail" id="print-dialog-thumb">
             ${
               detail?.thumbnail || state.thumbnail
-                ? `<img src="data:image/png;base64,${detail?.thumbnail || state.thumbnail}" alt="Preview" id="print-dialog-thumb-img">`
+                ? `<img src="data:image/png;base64,${detail?.thumbnail || state.thumbnail}" alt="Preview" id="print-dialog-thumb-img" class="${THUMBNAIL_CLASS}">`
                 : '<div class="print-dialog-no-thumb">No preview</div>'
             }
           </div>


### PR DESCRIPTION
Closes ELEG-42.

## The bug

Thumbnails arrive from the printer as base64 PNG (method 1045). A truncated or corrupt one fell through to the browser's broken-image icon — which reads as *the app* being broken rather than that one file having no usable preview.

## Approach: one delegated listener, not five handlers

`installThumbnailFallback()` in `src/ui/helpers.ts` registers a single `error` listener on `document` and swaps in a placeholder for any `<img>` carrying the `thumb-img` class.

Delegation rather than a handler per call site because **several thumbnails are rendered as HTML strings** with no element handle at render time (`files.ts` popover + file list, `print-dialog.ts`). It also means a thumbnail added later is covered without a second edit.

**Capture phase is required** — `error` on an `<img>` does not bubble, so a listener on `document` only sees it on the way down. Noted in the code, since it looks removable.

Sites marked: file-list inline thumb, popover thumb, hover popup, print dialog, and the print-status card in `index.html`.

## The placeholder

A stroke-only SVG data URI on a transparent background. A data-URI SVG **cannot read the stylesheet's custom properties**, so anything with a filled background would have to hardcode a colour and would then be wrong in whichever theme it was not picked for — ELEG-34 (light theme) is later in this same pass.

## Absent case, unified

The issue asked for "no thumbnail" and "bad thumbnail" to look alike. In the **file list** a gcode file without a thumbnail now gets the same placeholder rather than a 📄 emoji sitting in a grid of real previews.

**Judgement call:** the text placeholders in the print dialog (`No preview`) and the print-status card (`🖨️`) are left alone. They are already explicit, sized differently, and were never the bug — the bug was specifically the broken-image icon, which those paths now also avoid via the marker class.

## Two traps found while wiring it

Both would have shipped as regressions:

1. `handleInlineThumbnail` skipped any slot that already contained an `<img>`. The placeholder *is* one — so without widening that guard, **every gcode file would have kept the placeholder forever** and no real thumbnail would ever have appeared.
2. `applyDarkThumbnailCheck` samples pixel brightness. It would read the placeholder's transparent pixels as "dark" and dim the container for a file that merely has no preview.

## Verification

- `pnpm gates` green.
- **Nothing automated covers this.** There is no browser test in this repo, so neither the swap nor the placeholder's appearance is asserted by anything. The two traps above were found by reading the call sites, not by a failing test.
- Reviewer check on `pnpm dev:web` (opens no printer connection): point an `<img class="thumb-img">` at deliberately truncated base64 and confirm the placeholder appears rather than the broken-image icon; then confirm a *valid* thumbnail still replaces the file-list placeholder when it arrives — that is trap 1.
- **No printer was commanded.**