### PR TITLE
fix(server): stop the compat layers advertising authentication they never check (ELEG-26)

### DIFF
--- a/src/server/__tests__/compat-auth.test.ts
+++ b/src/server/__tests__/compat-auth.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  octoprintApiSettings,
+  octoprintLoginPayload,
+  NO_API_KEY_MESSAGE,
+  MOONRAKER_NO_API_KEY_CODE,
+} from '../compat-auth.js';
+
+/**
+ * The compat layers are pure state→JSON translation, and a client breaks silently when
+ * a field's shape drifts. These assert the emitted shape directly — no printer, no
+ * network — which is what ELEG-26 asked for.
+ */
+
+describe('octoprintApiSettings', () => {
+  it('reports API-key auth as disabled', () => {
+    expect(octoprintApiSettings()).toEqual({ enabled: false, key: null });
+  });
+
+  it('never emits a key', () => {
+    // The regression this exists to catch: a fixed string that made clients show
+    // themselves as authenticated against a service that checks nothing.
+    expect(octoprintApiSettings().key).toBeNull();
+  });
+});
+
+describe('octoprintLoginPayload', () => {
+  const payload = octoprintLoginPayload();
+
+  it('carries no apikey field at all', () => {
+    expect('apikey' in payload).toBe(false);
+  });
+
+  it('claims no login mechanism', () => {
+    expect(payload._login_mechanism).toBeNull();
+  });
+
+  it('still reports full control, because that is true', () => {
+    // With no authentication every caller does have admin capability. Understating it
+    // would be its own dishonesty — the exposure is the point of ELEG-2.
+    expect(payload.admin).toBe(true);
+    expect(payload.user).toBe(true);
+    expect(payload.active).toBe(true);
+  });
+
+  it('keeps the fields OctoPrint clients read, so the shape stays usable', () => {
+    for (const key of ['name', 'groups', 'roles', 'permissions', 'needs']) {
+      expect(payload, `missing ${key}`).toHaveProperty(key);
+    }
+  });
+
+  it('mentions no credential anywhere in the serialised body', () => {
+    // Belt and braces: catches a credential reintroduced under a different field name.
+    expect(JSON.stringify(payload)).not.toMatch(/elegoo-cc2-compat|apikey|api_key/i);
+  });
+});
+
+describe('the no-API-key answer', () => {
+  it('explains itself rather than returning an empty string', () => {
+    expect(NO_API_KEY_MESSAGE).toMatch(/no authentication/i);
+    expect(NO_API_KEY_MESSAGE.length).toBeGreaterThan(20);
+  });
+
+  it('uses a JSON-RPC error code, not a success code', () => {
+    expect(MOONRAKER_NO_API_KEY_CODE).toBeLessThan(0);
+  });
+});

--- a/src/server/compat-auth.ts
+++ b/src/server/compat-auth.ts
@@ -1,0 +1,61 @@
+/**
+ * What the compat layers say about authentication — which is that there isn't any.
+ *
+ * Both layers used to answer credential requests with a plausible fixed string:
+ * OctoPrint returned `apikey: 'elegoo-cc2-compat'`, Moonraker answered
+ * `access.get_api_key` with `'elegoo-compat-api-key'`. Nothing was ever checked against
+ * either. A client that asked got an answer and displayed itself as **authenticated**,
+ * and anyone auditing the code could find the handling and conclude an auth path
+ * existed. ELEG-2's description had to carry a warning not to read these as evidence —
+ * that warning was only necessary because the code lied (ELEG-26).
+ *
+ * This service has no authentication at all. See `.agents/security.md`.
+ *
+ * Kept in its own module, free of dependencies, so both layers say the same thing and
+ * the shapes can be asserted directly — the compat layers are pure state→JSON
+ * translation, which `.agents/testing.md` names as the high-value test target, and a
+ * client breaks silently when a field's shape drifts.
+ */
+
+/** Returned in place of a fabricated key. Phrased for a human reading a client's error. */
+export const NO_API_KEY_MESSAGE =
+  'This service has no authentication and issues no API key. ' +
+  'Access is controlled by the network it is reachable from.';
+
+/** Moonraker's JSON-RPC error code for an unavailable method. */
+export const MOONRAKER_NO_API_KEY_CODE = -32601;
+
+/**
+ * OctoPrint's `api` block in `GET /api/settings`.
+ *
+ * `enabled: false` is the honest statement, and it is a statement OctoPrint clients
+ * already understand: it means this server does not do API-key authentication. The old
+ * `enabled: true` plus a fixed key claimed the opposite.
+ */
+export function octoprintApiSettings(): { enabled: false; key: null } {
+  return { enabled: false, key: null };
+}
+
+/**
+ * OctoPrint's `POST /api/login` body.
+ *
+ * `admin`/`user` stay true, and that is not a lie: with no authentication every caller
+ * genuinely does have full control of this service — that is precisely the exposure
+ * ELEG-2 is about, and understating it would be its own kind of dishonesty. What goes
+ * is the claim about *how* the caller got that access: there is no api key and no login
+ * mechanism, so `apikey` is dropped and `_login_mechanism` is null.
+ */
+export function octoprintLoginPayload(): Record<string, unknown> {
+  return {
+    _is_external_client: false,
+    _login_mechanism: null,
+    active: true,
+    admin: true,
+    groups: ['admins', 'users'],
+    name: 'elegoo',
+    needs: { group: ['admins'], role: [] },
+    permissions: [],
+    roles: ['admin', 'user'],
+    user: true,
+  };
+}

