### PR TITLE
feat(ui): export the MQTT log as JSON (ELEG-31)

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,8 +535,10 @@
               </label>
               <button class="btn btn-sm btn-ghost" id="slog-pause" title="Pause updates">⏸</button>
               <button class="btn btn-sm btn-ghost" id="slog-diff" title="Toggle diff view">Δ Diff</button>
+              <button class="btn btn-sm btn-ghost" id="slog-export" title="Download the filtered log as JSON">⬇ Export</button>
               <button class="btn btn-sm btn-ghost" id="slog-clear">Clear</button>
             </div>
+            <p class="settings-hint log-export-note">Exports the messages currently shown. The payloads include the printer's serial number and local IP — check before posting one publicly.</p>
             <div id="slog-entries" class="log-entries"></div>
             <div class="log-status-bar">
               <span id="slog-count">0 messages</span>
@@ -551,8 +553,10 @@
               <label class="log-autoscroll-label">
                 <input type="checkbox" id="log-autoscroll" checked> Auto-scroll
               </label>
+              <button class="btn btn-sm btn-ghost" id="log-export" title="Download the filtered log as JSON">⬇ Export</button>
               <button class="btn btn-sm btn-ghost" id="log-clear">Clear</button>
             </div>
+            <p class="settings-hint log-export-note">Exports the messages currently shown. The payloads include the printer's serial number and local IP — check before posting one publicly.</p>
             <div id="log-entries" class="log-entries"></div>
           </div>
         </div>

