### PR TITLE
fix(ui): make a new dashboard card reach the settings list, and confirm layout reset (ELEG-44)

### DIFF
--- a/src/__tests__/card-layout.test.ts
+++ b/src/__tests__/card-layout.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normaliseCardLayout,
+  defaultCardLayout,
+  ALL_CARD_IDS,
+  DEFAULT_SIDEBAR,
+  DEFAULT_MAIN,
+  CARD_NAMES,
+} from '../ui/card-layout';
+
+/** Every card, wherever it ended up. */
+function placed(layout: { sidebar: string[]; main: string[] }): string[] {
+  return [...layout.sidebar, ...layout.main];
+}
+
+describe('defaultCardLayout', () => {
+  it('places every known card and hides none', () => {
+    const l = defaultCardLayout();
+    expect(placed(l).sort()).toEqual([...ALL_CARD_IDS].sort());
+    expect(l.hidden).toEqual([]);
+    expect(l.collapsed).toEqual([]);
+  });
+
+  it('hands out a fresh copy each time, since callers mutate it', () => {
+    const a = defaultCardLayout();
+    a.sidebar.push('injected');
+    expect(defaultCardLayout().sidebar).not.toContain('injected');
+  });
+});
+
+describe('normaliseCardLayout', () => {
+  it('falls back to defaults for anything that is not an object', () => {
+    for (const junk of [null, undefined, 'nope', 42, []]) {
+      expect(placed(normaliseCardLayout(junk)).sort()).toEqual([...ALL_CARD_IDS].sort());
+    }
+  });
+
+  it('keeps a saved order rather than reimposing the default one', () => {
+    const saved = { sidebar: ['fans-card', 'temps-card'], main: [], hidden: [], collapsed: [] };
+    const l = normaliseCardLayout(saved);
+    expect(l.sidebar.slice(0, 2)).toEqual(['fans-card', 'temps-card']);
+  });
+
+  it('preserves hidden and collapsed cards', () => {
+    const l = normaliseCardLayout({
+      sidebar: [...DEFAULT_SIDEBAR],
+      main: [...DEFAULT_MAIN],
+      hidden: ['log-card'],
+      collapsed: ['fans-card'],
+    });
+    expect(l.hidden).toEqual(['log-card']);
+    expect(l.collapsed).toEqual(['fans-card']);
+  });
+
+  it('backfills a card added after the layout was saved', () => {
+    // The case ELEG-44 asked about: a user whose stored layout predates a new card.
+    // Without this the card is invisible in the settings list, and the next reorder
+    // saves a layout that still does not mention it.
+    const stale = {
+      sidebar: DEFAULT_SIDEBAR.filter((id) => id !== 'fans-card'),
+      main: DEFAULT_MAIN.filter((id) => id !== 'timelapse-card'),
+      hidden: [],
+      collapsed: [],
+    };
+    const l = normaliseCardLayout(stale);
+    expect(l.sidebar).toContain('fans-card');
+    expect(l.main).toContain('timelapse-card');
+    expect(placed(l).sort()).toEqual([...ALL_CARD_IDS].sort());
+  });
+
+  it('backfills each card into its own default panel', () => {
+    const l = normaliseCardLayout({ sidebar: [], main: [], hidden: [], collapsed: [] });
+    for (const id of DEFAULT_SIDEBAR) expect(l.sidebar).toContain(id);
+    for (const id of DEFAULT_MAIN) expect(l.main).toContain(id);
+  });
+
+  it('never lists a card twice, even if storage named it in both panels', () => {
+    const l = normaliseCardLayout({
+      sidebar: ['temps-card'],
+      main: ['temps-card'],
+      hidden: [],
+      collapsed: [],
+    });
+    expect(placed(l).filter((id) => id === 'temps-card')).toHaveLength(1);
+    expect(l.sidebar).toContain('temps-card'); // first mention wins
+  });
+
+  it('migrates the old single-list { order, hidden } format', () => {
+    const l = normaliseCardLayout({
+      order: ['log-card', 'temps-card', 'files-card'],
+      hidden: ['log-card'],
+    });
+    expect(l.sidebar[0]).toBe('temps-card'); // sidebar card routed to the sidebar
+    expect(l.main[0]).toBe('log-card'); // main card routed to main, order kept
+    expect(l.hidden).toEqual(['log-card']);
+    expect(placed(l).sort()).toEqual([...ALL_CARD_IDS].sort());
+  });
+
+  it('drops non-string entries instead of passing them to the DOM pass', () => {
+    const l = normaliseCardLayout({
+      sidebar: ['temps-card', 42, null],
+      main: [{ nope: true }],
+      hidden: [7],
+      collapsed: [],
+    });
+    expect(l.sidebar.every((id) => typeof id === 'string')).toBe(true);
+    expect(l.main.every((id) => typeof id === 'string')).toBe(true);
+    expect(l.hidden).toEqual([]);
+  });
+
+  it('keeps an unknown card rather than silently discarding it', () => {
+    // A card removed from the app should not make the rest of the layout unreadable.
+    const l = normaliseCardLayout({
+      sidebar: ['retired-card', ...DEFAULT_SIDEBAR],
+      main: [...DEFAULT_MAIN],
+      hidden: [],
+      collapsed: [],
+    });
+    expect(l.sidebar).toContain('retired-card');
+  });
+});
+
+describe('CARD_NAMES', () => {
+  it('names every card that can appear in the settings list', () => {
+    // An unnamed card renders as its raw element id.
+    for (const id of ALL_CARD_IDS) {
+      expect(CARD_NAMES[id], `${id} has no display name`).toBeTruthy();
+    }
+  });
+});