--- a/src/server/moonraker-server.ts
+++ b/src/server/moonraker-server.ts
@@ -40,6 +40,7 @@ import type { StateStore } from './state-store.js';
 import type { MqttBridge } from './mqtt-bridge.js';
 import type { ServiceConfig } from './config.js';
 import { applyCors, corsHeaders } from './cors.js';
+import { NO_API_KEY_MESSAGE, MOONRAKER_NO_API_KEY_CODE } from './compat-auth.js';
 import type { FanInfo } from '../types.js';
 import { MOONRAKER_VERSION, AVAILABLE_OBJECTS, queryObjects } from './moonraker-compat.js';
 import { createOctoPrintRouter } from './octoprint-compat.js';
@@ -1060,7 +1061,11 @@ export class MoonrakerServer {
 
       case 'access.get_api_key':
       case 'access.post_api_key':
-        client.ws.send(rpcResult(msg.id, 'elegoo-compat-api-key'));
+        // No key is issued, so none is returned. Answering with a fixed string made
+        // clients display themselves as authenticated against a service that checks
+        // nothing (ELEG-26). `access.info` below reports login_required: false, which
+        // is how a client is supposed to learn that no credential is needed.
+        client.ws.send(rpcError(msg.id, MOONRAKER_NO_API_KEY_CODE, NO_API_KEY_MESSAGE));
         break;
 
       case 'access.info':
@@ -1640,9 +1645,15 @@ export class MoonrakerServer {
 
     // --- GET /access/info ---
     if (urlPath === '/access/info' && method === 'GET') {
+      // `login_required` and `trusted` were on the JSON-RPC `access.info` but missing
+      // here, so an HTTP-only client was never told that no credential is needed — and
+      // now that the api_key endpoint no longer hands out a fake one, this is where it
+      // has to learn it (ELEG-26).
       jsonResult(res, {
         default_source: 'moonraker',
         available_sources: ['moonraker'],
+        login_required: false,
+        trusted: true,
       });
       return;
     }
@@ -1902,9 +1913,9 @@ export class MoonrakerServer {
       return;
     }
 
-    // GET/POST /access/api_key
+    // GET/POST /access/api_key — see the JSON-RPC case above (ELEG-26).
     if (urlPath === '/access/api_key' && (method === 'GET' || method === 'POST')) {
-      jsonResult(res, 'elegoo-compat-api-key');
+      jsonError(res, NO_API_KEY_MESSAGE, 404);
       return;
     }
 

--- a/src/server/octoprint-compat.ts
+++ b/src/server/octoprint-compat.ts
@@ -16,6 +16,7 @@ import type { MqttBridge } from './mqtt-bridge.js';
 import type { ServiceConfig } from './config.js';
 import type { FanInfo } from '../types.js';
 import { getLogger } from './logger.js';
+import { octoprintApiSettings, octoprintLoginPayload } from './compat-auth.js';
 
 const _log = getLogger('OctoPrint');
 
@@ -363,7 +364,7 @@ export function createOctoPrintRouter(
     // --- GET /api/settings (minimal stub) ---
     if (path === '/api/settings' && method === 'GET') {
       json(res, {
-        api: { enabled: true, key: 'elegoo-cc2-compat' },
+        api: octoprintApiSettings(),
         feature: {
           sdSupport: true,
           temperatureGraph: true,
@@ -426,19 +427,7 @@ export function createOctoPrintRouter(
 
     // --- GET /api/login (stub, always "logged in") ---
     if (path === '/api/login' && method === 'POST') {
-      json(res, {
-        _is_external_client: false,
-        _login_mechanism: 'apikey',
-        active: true,
-        admin: true,
-        apikey: 'elegoo-cc2-compat',
-        groups: ['admins', 'users'],
-        name: 'elegoo',
-        needs: { group: ['admins'], role: [] },
-        permissions: [],
-        roles: ['admin', 'user'],
-        user: true,
-      });
+      json(res, octoprintLoginPayload());
       return true;
     }
 


### PR DESCRIPTION
Closes ELEG-26. Child of ELEG-2, and independent of ELEG-25's decision.

Takes **option 1** — stop advertising it — which the issue named as the honest change and the one to cost first.

## What was wrong

OctoPrint returned `apikey: 'elegoo-cc2-compat'`; Moonraker answered `access.get_api_key` with `'elegoo-compat-api-key'`. **Nothing was ever checked against either.** A client that asked got a plausible answer and showed itself as authenticated, and a reader of the code could find the handling and conclude an auth path existed. ELEG-2's description had to carry an explicit warning not to read these as evidence — that warning was only necessary because the code lied.

## Changes

| Surface | Was | Now |
| --- | --- | --- |
| OctoPrint `GET /api/settings` | `api: { enabled: true, key: 'elegoo-cc2-compat' }` | `api: { enabled: false, key: null }` |
| OctoPrint `POST /api/login` | `apikey: '…'`, `_login_mechanism: 'apikey'` | field removed, mechanism `null` |
| Moonraker `access.get_api_key` / `post_api_key` | fixed string | JSON-RPC error, `-32601`, explaining there is none |
| Moonraker `GET|POST /access/api_key` | fixed string | 404 with the same explanation |
| Moonraker `GET /access/info` | omitted `login_required` | `login_required: false, trusted: true` |

**`admin`/`user` deliberately stay `true` on the login payload.** That is not the lie — with no authentication every caller genuinely does have full control of this service, which is precisely the exposure ELEG-2 is about. Understating it would be its own kind of dishonesty. What goes is the claim about *how* the caller got that access.

## The `/access/info` fix was not in the issue, and it matters

`login_required: false` is how a Moonraker client is supposed to learn no credential is needed. It was present on the **JSON-RPC** `access.info` but **missing from the HTTP** one. Now that the api_key endpoint no longer hands out a fake key, an HTTP-only client needs that field to know the difference between "no auth" and "auth is broken". Made consistent across both transports.

## Deliberately out of scope, filed as ELEG-53

The same file fabricates JWTs (`access.login`, `access.refresh_jwt`, `access.post_user`) and a `oneshot_token`. Same defect — but `oneshot_token` exists so a browser can open a WebSocket where no header can be set, and a client may fetch one *before* reading `access.info`. Withdrawing it could break the WebSocket outright, which would be a regression rather than a security improvement. That needs facts from a real client first, so it is **ELEG-53**, not a quiet omission.

## Verification

- `pnpm gates` green — 106 tests.
- **Covered by tests**: `src/server/__tests__/compat-auth.test.ts` — the **first test of either compat layer**. Asserts the emitted shapes directly, no printer and no network, which is what the issue asked for. Includes a serialised-body check that catches a credential reintroduced under a different field name.
- **Nothing covers** the routing itself — that these builders are wired to the right paths was verified by reading, and neither compat layer has any other test.
- **Not verified against a real client.** The issue notes some clients may refuse to connect without a key; that is a human with Mainsail open, not a gate, and it is worth doing before this is relied on.
- **No printer was commanded.**