--- a/src/__tests__/log-export.test.ts
+++ b/src/__tests__/log-export.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { toCaptureFormat, captureFilename } from '../ui/log-export';
+import type { LogEntry } from '../log-store';
+
+function entry(over: Partial<LogEntry> = {}): LogEntry {
+  return {
+    timestamp: 1775469197933,
+    direction: 'received',
+    topic: 'elegoo/SN/api_status',
+    method: 6000,
+    payload: '{"truncated":true}',
+    raw: { id: 1, method: 6000, result: { extruder: { temperature: 209 } } },
+    ...over,
+  };
+}
+
+describe('toCaptureFormat', () => {
+  it('emits the same shape as a server-side capture file', () => {
+    // Byte-compatible with data/logs/mqtt-capture-*.json on purpose: ELEG-28 wants
+    // fixtures from captured payloads, and a second format would need a converter.
+    const [msg] = toCaptureFormat([entry()]);
+    expect(Object.keys(msg).sort()).toEqual(['data', 'direction', 'topic', 'ts']);
+    expect(msg.direction).toBe('received');
+    expect(msg.topic).toBe('elegoo/SN/api_status');
+    expect(msg.ts).toBe(1775469197933);
+  });
+
+  it('exports the full payload, not the truncated display string', () => {
+    // `payload` is capped at 500 chars for rendering and is useless as a fixture.
+    const [msg] = toCaptureFormat([entry()]);
+    expect(msg.data).toEqual({ id: 1, method: 6000, result: { extruder: { temperature: 209 } } });
+    expect(msg.data).not.toBe('{"truncated":true}');
+  });
+
+  it('preserves order and count', () => {
+    const msgs = toCaptureFormat([
+      entry({ timestamp: 1 }),
+      entry({ timestamp: 2 }),
+      entry({ timestamp: 3 }),
+    ]);
+    expect(msgs.map((m) => m.ts)).toEqual([1, 2, 3]);
+  });
+
+  it('handles an empty list', () => {
+    expect(toCaptureFormat([])).toEqual([]);
+  });
+
+  it('keeps a sent entry sent', () => {
+    expect(toCaptureFormat([entry({ direction: 'sent' })])[0].direction).toBe('sent');
+  });
+});
+
+describe('captureFilename', () => {
+  const at = new Date('2026-08-08T10:11:12.345Z');
+
+  it('names the view so two exports in one session do not collide', () => {
+    expect(captureFilename(at, 'raw')).toContain('raw');
+    expect(captureFilename(at, 'structured')).toContain('structured');
+    expect(captureFilename(at, 'raw')).not.toBe(captureFilename(at, 'structured'));
+  });
+
+  it('contains no character Windows rejects in a filename', () => {
+    // A browser download is the one place colons in an ISO timestamp reliably bite.
+    const name = captureFilename(at, 'raw');
+    expect(name).not.toMatch(/[:*?"<>|]/);
+    expect(name.endsWith('.json')).toBe(true);
+  });
+
+  it('follows the server capture naming convention', () => {
+    expect(captureFilename(at, 'raw')).toMatch(/^mqtt-raw-2026-08-08T10-11-12-345Z\.json$/);
+  });
+});

--- a/src/ui/log-export.ts
+++ b/src/ui/log-export.ts
@@ -1,0 +1,78 @@
+/**
+ * Export the MQTT log as JSON (ELEG-31).
+ *
+ * Both log views are browser-only and scroll away, so when something odd happens on the
+ * printer there is no way to hand anyone the evidence.
+ *
+ * ## The format is not a new one, deliberately
+ *
+ * The output is byte-compatible with the server-side capture files that
+ * `POST /api/debug/capture` writes into `data/logs/`: a plain array of
+ * `{ direction, topic, data, ts }`, newest last.
+ *
+ * That matters because of the second reason this exists. ELEG-28 wants delta-merge
+ * tests built from captured real payloads, and a browser export in its own shape would
+ * mean two fixture formats and a converter between them. Matching the existing one
+ * means anything already able to read a capture can read an export.
+ *
+ * `data` is the **full parsed message** (`LogEntry.raw`), not `LogEntry.payload` — the
+ * latter is truncated to 500 characters for display and is useless as a fixture.
+ */
+
+import type { LogEntry, LogDirection } from '../log-store';
+
+/** One message, in the same shape `data/logs/mqtt-capture-*.json` uses. */
+export interface CapturedMessage {
+  direction: LogDirection;
+  topic: string;
+  data: unknown;
+  ts: number;
+}
+
+/** Convert log entries to the capture format. Pure. */
+export function toCaptureFormat(entries: readonly LogEntry[]): CapturedMessage[] {
+  return entries.map((e) => ({
+    direction: e.direction,
+    topic: e.topic,
+    data: e.raw,
+    ts: e.timestamp,
+  }));
+}
+
+/**
+ * Filename for an export, matching the server's `mqtt-capture-<iso>.json` convention
+ * with the view name folded in so two exports from one session do not collide.
+ *
+ * Colons and dots are replaced because Windows rejects them in filenames and a browser
+ * download is the one place this reliably bites.
+ */
+export function captureFilename(now: Date, view: string): string {
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  return `mqtt-${view}-${stamp}.json`;
+}
+
+/** Trigger a browser download of `payload` as pretty-printed JSON. */
+export function downloadJson(filename: string, payload: unknown): void {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Without this the blob is held for the life of the document.
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Export the entries a view is currently showing.
+ *
+ * **Filtered, not the whole buffer** — the filter is how you found the interesting
+ * thing, and an unfiltered dump is what people already cannot read.
+ */
+export function exportLogEntries(entries: readonly LogEntry[], view: string): number {
+  const messages = toCaptureFormat(entries);
+  downloadJson(captureFilename(new Date(), view), messages);
+  return messages.length;
+}

--- a/src/ui/log.ts
+++ b/src/ui/log.ts
@@ -1,5 +1,7 @@
 import type { LogStore, LogEntry } from '../log-store';
 import { $, escapeHtml } from './helpers';
+import { exportLogEntries } from './log-export';
+import { toast } from './toast';
 
 let autoScroll = true;
 const expandedEntries = new Set<number>();
@@ -115,5 +117,17 @@ export function bindLogControls(store: LogStore): void {
   $('log-filter').addEventListener('input', (e) => {
     filterText = (e.target as HTMLInputElement).value;
     renderLog(store);
+  });
+
+  $('log-export').addEventListener('click', () => {
+    // The filtered view, not the whole buffer — the filter is how you found the
+    // interesting thing, and an unfiltered dump is what people already cannot read.
+    const entries = store.getEntries().filter(matchesFilter);
+    if (!entries.length) {
+      toast('Nothing to export — no messages match the filter', 'warning');
+      return;
+    }
+    const count = exportLogEntries(entries, 'raw');
+    toast(`Exported ${count} message${count === 1 ? '' : 's'}`, 'success');
   });
 }

--- a/src/ui/structured-log.ts
+++ b/src/ui/structured-log.ts
@@ -4,6 +4,8 @@ import type { LogStore, LogEntry } from '../log-store';
 import { $, escapeHtml } from './helpers';
 import { METHOD_NAMES } from './log-methods';
 import { loadUISettings, saveUISettings } from './ui-settings';
+import { exportLogEntries } from './log-export';
+import { toast } from './toast';
 
 let autoScroll = true;
 let paused = false;
@@ -387,6 +389,18 @@ export function bindStructuredLogControls(store: LogStore): void {
     pinnedEntries.clear();
     lastRenderedTs = '';
     lastRenderedCount = '';
+  });
+
+  $('slog-export').addEventListener('click', () => {
+    // Whatever the direction / type / method / search filters are currently showing —
+    // the same set on screen, so the file matches what the user was looking at.
+    const entries = store.getEntries().filter(matchesFilters);
+    if (!entries.length) {
+      toast('Nothing to export — no messages match the filters', 'warning');
+      return;
+    }
+    const count = exportLogEntries(entries, 'structured');
+    toast(`Exported ${count} message${count === 1 ? '' : 's'}`, 'success');
   });
 
   // Diff toggle


### PR DESCRIPTION
Closes ELEG-31.

## The format is the interesting decision

The output is **byte-compatible with the server-side capture files** that `POST /api/debug/capture` already writes into `data/logs/` — a plain array of `{ direction, topic, data, ts }`.

That is deliberate. The issue names ELEG-28 (delta-merge tests from captured real payloads) as the second reason to want this. A browser export in its own shape would have meant **two fixture formats and a converter between them**; matching the existing one means anything that can already read a capture can read an export.

Verified against the real file: `data/logs/mqtt-capture-*.json` entries have exactly the keys `direction`, `topic`, `data`, `ts`, and the test asserts the same set.

## What changed

- `src/ui/log-export.ts` — `toCaptureFormat` (pure), `captureFilename` (pure), and the download helper.
- Export button on **both** log tabs, each exporting **the currently filtered view**, not the whole buffer. The raw tab uses its `matchesFilter`; the structured tab uses its `matchesFilters`, so direction/type/method/search all apply and the file matches what was on screen.
- A note under each log saying what is in the file.

## Two details that would have made the export useless

- **`data` carries `LogEntry.raw`, not `LogEntry.payload`.** `payload` is truncated to 500 characters for display — an export built from it would look right and be worthless as a fixture. Covered by a test that asserts the full object comes through and the truncated string does not.
- **The filename strips `:` and `.` from the ISO timestamp.** A browser download is the one place colons in a filename reliably break on Windows. Also covered.

## Privacy note

The payloads contain the printer's **serial number and local IP**. Not secrets under the org data-protection policy, but identifiers — so the UI says so before someone pastes an export into a public issue, as the issue asked.

## Verification

- `pnpm gates` green — 119 tests.
- **Covered by tests**: `src/__tests__/log-export.test.ts`, 8 tests — the capture-format shape, full-vs-truncated payload, ordering, empty input, and filename safety.
- **Nothing covers** the button wiring or the download itself; there is no browser test in this repo. Both element ids (`log-export`, `slog-export`) were checked to exist on both sides — the `/ws`-style rename hazard, but for DOM ids.
- Reviewer check on `pnpm dev:web`: filter the log, export, and confirm the file contains only the filtered messages and full payloads.
- **No printer was commanded.** This reads a buffer the browser already holds.