### PR TITLE
feat(ui): prompt to resume or cancel after a power loss (ELEG-29)

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -8,6 +8,7 @@ import {
   ERROR_CODE_NAMES,
   BUSY_ERROR_CODES,
   REJECTED_ERROR_CODES,
+  powerLossState,
 } from '../types';
 
 describe('detectZone', () => {
@@ -114,5 +115,35 @@ describe('command tables', () => {
     }
     expect(COMMAND_METHOD_NAMES[1027]).toBe('Move');
     expect(COMMAND_METHOD_NAMES[1032]).toBe('Auto-level');
+  });
+});
+
+describe('powerLossState', () => {
+  it('reports none for any status that is not 15', () => {
+    for (const status of [0, 1, 2, 14, undefined, null]) {
+      expect(powerLossState(status, 0)).toBe('none');
+    }
+  });
+
+  it('reports awaiting_decision for a bare status 15', () => {
+    // The printer is sitting on a half-finished job with nobody having told it what to
+    // do. This is the state that must prompt.
+    expect(powerLossState(15, 0)).toBe('awaiting_decision');
+    expect(powerLossState(15, undefined)).toBe('awaiting_decision');
+  });
+
+  it('reports resuming once 2405 arrives, so it stops prompting', () => {
+    // Prompting again here would invite a second resume on a print already recovering.
+    expect(powerLossState(15, 2405)).toBe('resuming');
+  });
+
+  it('reports resumed on 2406', () => {
+    expect(powerLossState(15, 2406)).toBe('resumed');
+  });
+
+  it('does not confuse a normal resume sub-status with a power-loss one', () => {
+    // 2401/2402 are an ordinary resume and never accompany status 15.
+    expect(powerLossState(2, 2401)).toBe('none');
+    expect(powerLossState(15, 2401)).toBe('awaiting_decision');
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,35 @@ export function isFilamentChangeSubStatus(subStatus: number): boolean {
   return false;
 }
 
+// ─── Power loss recovery ─────────────────────────────────────────────
+
+/** Machine status the CC2 reports after a power loss with a print in progress. */
+export const STATUS_POWER_LOSS_RECOVERY = 15;
+
+/** Sub-statuses the printer moves through once a recovery has been started. */
+const SUB_POWER_LOSS_RESUMING = 2405;
+const SUB_POWER_LOSS_RESUMED = 2406;
+
+/**
+ * Where a power-loss recovery has got to.
+ *
+ * The distinction that matters is `awaiting_decision` versus the rest. Status 15 alone
+ * means the printer is sitting on a half-finished job with nobody having told it what
+ * to do; once 2405 arrives the decision has been made and prompting again would invite
+ * a second resume on a print already resuming.
+ */
+export type PowerLossState = 'none' | 'awaiting_decision' | 'resuming' | 'resumed';
+
+export function powerLossState(
+  status: number | undefined | null,
+  subStatus: number | undefined | null,
+): PowerLossState {
+  if (status !== STATUS_POWER_LOSS_RECOVERY) return 'none';
+  if (subStatus === SUB_POWER_LOSS_RESUMING) return 'resuming';
+  if (subStatus === SUB_POWER_LOSS_RESUMED) return 'resumed';
+  return 'awaiting_decision';
+}
+
 // ─── Command result codes (`error_code` on a method response) ────────
 //
 // Distinct from EXCEPTION_NAMES below: an *exception* is a hardware fault the printer

--- a/src/ui/power-loss-dialog.ts
+++ b/src/ui/power-loss-dialog.ts
@@ -1,0 +1,110 @@
+/**
+ * Power-loss recovery prompt (ELEG-29).
+ *
+ * The CC2 reports machine status 15 after power is restored with a print in progress.
+ * It then sits there waiting to be told whether to carry on or give up, and the web app
+ * is the thing people have open — so this is the one place where *not* having UI has a
+ * real cost.
+ *
+ * ## The methods, and how far they are verified
+ *
+ * Resume is **1023 (ResumePrint)** and cancel is **1022 (CancelPrint)** — the same
+ * methods as a normal resume and stop, both taking no parameters. The issue asked for
+ * that assumption to be checked rather than believed. It was, against both protocol
+ * sources in `data/`:
+ *
+ * - `CC2_PROTOCOL_REFERENCE.md` — the full method table has no power-loss-specific
+ *   method; state 15 is `PowerOffResume` and 2405/2406 are its sub-statuses.
+ * - `CC2-OFFICIAL-APP-PATTERNS.md` — same, independently transcribed from the app.
+ *
+ * So the assumption is *supported* by everything available. It is **not confirmed
+ * against a live recovery**, because triggering one means cutting power mid-print,
+ * which nobody should do to find out. See the OPERATOR issue linked from ELEG-29.
+ *
+ * ## The boundary
+ *
+ * Both buttons command the printer. Neither was ever fired to test this, per AGENTS.md.
+ */
+
+import type { CommandSender } from '../ws-client';
+import type { PowerLossState } from '../types';
+import { escapeHtml } from './helpers';
+
+/**
+ * Only prompt once per recovery. Without this, the dialog would be rebuilt on every
+ * status frame — roughly once a second — and a click could never land.
+ */
+let promptedForRecovery = false;
+
+/** Reset when the printer leaves the recovery state, so a later power loss prompts again. */
+function resetIfClear(state: PowerLossState): void {
+  if (state === 'none') promptedForRecovery = false;
+}
+
+/** Show the prompt if a recovery is waiting on a decision, and has not been prompted. */
+export function maybeShowPowerLossDialog(
+  state: PowerLossState,
+  filename: string | undefined,
+  client: CommandSender,
+): void {
+  resetIfClear(state);
+  // 'resuming' and 'resumed' mean the decision is already made; prompting again would
+  // invite a second resume on a print that is already recovering.
+  if (state !== 'awaiting_decision') return;
+  if (promptedForRecovery) return;
+  if (document.getElementById('power-loss-overlay')) return;
+  promptedForRecovery = true;
+  showPowerLossDialog(filename, client);
+}
+
+function close(): void {
+  document.getElementById('power-loss-overlay')?.remove();
+}
+
+function showPowerLossDialog(filename: string | undefined, client: CommandSender): void {
+  const overlay = document.createElement('div');
+  overlay.id = 'power-loss-overlay';
+  overlay.className = 'print-dialog-overlay';
+
+  const fileLine = filename
+    ? `<div class="print-dialog-filename" title="${escapeHtml(filename)}">${escapeHtml(filename)}</div>`
+    : '';
+
+  overlay.innerHTML = `
+    <div class="print-dialog">
+      <div class="print-dialog-header">
+        <span>⚡ Power loss detected</span>
+      </div>
+      <div class="print-dialog-body">
+        <p>The printer lost power during a print and is waiting for a decision.</p>
+        ${fileLine}
+        <p class="settings-hint">
+          Check the model and the bed before resuming — a print that shifted or came
+          loose while the power was off will not recover, and resuming will print into
+          the air. Cancelling cannot be undone.
+        </p>
+      </div>
+      <div class="print-dialog-footer">
+        <button class="btn btn-ghost" id="power-loss-dismiss">Decide later</button>
+        <button class="btn btn-danger" id="power-loss-cancel">Cancel print</button>
+        <button class="btn btn-primary" id="power-loss-resume">Resume print</button>
+      </div>
+    </div>`;
+
+  document.body.appendChild(overlay);
+
+  overlay.querySelector('#power-loss-dismiss')?.addEventListener('click', close);
+
+  overlay.querySelector('#power-loss-resume')?.addEventListener('click', () => {
+    close();
+    client.sendCommand(1023, {});
+  });
+
+  overlay.querySelector('#power-loss-cancel')?.addEventListener('click', () => {
+    // Confirmed separately: this abandons a job that may be most of the way done, and
+    // the printer cannot be asked to undo it.
+    if (!confirm('Cancel the interrupted print?\n\nThis cannot be undone.')) return;
+    close();
+    client.sendCommand(1022, {});
+  });
+}

--- a/src/ui/print-status.ts
+++ b/src/ui/print-status.ts
@@ -1,6 +1,13 @@
 import type { PrinterState } from '../printer-state';
 import type { CommandSender } from '../ws-client';
-import { STATUS_NAMES, SUB_STATUS_NAMES, EXCEPTION_NAMES, CRITICAL_EXCEPTIONS } from '../types';
+import {
+  STATUS_NAMES,
+  SUB_STATUS_NAMES,
+  EXCEPTION_NAMES,
+  CRITICAL_EXCEPTIONS,
+  powerLossState,
+} from '../types';
+import { maybeShowPowerLossDialog } from './power-loss-dialog';
 import { $, formatTime, formatClock, fanPct, escapeHtml, applyDarkThumbnailCheck } from './helpers';
 import { loadUISettings, saveUISettings } from './ui-settings';
 
@@ -142,6 +149,10 @@ export function renderDashboard(state: PrinterState, client: CommandSender): voi
   const isPaused = machineStatus?.sub_status === 2502 || machineStatus?.sub_status === 2505;
   const statusName = STATUS_NAMES[machineStatus?.status] ?? 'Unknown';
   const subStatusName = SUB_STATUS_NAMES[machineStatus?.sub_status] ?? '';
+  const powerLoss = powerLossState(machineStatus?.status, machineStatus?.sub_status);
+
+  // A half-finished print is waiting on a human, and this is the thing they have open.
+  maybeShowPowerLossDialog(powerLoss, ps?.filename, client);
 
   // Thumbnail — request once per file, don't retry on failure
   if (ps?.filename && ps.filename !== lastThumbnailFile) {
@@ -206,6 +217,16 @@ export function renderDashboard(state: PrinterState, client: CommandSender): voi
   } else if (machineStatus?.status === 14) {
     badge.textContent = `🛑 ${statusName}`;
     badge.className = 'print-status-badge badge-error';
+  } else if (powerLoss !== 'none') {
+    // Status 15 used to fall through to the `else` below and render as `badge-idle` —
+    // the printer sitting on a half-finished job awaiting a decision, styled as though
+    // it had nothing to do (ELEG-29).
+    badge.textContent =
+      powerLoss === 'awaiting_decision'
+        ? '⚡ Power loss — resume or cancel'
+        : `⚡ ${statusName}${subLabel}`;
+    badge.className =
+      'print-status-badge ' + (powerLoss === 'awaiting_decision' ? 'badge-error' : 'badge-busy');
   } else {
     badge.textContent = statusName + subLabel;
     badge.className = 'print-status-badge badge-idle';


### PR DESCRIPTION
Closes ELEG-29. Live confirmation is **ELEG-54** (`OPERATOR:`).

## The defect was worse than "unhandled"

The issue says status 15 is unhandled and falls back to generic text. Half right: `STATUS_NAMES[15]` already reads *"Power Loss Recovery"*, so it was named. What it was not was **handled** — status 15 fell through the entire badge chain in `print-status.ts` to the final `else` and rendered as **`badge-idle`**.

So a printer sitting on a half-finished job, waiting for a human to decide, was styled exactly like a printer with nothing to do.

## The methods, checked rather than believed

The issue asked specifically not to assume that resume-after-power-loss is the same method as a normal resume. Checked against both protocol sources in `data/`, which agree:

| Source | Finding |
| --- | --- |
| `CC2_PROTOCOL_REFERENCE.md` | No power-loss-specific method in the table. State 15 = `PowerOffResume`; 2405/2406 are sub-statuses of it. |
| `CC2-OFFICIAL-APP-PATTERNS.md` | Independently transcribed from the app — same. |

So: **resume is 1023, cancel is 1022**, both parameterless, same as an ordinary resume and stop. The assumption is supported by everything available — and **not confirmed against a live recovery**, which is exactly what ELEG-54 exists for.

## What changed

- `powerLossState(status, subStatus)` in `types.ts` — pure, in the shape of `isFilamentChangeSubStatus` as the issue suggested. Returns `none` / `awaiting_decision` / `resuming` / `resumed`.
- The status badge shows status 15 distinctly: `⚡ Power loss — resume or cancel` in the error style while awaiting a decision, busy style once recovery is under way.
- `src/ui/power-loss-dialog.ts` — the prompt, in the shape of the existing print dialog. Resume, Cancel print (double-confirmed, since it cannot be undone), or "Decide later".

**The `awaiting_decision` vs `resuming` split is the part that matters.** Once 2405 arrives the decision is made; without that distinction the dialog would reappear on every status frame — roughly once a second — and could invite a second resume on a print already recovering. A `promptedForRecovery` latch handles the same hazard within a single recovery.

The dialog also tells the operator to check the bed before resuming, because a print that shifted while the power was off will extrude into the air — a judgement the UI cannot make.

## Verification

- `pnpm gates` green — 111 tests.
- **Covered by tests**: `powerLossState`, 5 cases in `src/__tests__/types.test.ts`, including that an ordinary resume sub-status (2401) is not mistaken for a power-loss one.
- **Proved load-bearing**: removing the 2405 guard turns the named test red; reverted with an inverse patch.
- **Nothing covers** the dialog rendering, the prompt-once latch in a real session, or the badge — no browser test exists in this repo.
- **Not tested against a printer, and cannot be.** Triggering this means cutting power mid-print. **No printer was commanded**; neither button was fired. ELEG-54 has the exact commands and what to look for at the receiver.