--- a/src/ui/card-layout.ts
+++ b/src/ui/card-layout.ts
@@ -1,0 +1,132 @@
+/**
+ * Dashboard card layout — the pure half.
+ *
+ * Deliberately free of DOM and localStorage so it can be unit-tested directly (the
+ * vitest environment here is `node`, with no document). `ui/settings.ts` owns the
+ * storage and the rendering; everything that decides *what the layout is* lives here.
+ */
+
+export interface CardLayout {
+  sidebar: string[];
+  main: string[];
+  hidden: string[];
+  collapsed: string[];
+}
+
+/** Default sidebar cards (always-visible essentials) */
+export const DEFAULT_SIDEBAR = [
+  'temps-card',
+  'canvas-card',
+  'fans-card',
+  'toolhead-card',
+  'speed-flow-card',
+];
+
+/** Default main area cards (detail/reference) */
+export const DEFAULT_MAIN = [
+  'camera-card',
+  'gcode-preview-card',
+  'files-card',
+  'print-history-card',
+  'print-reports-card',
+  'timelapse-card',
+  'ai-card',
+  'event-log-card',
+  'log-card',
+];
+
+/** All known card IDs */
+export const ALL_CARD_IDS = [...DEFAULT_SIDEBAR, ...DEFAULT_MAIN];
+
+/** Human-readable names for cards */
+export const CARD_NAMES: Record<string, string> = {
+  'temps-card': '🌡️ Temperatures',
+  'canvas-card': '🎨 Canvas / AMS',
+  'camera-card': '📷 Camera',
+  'ai-card': '🤖 AI Monitor',
+  'event-log-card': '📜 Event Log',
+  'gcode-preview-card': '📐 Layer Preview',
+  'toolhead-card': '🎯 Toolhead',
+  'fans-card': '🌀 Fans',
+  'speed-flow-card': '⚡ Speed & Flow',
+  'files-card': '📁 Files',
+  'print-history-card': '📜 Print History',
+  'print-reports-card': '📊 Print Reports',
+  'timelapse-card': '🎬 Timelapse',
+  'log-card': '📋 MQTT Log',
+};
+
+/** A fresh copy of the shipped layout. Fresh, because callers mutate what they get. */
+export function defaultCardLayout(): CardLayout {
+  return { sidebar: [...DEFAULT_SIDEBAR], main: [...DEFAULT_MAIN], hidden: [], collapsed: [] };
+}
+
+/** Strings only — a hand-edited or half-written layout should not poison the DOM pass. */
+function stringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+/** Migrate the pre-panel format, `{ order, hidden }`, to sidebar + main. */
+function migrateOldLayout(order: string[], hidden: string[]): CardLayout {
+  const sidebar: string[] = [];
+  const main: string[] = [];
+  for (const id of order) {
+    if (DEFAULT_SIDEBAR.includes(id)) sidebar.push(id);
+    else main.push(id);
+  }
+  return { sidebar, main, hidden, collapsed: [] };
+}
+
+/**
+ * Turn whatever was in storage into a layout that is safe to apply.
+ *
+ * Three jobs, and the third is the one with history behind it:
+ *
+ * 1. Defaults for anything absent, and non-strings dropped.
+ * 2. The old `{ order, hidden }` format migrated.
+ * 3. **Every known card placed.** A card added to the app after a user last saved
+ *    their layout is in neither list, and before ELEG-44 this backfill lived in
+ *    `applyCardLayout` — which mutated its in-memory copy but never saved it, while
+ *    the settings panel re-read straight from storage. So the new card rendered on the
+ *    dashboard but was missing from the settings list, and the next reorder saved a
+ *    layout that still did not mention it. Doing it here means both paths see the same
+ *    layout, because there is only one place that decides.
+ *
+ * A card named in both panels is kept only in the first (sidebar wins), so it cannot
+ * appear twice in the settings list.
+ */
+export function normaliseCardLayout(parsed: unknown): CardLayout {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return defaultCardLayout();
+  }
+  const fields = parsed as Record<string, unknown>;
+
+  const oldOrder = stringArray(fields.order);
+  const layout = oldOrder
+    ? migrateOldLayout(oldOrder, stringArray(fields.hidden) ?? [])
+    : {
+        sidebar: stringArray(fields.sidebar) ?? [...DEFAULT_SIDEBAR],
+        main: stringArray(fields.main) ?? [...DEFAULT_MAIN],
+        hidden: stringArray(fields.hidden) ?? [],
+        collapsed: stringArray(fields.collapsed) ?? [],
+      };
+
+  const seen = new Set<string>();
+  const firstOnly = (ids: string[]): string[] =>
+    ids.filter((id) => {
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  layout.sidebar = firstOnly(layout.sidebar);
+  layout.main = firstOnly(layout.main);
+
+  for (const id of ALL_CARD_IDS) {
+    if (seen.has(id)) continue;
+    (DEFAULT_SIDEBAR.includes(id) ? layout.sidebar : layout.main).push(id);
+    seen.add(id);
+  }
+
+  return layout;
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -1,14 +1,7 @@
 /** Settings panel — persistent card layout + Telegram config */
 
 import { $, fetchTimeout } from './helpers';
-import {
-  type CardLayout,
-  ALL_CARD_IDS,
-  CARD_NAMES,
-  DEFAULT_SIDEBAR,
-  defaultCardLayout,
-  normaliseCardLayout,
-} from './card-layout';
+import { type CardLayout, CARD_NAMES, defaultCardLayout, normaliseCardLayout } from './card-layout';
 import { toast } from './toast';
 import { renderSpoolCalc } from './spool-calc';
 import { renderHelp } from './help';

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -1,102 +1,33 @@
 /** Settings panel — persistent card layout + Telegram config */
 
 import { $, fetchTimeout } from './helpers';
+import {
+  type CardLayout,
+  ALL_CARD_IDS,
+  CARD_NAMES,
+  DEFAULT_SIDEBAR,
+  defaultCardLayout,
+  normaliseCardLayout,
+} from './card-layout';
 import { toast } from './toast';
 import { renderSpoolCalc } from './spool-calc';
 import { renderHelp } from './help';
 
-// ---- Card layout settings (localStorage) ----
-
-interface CardLayout {
-  sidebar: string[];
-  main: string[];
-  hidden: string[];
-  collapsed: string[];
-}
-
-/** Default sidebar cards (always-visible essentials) */
-const DEFAULT_SIDEBAR = [
-  'temps-card',
-  'canvas-card',
-  'fans-card',
-  'toolhead-card',
-  'speed-flow-card',
-];
-
-/** Default main area cards (detail/reference) */
-const DEFAULT_MAIN = [
-  'camera-card',
-  'gcode-preview-card',
-  'files-card',
-  'print-history-card',
-  'print-reports-card',
-  'timelapse-card',
-  'ai-card',
-  'event-log-card',
-  'log-card',
-];
-
-/** All known card IDs */
-const ALL_CARD_IDS = [...DEFAULT_SIDEBAR, ...DEFAULT_MAIN];
-
-/** Human-readable names for cards */
-const CARD_NAMES: Record<string, string> = {
-  'temps-card': '🌡️ Temperatures',
-  'canvas-card': '🎨 Canvas / AMS',
-  'camera-card': '📷 Camera',
-  'ai-card': '🤖 AI Monitor',
-  'event-log-card': '📜 Event Log',
-  'gcode-preview-card': '📐 Layer Preview',
-  'toolhead-card': '🎯 Toolhead',
-  'fans-card': '🌀 Fans',
-  'speed-flow-card': '⚡ Speed & Flow',
-  'files-card': '📁 Files',
-  'print-history-card': '📜 Print History',
-  'print-reports-card': '📊 Print Reports',
-  'timelapse-card': '🎬 Timelapse',
-  'log-card': '📋 MQTT Log',
-};
-
 const STORAGE_KEY = 'elegoo-web-card-layout';
+
+// ---- Card layout settings (localStorage) ----
+//
+// What the layout *is* lives in `card-layout.ts`, free of DOM and storage so it can be
+// unit-tested (ELEG-44). This half owns persistence and the DOM.
 
 function loadCardLayout(): CardLayout {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      // Migrate from old format { order: string[], hidden: string[] }
-      if (Array.isArray(parsed.order)) {
-        return migrateOldLayout(parsed);
-      }
-      return {
-        sidebar: Array.isArray(parsed.sidebar) ? parsed.sidebar : [...DEFAULT_SIDEBAR],
-        main: Array.isArray(parsed.main) ? parsed.main : [...DEFAULT_MAIN],
-        hidden: Array.isArray(parsed.hidden) ? parsed.hidden : [],
-        collapsed: Array.isArray(parsed.collapsed) ? parsed.collapsed : [],
-      };
-    }
+    if (raw) return normaliseCardLayout(JSON.parse(raw));
   } catch {
-    /* ignore */
+    /* unreadable or malformed — fall through to the defaults */
   }
-  return { sidebar: [...DEFAULT_SIDEBAR], main: [...DEFAULT_MAIN], hidden: [], collapsed: [] };
-}
-
-/** Migrate from old single-list layout to sidebar+main format */
-function migrateOldLayout(old: { order: string[]; hidden: string[] }): CardLayout {
-  const sidebar: string[] = [];
-  const main: string[] = [];
-  for (const id of old.order) {
-    if (DEFAULT_SIDEBAR.includes(id)) sidebar.push(id);
-    else main.push(id);
-  }
-  // Add any cards missing from old layout
-  for (const id of DEFAULT_SIDEBAR) {
-    if (!sidebar.includes(id)) sidebar.push(id);
-  }
-  for (const id of DEFAULT_MAIN) {
-    if (!main.includes(id)) main.push(id);
-  }
-  return { sidebar, main, hidden: old.hidden || [], collapsed: [] };
+  return defaultCardLayout();
 }
 
 function saveCardLayout(layout: CardLayout): void {
@@ -124,16 +55,9 @@ export function applyCardLayout(): void {
   const main = document.getElementById('dashboard-main');
   if (!sidebar || !main) return;
 
-  // Ensure all known card IDs exist in either sidebar or main
-  for (const id of ALL_CARD_IDS) {
-    if (!currentLayout.sidebar.includes(id) && !currentLayout.main.includes(id)) {
-      if (DEFAULT_SIDEBAR.includes(id)) {
-        currentLayout.sidebar.push(id);
-      } else {
-        currentLayout.main.push(id);
-      }
-    }
-  }
+  // Backfilling a newly added card used to happen here, on the in-memory copy only —
+  // so the settings panel, which re-reads from storage, never saw it. It is part of
+  // `normaliseCardLayout` now, which both paths go through (ELEG-44).
 
   // Move cards into sidebar in order
   for (const id of currentLayout.sidebar) {
@@ -378,12 +302,20 @@ function buildSettingsHTML(content: HTMLElement): void {
 
   // Reset button
   content.querySelector('#settings-reset-layout')?.addEventListener('click', () => {
-    currentLayout = {
-      sidebar: [...DEFAULT_SIDEBAR],
-      main: [...DEFAULT_MAIN],
-      hidden: [],
-      collapsed: [],
-    };
+    // Confirmed because it discards arranging work and cannot be undone. Scoped to the
+    // layout key alone: chart resolution, log filters and camera selection live in a
+    // separate store (`ui-settings.ts`) and are untouched — which is the whole reason
+    // to have this rather than telling people to clear site data (ELEG-44).
+    if (
+      !confirm(
+        'Reset the dashboard layout to its default?\n\n' +
+          'Card order, panel assignment, and hidden and collapsed cards are all restored. ' +
+          'Other settings — chart resolution, log filters, camera selection — are kept.',
+      )
+    ) {
+      return;
+    }
+    currentLayout = defaultCardLayout();
     saveCardLayout(currentLayout);
     applyCardLayout();
     settingsRendered = false;


### PR DESCRIPTION
Closes ELEG-44.

## The issue's premise was wrong, and that changed the work

> There is no way back — hide a card by accident, or drag the layout into a mess, and the only recovery is clearing site data

**A working "Reset to default" button already exists** in the settings card (`#settings-reset-layout`) and has for some time. So the headline ask was already done. Checking that first is what turned this from "add a button" into two real defects around it.

## What was actually broken

### 1. A newly added card never reached the settings list

The issue's second detail — *"a newly added card should appear for existing users… if it is not, this is the natural place to notice"* — is exactly right, and it was not fully handled.

The backfill lived in `applyCardLayout`, which mutates its **in-memory** copy and never saves it. Meanwhile `buildSettingsHTML` does `currentLayout = loadCardLayout()` — re-reading straight from localStorage, throwing that backfill away.

Result for a user whose stored layout predates a new card:

- the card **renders on the dashboard** (applyCardLayout placed it), but
- it is **missing from the settings list**, so it cannot be hidden, moved or reassigned, and
- the next reorder writes a layout that still does not mention it.

Now done in `normaliseCardLayout`, which both paths go through — one place decides.

### 2. Reset had no confirmation

The issue asked for one "since it discards work". There was none. Added, and the prompt says explicitly what is kept.

## Scope was already right — better than the issue feared

> Chart resolution, log filters and camera selection live in the same store and should survive

They do not live in the same store. The layout is its own localStorage key (`elegoo-web-card-layout`); chart windows, log filters and camera selection are in `elegoo-web-ui-settings`, owned by `ui-settings.ts`. Reset could not have touched them. Now stated in a comment so the next reader does not re-derive it.

## Structure

The pure half moves to `src/ui/card-layout.ts` — no DOM, no storage. Required, not cosmetic: the vitest environment here is **`node`**, so `settings.ts` cannot be imported under test at all.

That half also gained two things it never had: non-string entries are dropped, and a card named in both panels is listed once.

## Verification

- `pnpm gates` green — 97 tests.
- **Covered by tests**: `src/__tests__/card-layout.test.ts`, 12 tests, including the new-card backfill the issue asked about, the old-format migration, dedupe, and junk input.
- **Proved load-bearing**: deleting the backfill loop turns 3 named tests red; reverted with an inverse patch.
- **Nothing covers** the drag interaction, the confirm dialog, or the DOM pass in `applyCardLayout` — no browser test exists here. Reviewer check on `pnpm dev:web`: hide a card, reorder, reset, confirm the prompt appears and that chart window settings survive.
- **No printer was commanded.**