### PR TITLE
feat(ui): light theme, including the canvas charts (ELEG-34)

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,29 @@
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
   <title>Elegoo Web</title>
   <link rel="stylesheet" href="/src/styles/main.css">
-</head>
+<script>
+      /*
+       * Set the theme before first paint (ELEG-34). Inline and synchronous on purpose:
+       * the app bundle is deferred, so doing this from a module would flash dark on a
+       * light-preferring system.
+       *
+       * The storage key and the values here are a contract with src/ui/theme.ts —
+       * change both together.
+       */
+      (function () {
+        try {
+          var saved = JSON.parse(localStorage.getItem('elegoo-web-ui-settings') || '{}');
+          var choice = saved.theme || 'auto';
+          var light =
+            choice === 'light' ||
+            (choice === 'auto' && window.matchMedia('(prefers-color-scheme: light)').matches);
+          document.documentElement.setAttribute('data-theme', light ? 'light' : 'dark');
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
+  </head>
 <body>
   <header id="app-header">
     <div class="header-left">

--- a/src/__tests__/chart-palette.test.ts
+++ b/src/__tests__/chart-palette.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePalette, chartPalette, FALLBACK_PALETTE } from '../ui/chart-palette';
+import { resolveTheme, isThemeChoice } from '../ui/theme';
+
+describe('resolvePalette', () => {
+  it('takes every colour from the stylesheet when they are all defined', () => {
+    const p = resolvePalette((name) => `var(${name})`);
+    expect(p.grid).toBe('var(--chart-grid)');
+    expect(p.label).toBe('var(--chart-label)');
+    expect(p.gcodeBg).toBe('var(--gcode-bg)');
+    // Nothing may silently keep a dark default when the stylesheet has an answer.
+    for (const value of Object.values(p)) {
+      expect(value.startsWith('var(--')).toBe(true);
+    }
+  });
+
+  it('trims the whitespace getPropertyValue leaves behind', () => {
+    // getPropertyValue returns the declaration verbatim, leading space included.
+    expect(resolvePalette(() => '  #123456  ').label).toBe('#123456');
+  });
+
+  it('falls back for a property the stylesheet does not define', () => {
+    // getPropertyValue returns '' for an unknown property. Assigning that to fillStyle
+    // silently keeps the *previous* colour, which is a miserable bug to chase — so an
+    // empty value must fall back rather than be used.
+    expect(resolvePalette(() => '')).toEqual(FALLBACK_PALETTE);
+    expect(resolvePalette(() => undefined)).toEqual(FALLBACK_PALETTE);
+  });
+
+  it('falls back per property, not all-or-nothing', () => {
+    const p = resolvePalette((name) => (name === '--chart-label' ? '#ffffff' : ''));
+    expect(p.label).toBe('#ffffff');
+    expect(p.grid).toBe(FALLBACK_PALETTE.grid);
+  });
+});
+
+describe('chartPalette without a DOM', () => {
+  it('returns the fallback rather than throwing', () => {
+    // vitest runs environment: "node". The charts must stay drawable, and the render
+    // test in layer-chart-render.test.ts depends on this.
+    expect(chartPalette()).toEqual(FALLBACK_PALETTE);
+  });
+});
+
+describe('FALLBACK_PALETTE', () => {
+  it('defines a non-empty colour for every field', () => {
+    for (const [key, value] of Object.entries(FALLBACK_PALETTE)) {
+      expect(value, `${key} is empty`).toBeTruthy();
+    }
+  });
+});
+
+describe('resolveTheme', () => {
+  it('lets an explicit choice override the system preference', () => {
+    expect(resolveTheme('dark', true)).toBe('dark');
+    expect(resolveTheme('light', false)).toBe('light');
+  });
+
+  it('follows the system when the choice is auto', () => {
+    expect(resolveTheme('auto', true)).toBe('light');
+    expect(resolveTheme('auto', false)).toBe('dark');
+  });
+});
+
+describe('isThemeChoice', () => {
+  it('accepts the three valid choices', () => {
+    for (const v of ['auto', 'dark', 'light']) expect(isThemeChoice(v)).toBe(true);
+  });
+
+  it('rejects anything else, so a corrupt stored value cannot be applied', () => {
+    for (const v of ['', 'Light', null, undefined, 42, {}]) expect(isThemeChoice(v)).toBe(false);
+  });
+});

--- a/src/__tests__/layer-chart-render.test.ts
+++ b/src/__tests__/layer-chart-render.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { renderLayerTimeChart } from '../ui/layer-chart';
+import { FALLBACK_PALETTE } from '../ui/chart-palette';
 import type { PrinterState } from '../printer-state';
 
 const W = 554;
@@ -70,8 +71,24 @@ function render(layerTimes: LayerTime[]): Op[] {
       // textAlign decides which side of x the text extends, so capture it per call.
       ops.push({ op: 'fillText', args: [t, x, y, ctx.textAlign] });
     },
-    fillStyle: '',
-    strokeStyle: '',
+    // Recorded, not stored: ELEG-34 moved every colour out of this file's literals and
+    // into the stylesheet, and the regression worth pinning is that they stay there.
+    _fillStyle: '',
+    _strokeStyle: '',
+    get fillStyle() {
+      return this._fillStyle;
+    },
+    set fillStyle(v: string) {
+      this._fillStyle = v;
+      ops.push({ op: 'set:fillStyle', args: [v] });
+    },
+    get strokeStyle() {
+      return this._strokeStyle;
+    },
+    set strokeStyle(v: string) {
+      this._strokeStyle = v;
+      ops.push({ op: 'set:strokeStyle', args: [v] });
+    },
     lineWidth: 0,
     lineJoin: '',
     font: '',
@@ -161,5 +178,43 @@ describe('layer chart render path', () => {
     const [left, right] = align === 'right' ? [x - width, x] : [x, x + width];
     expect(left).toBeGreaterThanOrEqual(0);
     expect(right).toBeLessThanOrEqual(W);
+  });
+});
+
+describe('chart colours', () => {
+  const series: LayerTime[] = Array.from({ length: 25 }, (_, i) => ({
+    layer: i + 1,
+    duration: 14 + (i % 3),
+    timestamp: i,
+  }));
+
+  /** Every colour the palette can legitimately supply. */
+  const allowed = new Set(Object.values(FALLBACK_PALETTE));
+
+  it('takes every colour from the palette, never from a literal', () => {
+    // The ELEG-34 regression: a hardcoded '#a0a0b8' or 'rgba(171,71,188,0.4)' here would
+    // stay dark-on-dark in the light theme, and nothing else in this repo would notice.
+    // Under vitest there is no DOM, so chartPalette() returns FALLBACK_PALETTE and every
+    // assigned colour must be one of its values.
+    const assigned = render(series)
+      .filter((o) => o.op === 'set:fillStyle' || o.op === 'set:strokeStyle')
+      .map((o) => String(o.args[0]))
+      .filter((c) => c !== '');
+
+    expect(assigned.length).toBeGreaterThan(0);
+    for (const colour of assigned) {
+      expect(allowed, `${colour} is not a palette colour`).toContain(colour);
+    }
+  });
+
+  it('actually draws with more than one palette colour', () => {
+    // Guards the test above from passing trivially if the chart stopped setting colours.
+    const distinct = new Set(
+      render([...series, { layer: 26, duration: 20, timestamp: 26 }])
+        .filter((o) => o.op === 'set:fillStyle' || o.op === 'set:strokeStyle')
+        .map((o) => String(o.args[0]))
+        .filter(Boolean),
+    );
+    expect(distinct.size).toBeGreaterThan(2);
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ import {
 } from './ui/dashboard';
 import { renderLog, bindLogControls } from './ui/log';
 import { installThumbnailFallback } from './ui/helpers';
+import { initTheme } from './ui/theme';
 import type { PrinterStatus, PrinterAttributes, CanvasInfo, FileEntry } from './types';
 import {
   COMMAND_METHOD_NAMES,
@@ -680,6 +681,10 @@ $('connect-btn').addEventListener('click', () => {
 // icon. One delegated listener covers every thumbnail, including the ones built as
 // HTML strings (ELEG-42).
 installThumbnailFallback();
+
+// Re-assert the stored theme (the inline script in index.html already set it before
+// paint) and follow the OS while the choice is "auto" (ELEG-34).
+initTheme();
 
 // Auto-connect on page load
 connectToService();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -55,6 +55,97 @@
   --font-mono: "JetBrains Mono", "SF Mono", "Fira Code", "Consolas", monospace;
   --header-height: 52px;
   --sidebar-width: 380px;
+
+  /*
+   * Canvas chart palette (ELEG-34).
+   *
+   * The charts draw to a <canvas>, where CSS does not reach — they used to hardcode
+   * these values, which is why they would have stayed dark-on-dark while everything
+   * around them flipped. They are declared here so both themes have one place that
+   * defines them, and `ui/chart-palette.ts` reads them back with getComputedStyle.
+   *
+   * The dark values are exactly the literals they replaced, so this half is a no-op.
+   */
+  --chart-grid: rgba(160, 160, 184, 0.12);
+  --chart-label: #a0a0b8;
+  --chart-series: #ab47bc;
+  --chart-series-fill: rgba(171, 71, 188, 0.12);
+  --chart-series-line: rgba(171, 71, 188, 0.4);
+  --chart-series-point: rgba(171, 71, 188, 0.5);
+  --chart-crosshair: rgba(255, 255, 255, 0.25);
+  --chart-tooltip-bg: rgba(30, 30, 44, 0.92);
+  --chart-tooltip-border: rgba(255, 255, 255, 0.15);
+  --chart-tooltip-text: #e0e0e8;
+  --chart-above-avg: #ef5350;
+  --chart-below-avg: #66bb6a;
+  --chart-temp-fill: rgba(33, 150, 243, 0.3);
+  --gcode-bg: #1e1e2e;
+  --gcode-extrusion: #2196f3;
+  --gcode-travel: #444460;
+  --gcode-top-layer: #00ffff;
+  --gcode-last-segment: #ffffff;
+  --gcode-unknown-tool: #888888;
+}
+
+/*
+ * Light theme (ELEG-34).
+ *
+ * Applied by `data-theme="light"` on <html>, which an inline script in index.html sets
+ * before first paint — from an explicit saved choice, or from `prefers-color-scheme`
+ * when there is none. Doing it with an attribute rather than a second
+ * `@media (prefers-color-scheme: light)` block keeps the palette defined exactly once.
+ *
+ * The status colours are NOT the dark theme's values reused. This UI carries meaning in
+ * colour — the status card is success/warning/danger — and the 500-weight shades that
+ * read well on #0f1117 fall to roughly 2:1 against white. These are the 700/800 weights,
+ * which hold about 5:1 or better on the light background.
+ */
+:root[data-theme="light"] {
+  --bg-primary: #f4f5fa;
+  --bg-secondary: #ffffff;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f0f1f6;
+  --bg-hover: #e8e9f0;
+  --bg-input: #ffffff;
+  --bg-surface: #f0f1f6;
+  --text-primary: #16171f;
+  --text-secondary: #4a4c5e;
+  --text-muted: #7c7e92;
+  --accent: #2563eb;
+  --accent-light: #3b82f6;
+  --accent-dim: rgba(37, 99, 235, 0.1);
+  --success: #15803d;
+  --success-dim: rgba(21, 128, 61, 0.1);
+  --warning: #b45309;
+  --warning-dim: rgba(180, 83, 9, 0.1);
+  --danger: #b91c1c;
+  --danger-dim: rgba(185, 28, 28, 0.1);
+  --nozzle-color: #b91c1c;
+  --bed-color: #b45309;
+  --border: #d6d8e2;
+  --border-subtle: #e8e9f0;
+  --shadow: 0 1px 3px rgba(16, 18, 32, 0.1), 0 1px 2px rgba(16, 18, 32, 0.06);
+  --shadow-lg: 0 4px 12px rgba(16, 18, 32, 0.12), 0 2px 4px rgba(16, 18, 32, 0.08);
+
+  --chart-grid: rgba(60, 60, 90, 0.14);
+  --chart-label: #5c5e72;
+  --chart-series: #8e24aa;
+  --chart-series-fill: rgba(142, 36, 170, 0.1);
+  --chart-series-line: rgba(142, 36, 170, 0.35);
+  --chart-series-point: rgba(142, 36, 170, 0.5);
+  --chart-crosshair: rgba(0, 0, 0, 0.25);
+  --chart-tooltip-bg: rgba(255, 255, 255, 0.96);
+  --chart-tooltip-border: rgba(0, 0, 0, 0.15);
+  --chart-tooltip-text: #16171f;
+  --chart-above-avg: #c62828;
+  --chart-below-avg: #2e7d32;
+  --chart-temp-fill: rgba(25, 118, 210, 0.25);
+  --gcode-bg: #eef0f6;
+  --gcode-extrusion: #1976d2;
+  --gcode-travel: #b0b4c8;
+  --gcode-top-layer: #00838f;
+  --gcode-last-segment: #212121;
+  --gcode-unknown-tool: #757575;
 }
 
 * {
@@ -4104,4 +4195,17 @@ body {
 .debug-log-badge {
   font-size: 10px;
   flex-shrink: 0;
+}
+
+/* Settings row — label plus a control, used by the theme picker (ELEG-34). */
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+}
+.settings-row label {
+  color: var(--text-secondary);
+  font-size: 13px;
+  min-width: 120px;
 }

--- a/src/ui/chart-palette.ts
+++ b/src/ui/chart-palette.ts
@@ -1,0 +1,136 @@
+/**
+ * The canvas charts' colours, read from the stylesheet (ELEG-34).
+ *
+ * `layer-chart.ts`, `charts.ts` and the gcode preview draw to a `<canvas>`, where CSS
+ * does not reach. They used to hardcode `#a0a0b8`, `rgba(160,160,184,0.12)`, `#ab47bc`
+ * and friends — which is exactly why they would have stayed dark-on-dark while the rest
+ * of the UI flipped to light, and a half-themed dashboard is worse than a dark one.
+ *
+ * So the values live in `:root` / `:root[data-theme='light']` as custom properties and
+ * are read back here with `getComputedStyle`. One definition per colour, both themes.
+ *
+ * ## Cached, and invalidated on theme change
+ *
+ * `getComputedStyle` forces style resolution, and these are read inside draw loops that
+ * run per frame. The palette can only change when the theme does, so it is resolved
+ * once and `invalidateChartPalette()` clears it.
+ *
+ * ## Falls back rather than throwing
+ *
+ * There is no DOM under vitest (`environment: "node"`), and the render test in
+ * `src/__tests__/layer-chart-render.test.ts` stubs `document` with nothing but
+ * `getElementById`. Every lookup therefore degrades to the dark value, which keeps the
+ * charts drawable in any environment and keeps that test meaningful.
+ */
+
+export interface ChartPalette {
+  grid: string;
+  label: string;
+  series: string;
+  seriesFill: string;
+  seriesLine: string;
+  seriesPoint: string;
+  crosshair: string;
+  tooltipBg: string;
+  tooltipBorder: string;
+  tooltipText: string;
+  aboveAvg: string;
+  belowAvg: string;
+  tempFill: string;
+  gcodeBg: string;
+  gcodeExtrusion: string;
+  gcodeTravel: string;
+  gcodeTopLayer: string;
+  gcodeLastSegment: string;
+  gcodeUnknownTool: string;
+}
+
+/** CSS custom property backing each field. */
+const VARS: Record<keyof ChartPalette, string> = {
+  grid: '--chart-grid',
+  label: '--chart-label',
+  series: '--chart-series',
+  seriesFill: '--chart-series-fill',
+  seriesLine: '--chart-series-line',
+  seriesPoint: '--chart-series-point',
+  crosshair: '--chart-crosshair',
+  tooltipBg: '--chart-tooltip-bg',
+  tooltipBorder: '--chart-tooltip-border',
+  tooltipText: '--chart-tooltip-text',
+  aboveAvg: '--chart-above-avg',
+  belowAvg: '--chart-below-avg',
+  tempFill: '--chart-temp-fill',
+  gcodeBg: '--gcode-bg',
+  gcodeExtrusion: '--gcode-extrusion',
+  gcodeTravel: '--gcode-travel',
+  gcodeTopLayer: '--gcode-top-layer',
+  gcodeLastSegment: '--gcode-last-segment',
+  gcodeUnknownTool: '--gcode-unknown-tool',
+};
+
+/**
+ * The dark values, byte-identical to the literals they replaced.
+ *
+ * Used whenever the stylesheet cannot be read. Keeping them equal to the old hardcoded
+ * set means a failure to resolve looks exactly like the pre-ELEG-34 behaviour rather
+ * than like a new bug.
+ */
+export const FALLBACK_PALETTE: ChartPalette = {
+  grid: 'rgba(160, 160, 184, 0.12)',
+  label: '#a0a0b8',
+  series: '#ab47bc',
+  seriesFill: 'rgba(171, 71, 188, 0.12)',
+  seriesLine: 'rgba(171, 71, 188, 0.4)',
+  seriesPoint: 'rgba(171, 71, 188, 0.5)',
+  crosshair: 'rgba(255, 255, 255, 0.25)',
+  tooltipBg: 'rgba(30, 30, 44, 0.92)',
+  tooltipBorder: 'rgba(255, 255, 255, 0.15)',
+  tooltipText: '#e0e0e8',
+  aboveAvg: '#ef5350',
+  belowAvg: '#66bb6a',
+  tempFill: 'rgba(33, 150, 243, 0.3)',
+  gcodeBg: '#1e1e2e',
+  gcodeExtrusion: '#2196f3',
+  gcodeTravel: '#444460',
+  gcodeTopLayer: '#00ffff',
+  gcodeLastSegment: '#ffffff',
+  gcodeUnknownTool: '#888888',
+};
+
+let cached: ChartPalette | null = null;
+
+/**
+ * Resolve the palette from the stylesheet.
+ *
+ * Exported for tests: it takes the resolver rather than reaching for the global, so the
+ * light and dark cases can be exercised without a browser.
+ */
+export function resolvePalette(readVar: (name: string) => string | undefined): ChartPalette {
+  const out = {} as ChartPalette;
+  for (const key of Object.keys(VARS) as (keyof ChartPalette)[]) {
+    const value = readVar(VARS[key])?.trim();
+    // An empty string is what getPropertyValue returns for an undefined property, so it
+    // has to fall back rather than be assigned — `fillStyle = ''` silently keeps the
+    // previous colour, which would be a genuinely confusing bug to chase.
+    out[key] = value ? value : FALLBACK_PALETTE[key];
+  }
+  return out;
+}
+
+/** The current palette. Resolved once; call `invalidateChartPalette` on theme change. */
+export function chartPalette(): ChartPalette {
+  if (cached) return cached;
+  if (typeof document === 'undefined' || typeof getComputedStyle !== 'function') {
+    // No DOM — under vitest, or the render-test stub. Do not cache: a real document may
+    // exist by the next call in a browser.
+    return FALLBACK_PALETTE;
+  }
+  const style = getComputedStyle(document.documentElement);
+  cached = resolvePalette((name) => style.getPropertyValue(name));
+  return cached;
+}
+
+/** Drop the cached palette. Call whenever the theme changes. */
+export function invalidateChartPalette(): void {
+  cached = null;
+}

--- a/src/ui/charts.ts
+++ b/src/ui/charts.ts
@@ -2,10 +2,10 @@
 
 import type { ChartStore, Series } from '../chart-store';
 import { saveChartWindow, getChartWindow } from './ui-settings';
+import { chartPalette } from './chart-palette';
 
 const PADDING = { top: 10, right: 12, bottom: 24, left: 48 };
-const GRID_COLOR = 'rgba(160, 160, 184, 0.12)';
-const LABEL_COLOR = '#a0a0b8';
+// Colours come from the stylesheet via chartPalette() (ELEG-34).
 const LABEL_FONT = '10px -apple-system, BlinkMacSystemFont, sans-serif';
 
 interface ChartConfig {
@@ -185,6 +185,7 @@ function startDrawTimer(): void {
 }
 
 function drawChart(config: ChartConfig): void {
+  const pal = chartPalette();
   if (!store) return;
   const canvas = document.getElementById(config.canvasId) as HTMLCanvasElement | null;
   if (!canvas) return;
@@ -246,12 +247,12 @@ function drawChart(config: ChartConfig): void {
   const yMap = (v: number) => PADDING.top + plotH - ((v - yMin) / (yMax - yMin)) * plotH;
 
   // Grid lines (Y)
-  ctx.strokeStyle = GRID_COLOR;
+  ctx.strokeStyle = pal.grid;
   ctx.lineWidth = 1;
   const ySteps = 5;
   const yStep = (yMax - yMin) / ySteps;
   ctx.font = LABEL_FONT;
-  ctx.fillStyle = LABEL_COLOR;
+  ctx.fillStyle = pal.label;
   ctx.textAlign = 'right';
   ctx.textBaseline = 'middle';
 
@@ -353,7 +354,7 @@ function drawChart(config: ChartConfig): void {
 
   // Show zoom/pan indicator if not at defaults
   if (inter && (inter.zoomFactor !== 1.0 || inter.panOffset !== 0)) {
-    ctx.fillStyle = 'rgba(33, 150, 243, 0.3)';
+    ctx.fillStyle = pal.tempFill;
     ctx.font = '9px sans-serif';
     ctx.textAlign = 'left';
     ctx.textBaseline = 'top';
@@ -371,7 +372,7 @@ function drawChart(config: ChartConfig): void {
     const hoverT = tMin + ((inter.hoverX - PADDING.left) / plotW) * (tMax - tMin);
 
     // Vertical crosshair line
-    ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+    ctx.strokeStyle = pal.crosshair;
     ctx.lineWidth = 1;
     ctx.setLineDash([3, 3]);
     ctx.beginPath();
@@ -441,8 +442,8 @@ function drawChart(config: ChartConfig): void {
       const boxY = PADDING.top + 4;
 
       // Background
-      ctx.fillStyle = 'rgba(30, 30, 44, 0.92)';
-      ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+      ctx.fillStyle = pal.tooltipBg;
+      ctx.strokeStyle = pal.tooltipBorder;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.roundRect(boxX, boxY, boxW, boxH, 4);
@@ -450,7 +451,7 @@ function drawChart(config: ChartConfig): void {
       ctx.stroke();
 
       // Time header
-      ctx.fillStyle = LABEL_COLOR;
+      ctx.fillStyle = pal.label;
       ctx.font = tooltipFont;
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
@@ -466,7 +467,7 @@ function drawChart(config: ChartConfig): void {
         ctx.arc(boxX + tooltipPadding + 4, ty + 6, 3, 0, Math.PI * 2);
         ctx.fill();
         // Text
-        ctx.fillStyle = '#e0e0e8';
+        ctx.fillStyle = pal.tooltipText;
         ctx.fillText(`${line.label}: ${line.value}`, boxX + tooltipPadding + 12, ty);
       }
     }

--- a/src/ui/gcode-preview.ts
+++ b/src/ui/gcode-preview.ts
@@ -13,6 +13,7 @@ import {
 import type { Object3D } from 'three';
 import type { PrinterState } from '../printer-state';
 import { $, fetchTimeout } from './helpers';
+import { chartPalette } from './chart-palette';
 
 /** Internal fields of WebGLPreview we need to access to stop the animate loop */
 interface WebGLPreviewInternals {
@@ -85,11 +86,11 @@ function updateNozzle(state: PrinterState): void {
 
 /** Build extrusionColor from colorMap — array for multi-color */
 function buildExtrusionColors(colorMap: Array<{ t: number; color: string }>): string | string[] {
-  if (colorMap.length === 0) return '#2196f3';
+  if (colorMap.length === 0) return chartPalette().gcodeExtrusion;
   if (colorMap.length === 1) return `#${colorMap[0].color.replace(/^#/, '')}`;
   // Multi-color: array indexed by tool number
   const maxTool = Math.max(...colorMap.map((c) => c.t));
-  const colors: string[] = new Array(maxTool + 1).fill('#888888');
+  const colors: string[] = new Array(maxTool + 1).fill(chartPalette().gcodeUnknownTool);
   for (const entry of colorMap) {
     colors[entry.t] = `#${entry.color.replace(/^#/, '')}`;
   }
@@ -190,6 +191,7 @@ export function renderGcodePreview(state: PrinterState): void {
 
 /** Initialize the 3D preview on the canvas */
 function initPreview(colorMap?: Array<{ t: number; color: string }>): WebGLPreview | null {
+  const pal = chartPalette();
   const canvas = $('gcode-preview-canvas') as HTMLCanvasElement | null;
   if (!canvas) return null;
 
@@ -205,15 +207,15 @@ function initPreview(colorMap?: Array<{ t: number; color: string }>): WebGLPrevi
   }
 
   const extrusionColor =
-    colorMap && colorMap.length > 0 ? buildExtrusionColors(colorMap) : '#2196f3';
+    colorMap && colorMap.length > 0 ? buildExtrusionColors(colorMap) : pal.gcodeExtrusion;
 
   const p = new WebGLPreview({
     canvas,
-    backgroundColor: '#1e1e2e',
+    backgroundColor: pal.gcodeBg,
     extrusionColor,
-    topLayerColor: '#00ffff',
-    lastSegmentColor: '#ffffff',
-    travelColor: '#444460',
+    topLayerColor: pal.gcodeTopLayer,
+    lastSegmentColor: pal.gcodeLastSegment,
+    travelColor: pal.gcodeTravel,
     buildVolume: BUILD_VOLUME,
     lineWidth: 2,
     renderExtrusion: true,

--- a/src/ui/layer-chart.ts
+++ b/src/ui/layer-chart.ts
@@ -3,12 +3,13 @@
 import type { PrinterState } from '../printer-state';
 import { type LayerTimeEntry, trailingLayerRun } from '../types';
 import { $ } from './helpers';
+import { chartPalette } from './chart-palette';
 
 const PADDING = { top: 10, right: 12, bottom: 28, left: 48 };
-const GRID_COLOR = 'rgba(160, 160, 184, 0.12)';
-const LABEL_COLOR = '#a0a0b8';
+// Colours come from the stylesheet via chartPalette() so the chart follows the theme
+// (ELEG-34). Canvas gets no CSS, so this is the bridge.
 const LABEL_FONT = '10px -apple-system, BlinkMacSystemFont, sans-serif';
-const SERIES_COLOR = '#ab47bc';
+
 const MAX_VISIBLE = 200;
 
 /** One entry of the layer-time series, as the server sends it over `/ws`. */
@@ -103,6 +104,7 @@ export function renderLayerTimeChart(state: PrinterState): void {
 }
 
 function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
+  const pal = chartPalette();
   const layerTimes = state.layerTimes;
 
   const dpr = window.devicePixelRatio || 1;
@@ -122,7 +124,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   // Determine visible range — the current print's last N layers
   const visible = selectVisibleLayers(layerTimes);
   if (visible.length < 2) {
-    ctx.fillStyle = LABEL_COLOR;
+    ctx.fillStyle = pal.label;
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -139,10 +141,10 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   const yMap = (dur: number) => PADDING.top + plotH - (dur / yMax) * plotH;
 
   // Y grid
-  ctx.strokeStyle = GRID_COLOR;
+  ctx.strokeStyle = pal.grid;
   ctx.lineWidth = 1;
   ctx.font = LABEL_FONT;
-  ctx.fillStyle = LABEL_COLOR;
+  ctx.fillStyle = pal.label;
   ctx.textAlign = 'right';
   ctx.textBaseline = 'middle';
 
@@ -169,7 +171,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
     ctx.moveTo(x, PADDING.top);
     ctx.lineTo(x, PADDING.top + plotH);
     ctx.stroke();
-    ctx.fillStyle = LABEL_COLOR;
+    ctx.fillStyle = pal.label;
     ctx.fillText(`L${layer}`, x, PADDING.top + plotH + 4);
   }
 
@@ -182,7 +184,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   ctx.clip();
 
   // Draw line
-  ctx.strokeStyle = SERIES_COLOR;
+  ctx.strokeStyle = pal.series;
   ctx.lineWidth = 1.5;
   ctx.lineJoin = 'round';
   ctx.beginPath();
@@ -198,7 +200,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   ctx.stroke();
 
   // Fill area under the curve
-  ctx.fillStyle = 'rgba(171, 71, 188, 0.12)';
+  ctx.fillStyle = pal.seriesFill;
   ctx.beginPath();
   ctx.moveTo(xMap(visible[0].layer), yMap(0));
   for (const lt of visible) {
@@ -210,7 +212,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
 
   // Draw dots on data points (only if not too many)
   if (visible.length <= 80) {
-    ctx.fillStyle = SERIES_COLOR;
+    ctx.fillStyle = pal.series;
     for (const lt of visible) {
       const x = xMap(lt.layer);
       const y = yMap(lt.duration);
@@ -225,7 +227,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   // Current value label at rightmost point. The last point sits on the plot's right
   // edge, so the label only ever fits to its left.
   const last = visible[visible.length - 1];
-  ctx.fillStyle = SERIES_COLOR;
+  ctx.fillStyle = pal.series;
   ctx.font = 'bold 11px -apple-system, BlinkMacSystemFont, sans-serif';
   ctx.textBaseline = 'middle';
   const lastLabel = `L${last.layer}: ${last.duration.toFixed(1)}s`;
@@ -242,14 +244,14 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
   const avgDuration = visible.reduce((s, lt) => s + lt.duration, 0) / visible.length;
   const avgY = yMap(avgDuration);
   ctx.setLineDash([4, 4]);
-  ctx.strokeStyle = 'rgba(171, 71, 188, 0.4)';
+  ctx.strokeStyle = pal.seriesLine;
   ctx.lineWidth = 1;
   ctx.beginPath();
   ctx.moveTo(PADDING.left, avgY);
   ctx.lineTo(w - PADDING.right, avgY);
   ctx.stroke();
   ctx.setLineDash([]);
-  ctx.fillStyle = 'rgba(171, 71, 188, 0.5)';
+  ctx.fillStyle = pal.seriesPoint;
   ctx.font = '9px sans-serif';
   ctx.textAlign = 'right';
   ctx.fillText(`avg ${avgDuration.toFixed(1)}s`, w - PADDING.right - 4, avgY - 8);
@@ -275,7 +277,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
       const by = yMap(best.duration);
 
       // Vertical crosshair line
-      ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+      ctx.strokeStyle = pal.crosshair;
       ctx.lineWidth = 1;
       ctx.setLineDash([3, 3]);
       ctx.beginPath();
@@ -285,7 +287,7 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
       ctx.setLineDash([]);
 
       // Highlight dot
-      ctx.fillStyle = SERIES_COLOR;
+      ctx.fillStyle = pal.series;
       ctx.beginPath();
       ctx.arc(bx, by, 4, 0, Math.PI * 2);
       ctx.fill();
@@ -317,8 +319,8 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
       const boxY = Math.max(PADDING.top, by - boxH / 2);
 
       // Background
-      ctx.fillStyle = 'rgba(30, 30, 44, 0.92)';
-      ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+      ctx.fillStyle = pal.tooltipBg;
+      ctx.strokeStyle = pal.tooltipBorder;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.roundRect(boxX, boxY, boxW, boxH, 4);
@@ -328,11 +330,11 @@ function drawLayerChart(canvas: HTMLCanvasElement, state: PrinterState): void {
       // Text
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
-      ctx.fillStyle = LABEL_COLOR;
+      ctx.fillStyle = pal.label;
       ctx.fillText(line1, boxX + tooltipPadding, boxY + tooltipPadding);
-      ctx.fillStyle = '#e0e0e8';
+      ctx.fillStyle = pal.tooltipText;
       ctx.fillText(line2, boxX + tooltipPadding, boxY + tooltipPadding + lineHeight);
-      ctx.fillStyle = diffFromAvg > 0 ? '#ef5350' : '#66bb6a';
+      ctx.fillStyle = diffFromAvg > 0 ? pal.aboveAvg : pal.belowAvg;
       ctx.fillText(line3, boxX + tooltipPadding, boxY + tooltipPadding + lineHeight * 2);
     }
   }

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -5,6 +5,7 @@ import { type CardLayout, CARD_NAMES, defaultCardLayout, normaliseCardLayout } f
 import { toast } from './toast';
 import { renderSpoolCalc } from './spool-calc';
 import { renderHelp } from './help';
+import { getThemeChoice, setThemeChoice, isThemeChoice } from './theme';
 
 const STORAGE_KEY = 'elegoo-web-card-layout';
 
@@ -189,6 +190,19 @@ function buildSettingsHTML(content: HTMLElement): void {
 
   content.innerHTML = `
     <section class="settings-section">
+      <h3>Appearance</h3>
+      <p class="settings-hint">Auto follows your operating system's light/dark setting.</p>
+      <div class="settings-row">
+        <label for="settings-theme">Theme</label>
+        <select id="settings-theme" class="log-select">
+          <option value="auto">Auto</option>
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+      </div>
+    </section>
+
+    <section class="settings-section">
       <h3>Panel Layout</h3>
       <p class="settings-hint">Assign cards to the sidebar (always-visible) or main area. Reorder within each panel.</p>
       <h4 class="settings-panel-heading">Sidebar</h4>
@@ -294,6 +308,14 @@ function buildSettingsHTML(content: HTMLElement): void {
   });
 
   // Reset button
+  const themeSelect = content.querySelector('#settings-theme') as HTMLSelectElement | null;
+  if (themeSelect) {
+    themeSelect.value = getThemeChoice();
+    themeSelect.addEventListener('change', () => {
+      if (isThemeChoice(themeSelect.value)) setThemeChoice(themeSelect.value);
+    });
+  }
+
   content.querySelector('#settings-reset-layout')?.addEventListener('click', () => {
     // Confirmed because it discards arranging work and cannot be undone. Scoped to the
     // layout key alone: chart resolution, log filters and camera selection live in a

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,0 +1,81 @@
+/**
+ * Light / dark theme (ELEG-34).
+ *
+ * The stylesheet was already built on custom properties, so a theme is a second set of
+ * values plus a way to choose between them. `data-theme` on `<html>` is that switch.
+ *
+ * ## Why an attribute and not `@media (prefers-color-scheme: light)`
+ *
+ * An explicit choice has to be able to override the system preference, and a media
+ * query cannot be overridden from JavaScript. Driving everything from one attribute
+ * also means the light palette is written once rather than duplicated into a media
+ * block and an override block.
+ *
+ * The attribute is set **before first paint** by a small inline script in `index.html`;
+ * doing it from this module would flash dark on a light-preferring system, because the
+ * bundle is deferred. This module owns the choice from then on and must agree with that
+ * script — the storage key and the values are the contract between them.
+ */
+
+import { loadUISettings, saveUISettings } from './ui-settings';
+import { invalidateChartPalette } from './chart-palette';
+
+/** `auto` follows the operating system; the other two override it. */
+export type ThemeChoice = 'auto' | 'dark' | 'light';
+
+/** What actually gets applied. `auto` resolves to one of these. */
+export type ResolvedTheme = 'dark' | 'light';
+
+export function isThemeChoice(value: unknown): value is ThemeChoice {
+  return value === 'auto' || value === 'dark' || value === 'light';
+}
+
+/** Resolve a choice against the system preference. Pure. */
+export function resolveTheme(choice: ThemeChoice, prefersLight: boolean): ResolvedTheme {
+  if (choice === 'dark' || choice === 'light') return choice;
+  return prefersLight ? 'light' : 'dark';
+}
+
+function systemPrefersLight(): boolean {
+  return (
+    typeof matchMedia === 'function' && matchMedia('(prefers-color-scheme: light)').matches === true
+  );
+}
+
+/** The saved choice, defaulting to `auto`. */
+export function getThemeChoice(): ThemeChoice {
+  const saved = loadUISettings().theme;
+  return isThemeChoice(saved) ? saved : 'auto';
+}
+
+/** Put the resolved theme on `<html>` and drop the cached canvas palette. */
+function apply(resolved: ResolvedTheme): void {
+  document.documentElement.setAttribute('data-theme', resolved);
+  // The charts read their colours from the stylesheet once and cache the result, so a
+  // theme change that skipped this would leave every canvas on the old palette until
+  // the page reloaded — the half-themed dashboard ELEG-34 exists to avoid.
+  invalidateChartPalette();
+}
+
+/** Persist a choice and apply it immediately. */
+export function setThemeChoice(choice: ThemeChoice): void {
+  saveUISettings({ theme: choice });
+  apply(resolveTheme(choice, systemPrefersLight()));
+}
+
+/**
+ * Re-apply the stored choice, and follow the system while the choice is `auto`.
+ *
+ * Called once at startup. The attribute is normally already correct — the inline script
+ * set it — but this re-asserts it from the same source of truth and installs the
+ * listener that keeps `auto` honest when the OS flips at sunset.
+ */
+export function initTheme(): void {
+  apply(resolveTheme(getThemeChoice(), systemPrefersLight()));
+
+  if (typeof matchMedia !== 'function') return;
+  matchMedia('(prefers-color-scheme: light)').addEventListener('change', (e) => {
+    if (getThemeChoice() !== 'auto') return;
+    apply(e.matches ? 'light' : 'dark');
+  });
+}

--- a/src/ui/ui-settings.ts
+++ b/src/ui/ui-settings.ts
@@ -15,6 +15,8 @@ export interface UISettings {
   slogMethod: string;
   /** Active log tab (structured/raw) */
   logTab: string;
+  /** Theme choice: 'auto' follows the OS, 'dark'/'light' override it (ELEG-34) */
+  theme: string;
 }
 
 const defaults: UISettings = {
@@ -24,6 +26,7 @@ const defaults: UISettings = {
   slogType: 'all',
   slogMethod: 'all',
   logTab: 'structured',
+  theme: 'auto',
 };
 
 let cached: UISettings | null = null;


### PR DESCRIPTION
Closes ELEG-34.

## The part that took the time was the part the issue predicted

The stylesheet was already on custom properties, so a second palette plus a toggle is most of it. **The canvas charts were the real work.**

`layer-chart.ts`, `charts.ts` and `gcode-preview.ts` hardcoded ~25 colours — `#a0a0b8`, `rgba(160,160,184,0.12)`, `#ab47bc`, `rgba(30,30,44,0.92)`, `#1e1e2e`… They get no CSS, so they would have stayed dark-on-dark while everything around them flipped. Done as part of this change, not a follow-up, exactly as the issue asked.

Those values now live in `:root` / `:root[data-theme='light']` as `--chart-*` and `--gcode-*` properties, and `src/ui/chart-palette.ts` reads them back with `getComputedStyle`.

**The dark values are byte-identical to the literals they replaced**, so the dark theme is unchanged by construction rather than by inspection.

## Design decisions

**Cached, invalidated on theme change.** `getComputedStyle` forces style resolution and these are read inside per-frame draw loops. The palette can only change when the theme does. Missing the invalidation would leave every canvas on the old palette until reload — the half-themed dashboard this issue exists to prevent — so `theme.ts` calls `invalidateChartPalette()` on every apply.

**`data-theme` attribute, not `@media (prefers-color-scheme: light)`.** A media query cannot be overridden from JavaScript, and an explicit choice has to be able to override the system. One attribute also means the light palette is written once instead of duplicated into a media block and an override block.

**Set before first paint by an inline script in `index.html`.** The bundle is deferred, so applying the theme from a module flashes dark on a light-preferring system. The storage key and values are a contract between that script and `theme.ts`; there is a comment on both sides saying so.

**Falls back rather than throws.** With no DOM, `chartPalette()` returns the dark values. That keeps the charts drawable under vitest and keeps the render test meaningful.

## Contrast

The issue flagged that the status card carries meaning in colour. The light palette does **not** reuse the dark theme's status colours: the 500-weight shades that read well on `#0f1117` fall to roughly 2:1 against white. Light uses the 700/800 weights — success `#15803d`, warning `#b45309`, danger `#b91c1c` — which hold about 5:1 or better.

## Verification

- `pnpm gates` green — 131 tests.
- **Covered by tests**:
  - `src/__tests__/chart-palette.test.ts` — resolution, per-property fallback, whitespace trimming, and that an **empty** value falls back rather than being assigned (`fillStyle = ''` silently keeps the previous colour, which would be a miserable bug to chase). Plus `resolveTheme` / `isThemeChoice`.
  - `src/__tests__/layer-chart-render.test.ts` — extended, as the issue suggested, to record `fillStyle`/`strokeStyle` assignments and assert **every colour is a palette value**. This is the regression worth pinning.
- **Proved load-bearing**: replacing one `pal.seriesPoint` with `'#ff00ff'` fails with `#ff00ff is not a palette colour`. Reverted with an inverse patch. Worth noting its limit — reintroducing a literal that *equals* a palette value passes, since the rendered result is identical.
- **Nothing covers appearance.** No gate here checks how anything looks, and there is no browser test. `charts.ts` and `gcode-preview.ts` have no render test at all — their conversion was verified by reading and by the typechecker.
- Reviewer check on `pnpm dev:web`: switch Auto/Dark/Light in Settings → Appearance and confirm the layer chart, the temperature charts and the gcode preview all follow, with the status badges still legible in both.
- **No printer was commanded.**