### PR TITLE
fix(server): remember the printer SN so a restart cannot hang forever (ELEG-60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ docker run -d -p 8088:8088 -p 7125:7125 -e PRINTER_IP=172.20.100.236 ghcr.io/run
 |----------|---------|-------------|
 | `PRINTER_IP` | `172.20.100.236` | Printer IP address (required) |
 | `PRINTER_PASSWORD` | `123456` | Printer access code |
+| `PRINTER_SN` | — (discovered) | Printer serial number, e.g. `F01U3UD3798YT8K`. Normally discovered automatically and then cached in `<DATA_DIR>/printer-sn.json`, so this is rarely needed. Set it if a **first** start hangs at "registering": the printer only publishes while a client is registered, so a service that has never learned the serial has nothing to overhear |
 | `SERVICE_PORT` | `8088` | Web UI / API / WebSocket port |
 | `MOONRAKER_PORT` | `7125` | Moonraker compatibility API port |
 | `CAMERA_ENABLED` | `true` | Enable camera MJPEG proxy |

--- a/src/server/__tests__/sn-cache.test.ts
+++ b/src/server/__tests__/sn-cache.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { readCachedSn, writeCachedSn, isValidSn, snCachePath } from '../sn-cache.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sn-cache-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const REAL_SN = 'F01U3UD3798YT8K';
+
+describe('isValidSn', () => {
+  it('accepts a real CC2 serial', () => {
+    expect(isValidSn(REAL_SN)).toBe(true);
+  });
+
+  it('rejects anything with MQTT topic metacharacters', () => {
+    // The SN is interpolated straight into topic filters. A stray `#` would subscribe
+    // to the whole broker; a `/` would silently address the wrong topic level.
+    for (const bad of ['#', 'F01/#', 'a/b', 'sn#', '+', 'a+b']) {
+      expect(isValidSn(bad), `${bad} must be rejected`).toBe(false);
+    }
+  });
+
+  it('rejects empty, short and non-string values', () => {
+    for (const bad of ['', 'ab', null, undefined, 42, {}, []]) {
+      expect(isValidSn(bad)).toBe(false);
+    }
+  });
+});
+
+describe('readCachedSn', () => {
+  it('returns empty when no cache exists, which is a normal first start', () => {
+    expect(readCachedSn(dir)).toBe('');
+  });
+
+  it('round-trips a written SN', () => {
+    writeCachedSn(dir, REAL_SN);
+    expect(readCachedSn(dir)).toBe(REAL_SN);
+  });
+
+  it('returns empty rather than throwing on malformed JSON', () => {
+    writeFileSync(snCachePath(dir), 'not json at all', 'utf-8');
+    expect(readCachedSn(dir)).toBe('');
+  });
+
+  it('returns empty for the wrong shape', () => {
+    for (const body of ['{}', '[]', 'null', '{"sn": 42}', '{"serial":"X"}']) {
+      writeFileSync(snCachePath(dir), body, 'utf-8');
+      expect(readCachedSn(dir), body).toBe('');
+    }
+  });
+
+  it('refuses a cached SN that would poison a topic filter', () => {
+    // A hand-edited or corrupt file must not reach the subscribe call.
+    writeFileSync(snCachePath(dir), JSON.stringify({ sn: 'F01/#' }), 'utf-8');
+    expect(readCachedSn(dir)).toBe('');
+  });
+});
+
+describe('writeCachedSn', () => {
+  it('does not write an invalid SN', () => {
+    writeCachedSn(dir, 'a/b');
+    expect(readCachedSn(dir)).toBe('');
+  });
+
+  it('overwrites a previous SN, so swapping printers settles', () => {
+    writeCachedSn(dir, REAL_SN);
+    writeCachedSn(dir, 'F02NEWPRINTER01');
+    expect(readCachedSn(dir)).toBe('F02NEWPRINTER01');
+  });
+
+  it('stores it under an `sn` key, which is what readCachedSn expects', () => {
+    writeCachedSn(dir, REAL_SN);
+    expect(JSON.parse(readFileSync(snCachePath(dir), 'utf-8'))).toEqual({ sn: REAL_SN });
+  });
+
+  it('does not throw when the directory does not exist', () => {
+    // A read-only or missing data dir must cost one discovery cycle, never a crash.
+    expect(() => writeCachedSn(join(dir, 'nope'), REAL_SN)).not.toThrow();
+  });
+});

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -6,6 +6,12 @@ export interface ServiceConfig {
   // Printer
   printerIp: string;
   printerPassword: string;
+  /**
+   * Optional serial-number override. Normally discovered and then cached, but a
+   * printer that is silent at startup can never be discovered — so this lets a first
+   * start register immediately (ELEG-60). Empty means "discover it".
+   */
+  printerSn: string;
 
   // Service
   servicePort: number;
@@ -96,6 +102,7 @@ export function loadConfig(): ServiceConfig {
   return {
     printerIp,
     printerPassword: env('PRINTER_PASSWORD', '123456'),
+    printerSn: env('PRINTER_SN', '').trim(),
     servicePort,
     cameraEnabled: env('CAMERA_ENABLED') !== 'false',
     cameraUrl: env('CAMERA_URL') || `http://${printerIp}:8080`,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,6 +26,7 @@ import { PrintReportCollector } from './print-report-collector.js';
 import { getBuildInfo } from './build-info.js';
 import { applyCors, corsHeaders } from './cors.js';
 import { initLogger, getLogger } from './logger.js';
+import { readCachedSn, writeCachedSn } from './sn-cache.js';
 
 const config = loadConfig();
 initLogger(config.dataDir);
@@ -35,11 +36,21 @@ const log = getLogger('Service');
 // before the first /api/health request arrives.
 const build = getBuildInfo();
 
+// --- MQTT Bridge (singleton connection to printer) ---
+// A remembered SN turns "wait for the printer to say something" into "register now".
+// Without it a restart can hang in broker_only indefinitely (ELEG-60).
+const knownSn = config.printerSn || readCachedSn(config.dataDir);
+const bridge = new MqttBridge(config.printerIp, config.printerPassword, knownSn, (sn) =>
+  writeCachedSn(config.dataDir, sn),
+);
+
 log.info('🖨  Elegoo CC2 Service');
 log.info(
   `Build:   ${build.describe ?? build.shortCommit ?? 'unstamped (not an installed deploy?)'}`,
 );
-log.info(`Printer: ${config.printerIp}`);
+log.info(
+  `Printer: ${config.printerIp}${knownSn ? ` (SN ${knownSn}${config.printerSn ? ', from PRINTER_SN' : ', cached'})` : ' (SN not yet known)'}`,
+);
 log.info(`Service: http://0.0.0.0:${config.servicePort}`);
 log.info(`Camera:  ${config.cameraEnabled ? config.cameraUrl : 'disabled'}`);
 log.info(`Data:    ${config.dataDir}`);
@@ -52,9 +63,6 @@ if (config.aiEnabled) {
   );
 }
 log.info(`Moonraker: http://0.0.0.0:${config.moonrakerPort}`);
-
-// --- MQTT Bridge (singleton connection to printer) ---
-const bridge = new MqttBridge(config.printerIp, config.printerPassword);
 
 // --- State Store (shared state for all consumers) ---
 const store = new StateStore(bridge, config.progressInterval);

--- a/src/server/mqtt-bridge.ts
+++ b/src/server/mqtt-bridge.ts
@@ -35,13 +35,22 @@ export class MqttBridge extends EventEmitter {
   private _registerAttempts = 0;
   private heartbeatMissed = 0;
 
+  /**
+   * @param initialSn Serial number already known from config or the cache. When set,
+   *   registration starts on the first broker connect instead of waiting to overhear a
+   *   message the printer will not send while nothing is registered (ELEG-60).
+   * @param onSnLearned Called when an SN is discovered, so the caller can remember it.
+   */
   constructor(
     private printerIp: string,
     private password: string,
+    initialSn = '',
+    private onSnLearned?: (sn: string) => void,
   ) {
     super();
     this.clientId = this.generateId(10);
     this.requestId = this.generateId(26);
+    this.sn = initialSn;
   }
 
   private generateId(len: number): string {
@@ -84,8 +93,16 @@ export class MqttBridge extends EventEmitter {
       this._brokerConnected = true;
       // Subscribe broadly for SN discovery — printer may not publish
       // api_status until a client registers, so catch any elegoo topic
+      // Still subscribed broadly even when the SN is known: it is the fallback if the
+      // remembered SN is stale because the printer was swapped.
       this.client!.subscribe('elegoo/#', { qos: 1 });
-      if (this.sn) this.register();
+      if (this.sn) {
+        log.info(`Registering with known SN ${this.sn}...`);
+        this.register();
+      } else {
+        log.info('No known SN — waiting for the printer to publish. This can hang if the');
+        log.info('printer is idle and nothing is registered; set PRINTER_SN to skip it.');
+      }
     });
 
     this.client.on('message', (topic: string, payload: Buffer) => {
@@ -126,6 +143,7 @@ export class MqttBridge extends EventEmitter {
       if (parts.length >= 3 && parts[1].length > 0) {
         this.sn = parts[1];
         log.info(`Discovered printer SN: ${this.sn}`);
+        this.onSnLearned?.(this.sn);
         this.client!.unsubscribe('elegoo/#');
         this.register();
       }

--- a/src/server/sn-cache.ts
+++ b/src/server/sn-cache.ts
@@ -1,0 +1,67 @@
+/**
+ * Remember the printer's serial number across restarts (ELEG-60).
+ *
+ * `MqttBridge` can only learn the SN by overhearing an inbound `elegoo/<sn>/...`
+ * message — but the printer only publishes while a client is registered. So after a
+ * clean shutdown the printer goes quiet, a freshly started service has nothing to
+ * overhear, and registration is never even attempted. The service sits in
+ * `broker_only` until something else provokes the printer into talking.
+ *
+ * That is not theoretical. On 2026-08-08 two consecutive restarts of the same unit
+ * against the same healthy printer took **27 minutes** and **never**.
+ *
+ * So the SN is written down the first time it is learned, and read back at startup.
+ *
+ * Deliberately a tiny file of its own rather than a field in `state.json`: that one is
+ * loaded asynchronously and holds chart history, while this has to be available
+ * synchronously before the first broker connect, and losing it must never cost more
+ * than one discovery cycle.
+ *
+ * Every failure — missing, unreadable, malformed, empty — degrades to "unknown", which
+ * is exactly the pre-ELEG-60 behaviour. It can slow a start down; it cannot break one.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { getLogger } from './logger.js';
+
+const log = getLogger('MQTT');
+
+const FILE = 'printer-sn.json';
+
+/**
+ * A CC2 serial looks like `F01U3UD3798YT8K`. Validated rather than trusted because it
+ * is interpolated straight into MQTT topic filters — a stray `#` or `/` from a corrupt
+ * file would silently subscribe to the wrong thing.
+ */
+const SN_RE = /^[A-Za-z0-9_-]{4,64}$/;
+
+export function isValidSn(value: unknown): value is string {
+  return typeof value === 'string' && SN_RE.test(value);
+}
+
+export function snCachePath(dataDir: string): string {
+  return join(dataDir, FILE);
+}
+
+/** The remembered SN, or `''` if there is not a usable one. Never throws. */
+export function readCachedSn(dataDir: string): string {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(snCachePath(dataDir), 'utf-8'));
+    const sn = (parsed as { sn?: unknown } | null)?.sn;
+    return isValidSn(sn) ? sn : '';
+  } catch {
+    // Absent on a first-ever start, which is normal and not worth a warning.
+    return '';
+  }
+}
+
+/** Remember an SN. Never throws — a read-only data dir must not break registration. */
+export function writeCachedSn(dataDir: string, sn: string): void {
+  if (!isValidSn(sn)) return;
+  try {
+    writeFileSync(snCachePath(dataDir), JSON.stringify({ sn }), 'utf-8');
+  } catch (err) {
+    log.warn(`Could not cache printer SN: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}


### PR DESCRIPTION
Closes ELEG-60. Found by diagnosing a live incident: the service came up after a deploy and never connected, with a healthy printer throughout.

## The bug

`MqttBridge` could only learn the serial by **overhearing** an inbound `elegoo/<sn>/…` message:

```ts
private sn = '';                                // never restored, never configured
this.client.subscribe('elegoo/#', { qos: 1 });  // hope the printer says something
if (this.sn) this.register();                   // always false on a fresh process
```

**The printer only publishes while a client is registered.** After a clean shutdown it goes quiet, so a fresh process has nothing to overhear, never learns the SN, and therefore **never calls `register()` at all**. It sits in `broker_only` — with no error line, because no registration was ever attempted. The absence of a log was the only symptom.

## Evidence

Two consecutive restarts of the same unit, same printer, same day:

| Restart | Broker connected | SN discovered | Gap |
| --- | --- | --- | --- |
| 11:28:40 | 11:28:40 | 11:56:01 | **27 min 21 s** |
| 16:46:37 | 16:46:37 | never | **stuck** |

The printer was fine on both sides: persisted chart data has one point per second **up to 16:46:10**, 25 s before the service stopped. After the restart — ping 2 ms, broker accepting connections, camera streaming, and **zero** MQTT messages in 20 s.

So the 11:28 restart recovered by luck, and nobody noticed because nothing reported the wait.

## The fix

- SN written to `<DATA_DIR>/printer-sn.json` the first time it is learned, read back at startup.
- **`PRINTER_SN`** env override, for a first-ever start that has nothing cached.
- When an SN is known, **register on the first broker connect** rather than waiting.
- The broad `elegoo/#` subscribe stays as the fallback for a swapped printer.
- Startup banner and log now say which SN is in use and where it came from, and the no-SN path says out loud that it may hang and how to skip it.

**Its own small file, not a field in `state.json`** — that one loads asynchronously and carries chart history, while this must be readable synchronously before the first connect, and losing it must cost no more than one discovery cycle. Every failure mode degrades to the pre-fix behaviour.

**The cached value is validated before use.** It is interpolated straight into MQTT topic filters, so a stray `#` from a corrupt or hand-edited file would subscribe to the entire broker.

## Verification

- `pnpm gates` green — 143 tests.
- **Covered by tests**: `src/server/__tests__/sn-cache.test.ts`, 12 tests — round-trip, missing file, malformed JSON, wrong shape, invalid-SN rejection on both read and write, overwrite-on-swap, and a missing data dir not throwing.
- **Proved load-bearing**: relaxing the read-side validation to a bare `typeof === 'string'` turns *"refuses a cached SN that would poison a topic filter"* red. Reverted with an inverse patch.
- **Not covered**: the bridge wiring itself — `MqttBridge` has no test, and the end-to-end proof is a restart that reconnects in seconds instead of never. That needs a deploy, which is operator work.
- **No printer was commanded.** The diagnosis used read-only probes and the service's own WebSocket feed.

## Deploying this

The cache is empty on first run, so the very first start after this deploy still has nothing to read. Either set `PRINTER_SN=F01U3UD3798YT8K` in `.env` before restarting, or let it discover once — after which every subsequent restart is instant.