### PR TITLE
refactor(ui): truncate text in CSS, not in TypeScript (ELEG-43)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,28 @@
 /* Elegoo Web — Modern dark theme */
 
+/*
+ * TRUNCATION RULE (ELEG-43) — truncate in CSS, never in TypeScript.
+ *
+ * Long filenames and labels are shortened with `overflow: hidden` +
+ * `text-overflow: ellipsis` here, and the element carries the full string in a `title`
+ * attribute.
+ *
+ * Slicing the string in TypeScript before rendering is the thing to avoid. It cuts at a
+ * character count with no idea of the rendered width, so it shortens text that would
+ * have fit and leaves text that does not; and it removes the full value from the DOM
+ * entirely, so there is no tooltip and nothing to select or copy. It has already caused
+ * a real bug — a filename cut mid-string across the camera overlay.
+ *
+ * The one place JS slicing is correct is the canvas charts (`layer-chart.ts`,
+ * `charts.ts`, `gcode-preview.ts`), where CSS does not apply and `ctx.measureText` is
+ * the only way to measure.
+ *
+ * One deliberate exception outside canvas: `compactPayload` in `ui/structured-log.ts`
+ * caps a raw MQTT payload at 200 characters. That is a DOM-size guard, not a layout
+ * decision — a megabyte payload across hundreds of log rows is a performance problem no
+ * stylesheet can solve — and the row expands to show the payload in full.
+ */
+
 :root {
   --bg-primary: #0f1117;
   --bg-secondary: #1a1b26;

--- a/src/ui/ai-panel.ts
+++ b/src/ui/ai-panel.ts
@@ -1,6 +1,6 @@
 /** AI Monitor panel — shows live analysis results and alert history */
 
-import { $, escapeHtml } from './helpers';
+import { $, escapeHtml, escapeAttr } from './helpers';
 import { toast } from './toast';
 
 interface AIIssue {
@@ -157,7 +157,7 @@ function renderAlertItem(a: AIAlert): string {
   return `
     <div class="ai-alert-item ai-alert-${a.status}">
       <span>${statusIcon(a.status)}</span>
-      <span class="ai-alert-desc">${escapeHtml(a.description)}</span>
+      <span class="ai-alert-desc" title="${escapeAttr(a.description)}">${escapeHtml(a.description)}</span>
       <span class="ai-alert-issues">${issues}</span>
       <span class="ai-time">${timeAgo(a.timestamp)}</span>
     </div>
@@ -203,7 +203,7 @@ export function renderAIPanel(): void {
             return `<div class="ai-history-row ai-status-${a.status}">
         <span>${statusIcon(a.status)}</span>
         <span class="ai-source">${a.source}</span>
-        <span class="ai-hist-desc">${escapeHtml(a.description.slice(0, 80))}</span>
+        <span class="ai-hist-desc" title="${escapeAttr(a.description)}">${escapeHtml(a.description)}</span>
         <span class="ai-time">${t}</span>
       </div>`;
           })

--- a/src/ui/event-log.ts
+++ b/src/ui/event-log.ts
@@ -157,7 +157,7 @@ export function renderEventLog(): void {
       return `<div class="event-log-row ${meta.cls}">
       <span class="event-log-icon">${meta.icon}</span>
       <span class="event-log-time">${fmtTime(entry.ts)}</span>
-      <span class="event-log-desc">${desc}</span>
+      <span class="event-log-desc" title="${desc}">${desc}</span>
     </div>`;
     })
     .join('');

--- a/src/ui/files.ts
+++ b/src/ui/files.ts
@@ -570,7 +570,7 @@ export function renderFiles(state: PrinterState, client: CommandSender): void {
     html += `
       <div class="file-item ${isFolder ? 'file-item-folder' : ''}" data-filename="${escapeAttr(file.filename)}" data-type="${isFolder ? 'folder' : 'file'}">
         <div class="file-name-row">
-          <span class="file-name">${escapeHtml(file.filename)}</span>${cacheMarker}
+          <span class="file-name" title="${escapeAttr(file.filename)}">${escapeHtml(file.filename)}</span>${cacheMarker}
         </div>
         <div class="file-item-body">
           <div class="file-icon">${iconHtml}</div>

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -481,12 +481,6 @@ interface AILabelConfig {
   group: string;
 }
 
-/** Shorten a CLIP label for display */
-function _shortLabel(label: string): string {
-  if (label.length <= 60) return label;
-  return label.slice(0, 57) + '...';
-}
-
 async function loadAILabels(): Promise<void> {
   const container = $('settings-ai-labels');
   if (!container) return;

--- a/src/ui/structured-log.ts
+++ b/src/ui/structured-log.ts
@@ -166,6 +166,9 @@ function compactPayload(entry: LogEntry): string {
     }
   }
 
+  // The deliberate exception to the CSS-truncation rule (ELEG-43): this is a DOM-size
+  // guard, not a layout decision. A megabyte payload across hundreds of log rows is a
+  // performance problem no stylesheet can solve, and the row expands to show it in full.
   return entry.payload.slice(0, 200);
 }
 

--- a/src/ui/timelapse.ts
+++ b/src/ui/timelapse.ts
@@ -51,7 +51,7 @@ export function renderTimelapse(state: PrinterState): void {
       <div class="file-item timelapse-item" data-filename="${escapeAttr(name)}">
         <div class="file-icon">🎬</div>
         <div class="file-details">
-          <div class="file-name">${escapeHtml(name)}</div>
+          <div class="file-name" title="${escapeAttr(name)}">${escapeHtml(name)}</div>
           <div class="file-size">${meta}${isExported ? ' · ✅ Ready' : ' · ⏳ Needs export'}</div>
         </div>
         ${actionBtn}


### PR DESCRIPTION
Closes ELEG-43.

## The rule, now written down

**CSS truncation everywhere, with the full string in a `title` attribute.** JS slicing is reserved for the canvas charts, where CSS does not apply and `ctx.measureText` is the only way to measure. The rule is now a comment block at the top of `src/styles/main.css` so the next person does not reintroduce it — the issue explicitly asked for that.

## What was actually found

| Site | Was | Now |
| --- | --- | --- |
| `settings.ts` `_shortLabel` | sliced to 57 chars + `'...'` | **deleted — it was dead code**, declared and never called |
| `.ai-hist-desc` | sliced to 80 chars in TS **and** ellipsised by CSS | slice removed; CSS rule was already there |
| `.file-name` (file list, timelapse) | CSS truncation, no tooltip | `title` added |
| `.ai-alert-desc`, `.event-log-desc` | CSS truncation, no tooltip | `title` added |

`.history-filename`, `.report-filename` and `.print-file` already did it correctly and are untouched.

The double-truncation on `.ai-hist-desc` is worth calling out: the stylesheet was already ellipsising an element whose text TypeScript had *already* cut to 80 characters, so the full description was unreachable for no benefit.

## One deliberate exception

`compactPayload` in `ui/structured-log.ts` keeps its `payload.slice(0, 200)`. That is a **DOM-size guard, not a layout decision** — a megabyte MQTT payload across hundreds of log rows is a performance problem no stylesheet can solve, and the row already expands to show the payload in full. Documented in both the code and the CSS rule block so it does not look like an oversight.

## Verification

- `pnpm gates` green.
- **Nothing automated covers this.** It is layout and markup; there is no browser test in the repo. The change is mechanical and was verified by grepping for residual JS truncation of user-facing text (none left outside the documented exception and the canvas charts).
- Reviewer check on `pnpm dev:web`: a deliberately long filename in the file list should ellipsise, and hovering should show the full name.
- **No printer was commanded.**