### PR TITLE
feat(ui): delete print history entries, using method 1038 (ELEG-38)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -574,6 +574,21 @@ function connectToService(): void {
           toast('Self-check started', 'success');
         }
       }
+      if (method === 1038) {
+        // History delete. 1036 takes no paging params, so the refresh is a full refetch.
+        const result = (data as Record<string, unknown>).result as
+          | Record<string, unknown>
+          | undefined;
+        const code = result?.error_code as number | undefined;
+        if (classifyCommandOutcome(code) === 'ok') {
+          toast('History entry deleted', 'success');
+        } else if (classifyCommandOutcome(code) === 'busy') {
+          toast('Cannot delete — printer is busy. Try again in a moment.', 'warning');
+        } else {
+          toast(`Delete failed: ${describeCommandError(code)}`, 'error');
+        }
+        requestHistory();
+      }
       if (method === 1036) {
         requestAnimationFrame(() => renderPrintHistory(state));
         requestAnimationFrame(() => renderTimelapse(state));

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3064,6 +3064,16 @@ body {
   align-items: center;
   gap: 8px;
 }
+.history-delete-btn {
+  /* Pushed to the trailing edge so it does not crowd the filename (ELEG-38). */
+  margin-left: auto;
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+.history-delete-btn:hover {
+  opacity: 1;
+  color: var(--danger);
+}
 .history-status {
   font-size: 14px;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,6 +408,8 @@ export const COMMAND_METHOD_NAMES: Record<number, string> = {
   1033: 'Vibration optimization',
   1034: 'PID calibration',
   1035: 'Self-check',
+  // 1038 (HistoryDelete) is handled individually in main.ts so it can refresh the list
+  // and use delete-specific wording, so it is deliberately absent here.
 };
 
 // Exception codes from the CC2 protocol

--- a/src/ui/log-methods.ts
+++ b/src/ui/log-methods.ts
@@ -1,4 +1,13 @@
-/** Human-readable names for CC2 MQTT method codes */
+/**
+ * Human-readable names for CC2 MQTT method codes, for the log viewer.
+ *
+ * **Treat an entry here as a label, not as a citation.** Several were wrong, and
+ * because this is the most readable list of methods in the repo it is where uncited
+ * claims got copied from — ELEG-38 asked for a history delete on 1049, ELEG-30 for AI
+ * detection on 2010/2011, and ELEG-32 for OTA on 1064, all of which trace back to this
+ * table. `data/CC2_PROTOCOL_REFERENCE.md` is the citable source; ELEG-57 audits the
+ * rest of this table against it.
+ */
 
 export const METHOD_NAMES: Record<number, string> = {
   1001: 'GetAttributes',
@@ -20,13 +29,16 @@ export const METHOD_NAMES: Record<number, string> = {
   1035: 'SelfCheck',
   1036: 'PrintTaskList',
   1037: 'PrintTaskDetail',
-  1038: 'DeletePrintTask',
+  1038: 'HistoryDelete',
   1044: 'GetFileList',
   1045: 'GetThumbnail',
   1046: 'GetFileDetail',
   1047: 'DeleteFile',
   1048: 'GetDiskInfo',
-  1049: 'DeleteHistory',
+  // Was 'DeleteHistory', which collided with 1038 above — one operation, two entries,
+  // so one had to be wrong. Both protocol docs in `data/` say 1049 is UpdateToken, and
+  // ELEG-38 nearly sent a history-delete payload to it (ELEG-38).
+  1049: 'UpdateToken',
   1050: 'GetVideoUrl',
   1051: 'GetTimeLapse',
   1060: 'SetDeviceName',

--- a/src/ui/print-history.ts
+++ b/src/ui/print-history.ts
@@ -1,6 +1,7 @@
 import type { CommandSender } from '../ws-client';
 import type { PrinterState } from '../printer-state';
-import { $, escapeHtml, formatTime } from './helpers';
+import { $, escapeHtml, escapeAttr, formatTime } from './helpers';
+import { toast } from './toast';
 
 let historyClient: CommandSender | null = null;
 
@@ -48,10 +49,17 @@ export function renderPrintHistory(state: PrinterState): void {
       const duration =
         item.begin_time && item.end_time ? formatTime(item.end_time - item.begin_time) : '--';
 
+      // A record with no task_id cannot be addressed by 1038, so it gets no button
+      // rather than one that silently does nothing.
+      const deleteBtn = item.uuid
+        ? `<button class="btn btn-sm btn-ghost history-delete-btn" data-task-id="${escapeAttr(item.uuid)}" data-filename="${escapeAttr(item.filename)}" title="Delete this entry from the printer">🗑</button>`
+        : '';
+
       return `<div class="history-entry">
       <div class="history-entry-main">
         <span class="history-status ${statusClass}" title="${escapeHtml(item.status)}">${statusIcon}</span>
         <span class="history-filename" title="${escapeHtml(item.filename)}">${escapeHtml(item.filename)}</span>
+        ${deleteBtn}
       </div>
       <div class="history-entry-meta">
         <span title="Start time">🕐 ${escapeHtml(begin)}</span>
@@ -72,4 +80,30 @@ export function renderPrintHistory(state: PrinterState): void {
 
 export function bindHistoryControls(): void {
   $('btn-history-refresh').addEventListener('click', () => requestHistory());
+
+  // Delegated, because the list is re-rendered on every 1036 response and per-row
+  // listeners would be rebound each time.
+  $('print-history-entries').addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest('.history-delete-btn') as HTMLElement | null;
+    if (!btn) return;
+    const taskId = btn.dataset.taskId;
+    if (!taskId || !historyClient) return;
+
+    const name = btn.dataset.filename || 'this entry';
+    // The record is destroyed on the printer, not hidden here — same shape as the file
+    // delete in files.ts, and equally irreversible.
+    if (
+      !confirm(
+        `Delete the history entry for ${name}?\n\nThis removes it from the printer and cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+
+    // Method 1038 (HistoryDelete) takes a list of task ids. NOT 1049 — that is
+    // UpdateToken, and sending it here would have written the printer's auth token
+    // (ELEG-38).
+    historyClient.sendCommand(1038, { list: [taskId] });
+    toast('Deleting history entry…', 'info');
+  });
 }


### PR DESCRIPTION
Closes ELEG-38. Live confirmation is **ELEG-58** (`OPERATOR:`).

## Checking the method first is what saved this change

The issue asked for method **1049** and said to confirm it rather than trust the uncited TODO line. That confirmation matters more than usual here:

> **1049 is `UpdateToken`** — an authentication-token write.

Sending a history-delete payload to 1049 would have written the printer's auth token. History delete is **1038 (`HistoryDelete`)**, taking `{ list: [task_id, ...] }`.

**Two independent sources agree, and one of them is this repo.** `METHOD_NAMES` in `src/ui/log-methods.ts` listed *both*:

```ts
1038: 'DeletePrintTask',
1049: 'DeleteHistory',
```

One operation, two entries — so one had to be wrong regardless of any external document. `data/CC2_PROTOCOL_REFERENCE.md` says which, and documents the exact `list` parameter.

## The root cause, fixed and filed

That table is where the bad method numbers in the tracker came from — ELEG-38 (1049), ELEG-30 (2010/2011), and ELEG-32 (1064) all trace back to it. This PR corrects the 1049 row and adds a header saying the table is a display label, not a citation. **ELEG-57** audits the rest, which needs read-only probes and a vendor capture rather than a doc copy — parts of it may be empirically right where the reference doc is not.

## What changed

- Per-row 🗑 button, confirmed, sending 1038 with the entry's `task_id`.
- Full refetch via 1036 afterwards, since it takes no paging params.
- Outcome reported through the classifier from ELEG-40, so a busy printer reads as **busy** rather than as a failure.
- **Delegated** click handler, not per-row — the list re-renders on every 1036 response, so per-row listeners would be rebound each time.
- A record with **no `task_id`** gets no button, rather than one that silently does nothing.

## Verification

- `pnpm gates` green — 131 tests.
- **Nothing covers this.** No test exercises the button, the payload, or the refresh; there is no browser test in this repo and the history panel has no test at all. Green gates here mean the code compiles and the rest of the suite still passes — not that delete works.
- What *is* verified is the method number, against the protocol reference and against the internal contradiction above.
- **The command has not been fired.** It destroys data on the printer and is operator work. ELEG-58 has the steps — including the **page reload** check, which is what distinguishes a real delete from a UI that merely stopped rendering the row.