### PR TITLE
docs(agents): treat a method number in an issue as an unchecked claim (ELEG-57)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -104,6 +104,49 @@ and `${DATA_DIR}/state.json` is a real snapshot) rather than hand-writing an ide
 message — the CC2's actual payloads are the thing worth encoding. Strip anything
 identifying before committing a fixture.
 
+## Settling a protocol claim, read-only
+
+Several ELEG issues have been filed against method numbers that turned out not to
+exist, so it is worth writing down how to check one **without touching the machine**.
+
+**`METHOD_NAMES` in `src/ui/log-methods.ts` is a display label, not a citation.** It is
+the most readable list of methods in the repo, which is exactly why wrong numbers got
+copied out of it into issues — ELEG-38 asked for a history delete on 1049 (really
+`UpdateToken`, an auth-token write), ELEG-30 for AI detection on 2010/2011 (neither
+exists), ELEG-32 for OTA on 1064 (really 1039). It also contradicted itself, listing
+both 1038 and 1049 as history delete. ELEG-57 audits it.
+
+The citable sources are `data/CC2_PROTOCOL_REFERENCE.md` (transcribed from the official
+app, with the full method table, the `hh` error-code enum and per-method payloads) and
+`data/CC2-OFFICIAL-APP-PATTERNS.md`. When those two agree, that is usually enough. When
+they disagree with the running code — and they do, for 1062 and the 2006/2007 pair —
+neither wins on authority, because the reference may describe a different firmware.
+
+Then a **`Get…` method can simply be asked**, which is a read and therefore allowed:
+
+```bash
+# From the repo root, so `ws` resolves. Sends one Get and prints the reply.
+node -e "
+import('ws').then(({WebSocket}) => {
+  const ws = new WebSocket('ws://localhost:8088/ws');
+  ws.on('open', () => setTimeout(() =>
+    ws.send(JSON.stringify({type:'command', method:1062, params:{}})), 500));
+  ws.on('message', (r) => {
+    const m = JSON.parse(r.toString());
+    if (m.type === 'response' && m.method === 1062) { console.log(JSON.stringify(m.data)); ws.close(); }
+  });
+  setTimeout(() => process.exit(0), 8000);
+});
+"
+```
+
+That is how 1062 was shown to return `{"error_code": 1100}` on this firmware — an
+undocumented code, and the reason `systemInfo` has always been `null` (ELEG-55).
+
+**Only `Get…` methods.** A `Set…` is a write to a physical machine and must never be
+fired to find out what it does; resolve those from a vendor-app capture instead
+(`POST /api/debug/capture` records passively — see ELEG-56 for the shape).
+
 ## Do not test against the printer
 
 This is the repo's hard boundary and it is restated here because "just try it" is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,17 @@ Actions minutes (the private siblings do not, hence their self-hosted runners).
   `include: ["comments","links","attachments"]` before acting on one, and actually
   fetch any attachment. Decisions get recorded as comments; an issue still
   `blockedBy` an open one is not ready to start.
+- **A method number in an issue is a claim, and usually an unchecked one.** Three
+  issues in the ELEG tracker named methods that do not do what they said —
+  history-delete on 1049 (really `UpdateToken`, which writes the printer's *auth
+  token*), AI detection on 2010/2011 (neither exists), OTA on 1064 (really 1039). All
+  three were copied out of `METHOD_NAMES` in `src/ui/log-methods.ts`, which is a
+  **display label for the log viewer, not a citation**, and which contradicted itself
+  by listing 1038 *and* 1049 as history delete. Cite
+  [`data/CC2_PROTOCOL_REFERENCE.md`](data/CC2_PROTOCOL_REFERENCE.md) instead, and where
+  the docs and the running code disagree, settle it by **asking the printer** — a
+  `Get…` is a read and is allowed. `.agents/testing.md` has the one-liner. Never fire a
+  `Set…` to find out what it does.
 - **An issue's stated blocker is a claim, not a fact.** "This needs X", "the firmware
   doesn't expose that", "the printer can't do it" is what someone believed when they
   filed it. Before accepting the scope a blocker implies — and especially before


### PR DESCRIPTION
Partly addresses ELEG-57 — this is the **guidance** half. The table audit itself stays open on ELEG-57, because it needs read-only probes and a vendor capture rather than a doc copy.

## Why

Three issues in the ELEG-40… `/auto` pass named methods that do not do what they claimed:

| Issue | Claimed | Actually |
| --- | --- | --- |
| ELEG-38 | 1049 = history delete | **`UpdateToken`** — writes the printer's auth token |
| ELEG-30 | 2010/2011 = AI detection | neither method exists |
| ELEG-32 | 1064 = OTA | 1039 is `OTAUpgrade` |

All three trace to `METHOD_NAMES` in `src/ui/log-methods.ts` — a display table for the log viewer, which is simply the most readable list of methods in the repo. It also contradicted itself, listing **both** 1038 and 1049 as history delete.

## What this adds

- **`AGENTS.md`** — a convention entry saying a method number in an issue is an unchecked claim, naming the citable source, and pointing at how to settle it.
- **`.agents/testing.md`** — a "Settling a protocol claim, read-only" section with the actual one-liner. A `Get…` method can be asked over the service's own WebSocket, which is a read and therefore allowed. That is how 1062 was shown to return `{"error_code": 1100}` on this firmware — undocumented, and the reason `systemInfo` has always been null (ELEG-55).
- The boundary restated where it now bites: **only `Get…`**. A `Set…` is a write to a physical machine and is resolved from a passive vendor capture (ELEG-56), never from an experiment.

## Verification

- `pnpm gates` green.
- Documentation only — no code changed, and nothing automated checks prose. The commands in the new section are the ones actually run during this pass, not invented for the doc.
- **No printer was commanded.**