### PR TITLE
feat(ui): sortable, filterable Files list and a shared helper for the other three (ELEG-49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ Actions minutes (the private siblings do not, hence their self-hosted runners).
   from './config.js'` — the extension is required, not decorative: production runs
   the TypeScript **directly** under `node --import tsx`, so the specifier has to be
   the one Node resolves. Dropping the `.js` works in vite and breaks the service.
+  **The rule bites on the half that Node executes.** In practice the tree is a clean
+  split — every relative import under `src/server/**` and `src/telegram/**` carries
+  `.js`, and every one in the vite-bundled browser half (`src/main.ts`, `src/ui/**`,
+  `src/types.ts`) is extensionless, which `moduleResolution: "bundler"` accepts. Match
+  the half you are editing rather than "fixing" 120 frontend imports.
 - **There are three tsconfigs and CI only checks one of them.** `tsconfig.json`
   covers the browser half and **excludes `src/server` and `src/telegram`**;
   `tsconfig.server.json` covers those (via `pnpm service:check`). `pnpm build` runs

--- a/index.html
+++ b/index.html
@@ -502,6 +502,9 @@
             <div class="upload-progress-bar"><div class="upload-progress-fill" id="upload-progress-fill"></div></div>
             <span id="upload-progress-text">Uploading...</span>
           </div>
+          <!-- Sibling of the list, not inside it: #file-list is replaced wholesale on
+               every render, and a filter input inside it would lose focus mid-typing. -->
+          <div id="file-list-controls"></div>
           <div id="file-list" class="file-list">
             <div class="loading">Loading...</div>
           </div>

--- a/src/__tests__/list-sort.test.ts
+++ b/src/__tests__/list-sort.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type SortColumn,
+  compareValues,
+  directionIndicator,
+  filterItems,
+  matchesQuery,
+  nextSortState,
+  normaliseSortState,
+  sortItems,
+} from '../ui/list-sort';
+
+interface Row {
+  name: string;
+  size?: number;
+  folder?: boolean;
+}
+
+const byName: SortColumn<Row> = { key: 'name', label: 'Name', value: (r) => r.name };
+const bySize: SortColumn<Row> = {
+  key: 'size',
+  label: 'Size',
+  value: (r) => r.size,
+  initialDirection: 'desc',
+};
+
+describe('compareValues', () => {
+  it('orders numbers numerically, not lexically', () => {
+    expect(compareValues(9, 10)).toBeLessThan(0);
+    expect(compareValues(10, 9)).toBeGreaterThan(0);
+    expect(compareValues(5, 5)).toBe(0);
+  });
+
+  it('orders strings case-insensitively via localeCompare', () => {
+    expect(compareValues('apple', 'Banana')).toBeLessThan(0);
+    expect(compareValues('b', 'a')).toBeGreaterThan(0);
+  });
+
+  it('puts missing values last, and treats an empty string as missing', () => {
+    expect(compareValues(undefined, 3)).toBeGreaterThan(0);
+    expect(compareValues(3, undefined)).toBeLessThan(0);
+    expect(compareValues(undefined, undefined)).toBe(0);
+    expect(compareValues('', 'a')).toBeGreaterThan(0);
+  });
+});
+
+describe('sortItems', () => {
+  it('sorts ascending and descending by the named column', () => {
+    const rows: Row[] = [{ name: 'b' }, { name: 'c' }, { name: 'a' }];
+    expect(sortItems(rows, byName, 'asc').map((r) => r.name)).toEqual(['a', 'b', 'c']);
+    expect(sortItems(rows, byName, 'desc').map((r) => r.name)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('does not mutate the input', () => {
+    const rows: Row[] = [{ name: 'b' }, { name: 'a' }];
+    sortItems(rows, byName, 'asc');
+    expect(rows.map((r) => r.name)).toEqual(['b', 'a']);
+  });
+
+  it('keeps ties in arrival order, so a re-render does not reshuffle equal rows', () => {
+    const rows: Row[] = [
+      { name: 'first', size: 5 },
+      { name: 'second', size: 5 },
+      { name: 'third', size: 5 },
+    ];
+    expect(sortItems(rows, bySize, 'asc').map((r) => r.name)).toEqual(['first', 'second', 'third']);
+    // Reversing direction must not reverse the tiebreak either.
+    expect(sortItems(rows, bySize, 'desc').map((r) => r.name)).toEqual([
+      'first',
+      'second',
+      'third',
+    ]);
+  });
+
+  it('keeps missing values last in BOTH directions', () => {
+    const rows: Row[] = [{ name: 'a', size: 1 }, { name: 'b' }, { name: 'c', size: 3 }];
+    expect(sortItems(rows, bySize, 'asc').map((r) => r.name)).toEqual(['a', 'c', 'b']);
+    expect(sortItems(rows, bySize, 'desc').map((r) => r.name)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('holds the group ahead of the sort column, in both directions', () => {
+    const rows: Row[] = [
+      { name: 'zebra.gcode', size: 9 },
+      { name: 'alpha', folder: true },
+      { name: 'beta.gcode', size: 1 },
+      { name: 'omega', folder: true },
+    ];
+    const group = (r: Row) => (r.folder ? 0 : 1);
+
+    const asc = sortItems(rows, byName, 'asc', { group });
+    expect(asc.map((r) => r.name)).toEqual(['alpha', 'omega', 'beta.gcode', 'zebra.gcode']);
+
+    // Descending flips the names but folders are still the first two — the grouping is
+    // not a sort key and must survive a direction change.
+    const desc = sortItems(rows, byName, 'desc', { group });
+    expect(desc.map((r) => r.name)).toEqual(['omega', 'alpha', 'zebra.gcode', 'beta.gcode']);
+    expect(desc.slice(0, 2).every((r) => r.folder)).toBe(true);
+
+    // And it survives a change of column, too.
+    const bySizeDesc = sortItems(rows, bySize, 'desc', { group });
+    expect(bySizeDesc.slice(0, 2).every((r) => r.folder)).toBe(true);
+  });
+
+  it('returns a plain copy when there is no column and no group', () => {
+    const rows: Row[] = [{ name: 'b' }, { name: 'a' }];
+    expect(sortItems(rows, undefined, 'asc').map((r) => r.name)).toEqual(['b', 'a']);
+  });
+});
+
+describe('matchesQuery', () => {
+  it('matches case-insensitively on a substring', () => {
+    expect(matchesQuery('BENCH', 'benchy_v2.gcode')).toBe(true);
+    expect(matchesQuery('chy_v', 'benchy_v2.gcode')).toBe(true);
+    expect(matchesQuery('cube', 'benchy_v2.gcode')).toBe(false);
+  });
+
+  it('treats an empty or whitespace-only query as no filter', () => {
+    expect(matchesQuery('', 'anything')).toBe(true);
+    expect(matchesQuery('   ', 'anything')).toBe(true);
+  });
+});
+
+describe('filterItems', () => {
+  const rows: Row[] = [{ name: 'benchy.gcode' }, { name: 'cube.gcode' }, { name: 'Bench_plate' }];
+
+  it('keeps only matching rows', () => {
+    expect(filterItems(rows, 'bench', (r) => r.name).map((r) => r.name)).toEqual([
+      'benchy.gcode',
+      'Bench_plate',
+    ]);
+  });
+
+  it('returns a copy of everything for an empty query', () => {
+    const out = filterItems(rows, '  ', (r) => r.name);
+    expect(out).toHaveLength(3);
+    expect(out).not.toBe(rows);
+  });
+
+  it('keeps a row when any of several fields matches', () => {
+    const out = filterItems(rows, 'plate', (r) => [r.name, r.folder ? 'folder' : 'file']);
+    expect(out.map((r) => r.name)).toEqual(['Bench_plate']);
+  });
+});
+
+describe('nextSortState', () => {
+  it('toggles direction when the same column is clicked again', () => {
+    expect(nextSortState({ key: 'name', dir: 'asc' }, byName)).toEqual({
+      key: 'name',
+      dir: 'desc',
+    });
+    expect(nextSortState({ key: 'name', dir: 'desc' }, byName)).toEqual({
+      key: 'name',
+      dir: 'asc',
+    });
+  });
+
+  it('adopts the new column initial direction when switching columns', () => {
+    expect(nextSortState({ key: 'name', dir: 'desc' }, bySize)).toEqual({
+      key: 'size',
+      dir: 'desc',
+    });
+    expect(nextSortState({ key: 'size', dir: 'desc' }, byName)).toEqual({
+      key: 'name',
+      dir: 'asc',
+    });
+  });
+});
+
+describe('normaliseSortState', () => {
+  const fallback = { key: 'name', dir: 'asc' } as const;
+  const keys = ['name', 'size'];
+
+  it('accepts a stored state whose column still exists', () => {
+    expect(normaliseSortState({ key: 'size', dir: 'desc' }, keys, fallback)).toEqual({
+      key: 'size',
+      dir: 'desc',
+    });
+  });
+
+  it('falls back when the stored column has been removed or renamed', () => {
+    expect(normaliseSortState({ key: 'gone', dir: 'desc' }, keys, fallback)).toEqual(fallback);
+  });
+
+  it('survives junk in storage', () => {
+    expect(normaliseSortState(null, keys, fallback)).toEqual(fallback);
+    expect(normaliseSortState('nonsense', keys, fallback)).toEqual(fallback);
+    expect(normaliseSortState({}, keys, fallback)).toEqual(fallback);
+  });
+
+  it('defaults an unrecognised direction to ascending', () => {
+    expect(normaliseSortState({ key: 'size', dir: 'sideways' }, keys, fallback)).toEqual({
+      key: 'size',
+      dir: 'asc',
+    });
+  });
+
+  it('returns a fresh object so the caller cannot mutate the default', () => {
+    const out = normaliseSortState(null, keys, fallback);
+    expect(out).not.toBe(fallback);
+  });
+});
+
+describe('directionIndicator', () => {
+  it('distinguishes the two directions', () => {
+    expect(directionIndicator('asc')).not.toBe(directionIndicator('desc'));
+  });
+});

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4219,3 +4219,63 @@ body {
   font-size: 13px;
   min-width: 120px;
 }
+
+/* Shared list sort/filter control bar (ELEG-49). Used by Files, Print History,
+   Print Reports and Timelapse. Always a *sibling* of the list it controls, never
+   inside it — the lists are replaced wholesale on every render. */
+.list-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 0 8px;
+}
+.list-controls .list-filter {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  flex: 1 1 140px;
+  min-width: 120px;
+}
+.list-controls .list-select {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  padding: 4px 8px;
+  font-size: 0.8rem;
+}
+.list-sort {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.list-sort-btn {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.list-sort-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-light);
+}
+.list-sort-btn.active {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.list-count {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-left: auto;
+  white-space: nowrap;
+}

--- a/src/ui/files.ts
+++ b/src/ui/files.ts
@@ -11,6 +11,7 @@ import {
   THUMBNAIL_PLACEHOLDER_SRC,
 } from './helpers';
 import { requestPrintDialog } from './print-dialog';
+import { type ListControls, createListControls } from './list-controls';
 
 let currentSource: 'local' | 'u-disk' = 'local';
 let currentDir = '/';
@@ -503,10 +504,45 @@ export function handleThumbnailResponse(thumbnail: string | null): void {
   }
 }
 
+/**
+ * Sort and filter controls (ELEG-49). Created lazily on the first render because the
+ * card may be hidden at startup, and once only — the bar lives in `#file-list-controls`,
+ * a static sibling of `#file-list`, so nothing here is touched when the list repaints.
+ */
+let fileControls: ListControls<FileEntry> | null = null;
+
+function ensureFileControls(): ListControls<FileEntry> {
+  if (fileControls) return fileControls;
+  fileControls = createListControls<FileEntry>({
+    id: 'files',
+    container: $('file-list-controls'),
+    noun: 'files',
+    filterPlaceholder: 'Filter files…',
+    filterText: (file) => file.filename,
+    // Folders first is a *grouping*, not a sort key: it holds whichever column is
+    // active and in both directions, which is why it is not just another comparator.
+    group: (file) => (file.type === 'folder' ? 0 : 1),
+    columns: [
+      { key: 'name', label: 'Name', value: (f) => f.filename },
+      { key: 'size', label: 'Size', value: (f) => f.size, initialDirection: 'desc' },
+      { key: 'time', label: 'Print time', value: (f) => f.print_time, initialDirection: 'desc' },
+      { key: 'layers', label: 'Layers', value: (f) => f.layer, initialDirection: 'desc' },
+      { key: 'created', label: 'Added', value: (f) => f.create_time, initialDirection: 'desc' },
+    ],
+    defaultSort: { key: 'name', dir: 'asc' },
+    onChange: () => {
+      if (_lastState && _popoverClient) renderFiles(_lastState, _popoverClient);
+    },
+  });
+  return fileControls;
+}
+
 export function renderFiles(state: PrinterState, client: CommandSender): void {
   _lastState = state;
+  _popoverClient = client;
   const container = $('file-list');
   const files = state.files;
+  const controls = ensureFileControls();
 
   let html = renderCapacityBar(state);
 
@@ -517,20 +553,18 @@ export function renderFiles(state: PrinterState, client: CommandSender): void {
 
   html += renderBreadcrumb(client);
 
-  if (!files.length) {
-    html += `<div class="file-empty">No files ${currentDir === '/' ? '' : 'in this folder '}on ${currentSource === 'u-disk' ? 'USB drive' : 'printer'}</div>`;
+  // Sorted client-side over the whole listing: 1044 returns the directory in one
+  // response and offers no ordering, so there is no server-side sort to ask for.
+  const sorted = controls.apply(files);
+
+  if (!sorted.length) {
+    html += controls.emptyHtml(
+      `No files ${currentDir === '/' ? '' : 'in this folder '}on ${currentSource === 'u-disk' ? 'USB drive' : 'printer'}`,
+    );
     container.innerHTML = html;
     ensureFileDelegation(container);
-    _popoverClient = client;
     return;
   }
-
-  // Sort: folders first, then by name
-  const sorted = [...files].sort((a, b) => {
-    if (a.type === 'folder' && b.type !== 'folder') return -1;
-    if (a.type !== 'folder' && b.type === 'folder') return 1;
-    return a.filename.localeCompare(b.filename);
-  });
 
   for (const file of sorted) {
     const isFolder = file.type === 'folder';
@@ -589,7 +623,6 @@ export function renderFiles(state: PrinterState, client: CommandSender): void {
 
   // Build file map for popover lookups
   _fileMap = new Map(sorted.filter((f) => f.type !== 'folder').map((f) => [f.filename, f]));
-  _popoverClient = client;
 
   // Close any stale popover from previous render
   closeFilePopover();

--- a/src/ui/list-controls.ts
+++ b/src/ui/list-controls.ts
@@ -1,0 +1,194 @@
+/**
+ * List control bar — the DOM half of the shared sort/filter helper (ELEG-49).
+ *
+ * The pure decisions live in `list-sort.ts`; this owns the markup, the events and the
+ * persistence. Adopted by Files, Print History, Print Reports and Timelapse.
+ *
+ * **The control bar is mounted once and never re-rendered wholesale.** That is the whole
+ * design, and it is what makes the trap ELEG-22 names impossible here: these views
+ * re-render on every WebSocket message, so a filter input rebuilt as part of the render
+ * would lose focus and selection under anyone typing while a 1036 response lands. The
+ * bar therefore lives in a *static* container that is a sibling of the list, sort/filter
+ * state lives in this closure rather than in the render function, and the only thing a
+ * re-render touches is the list itself. Clicking a sort button repaints the buttons
+ * alone — never the input.
+ */
+
+import {
+  type SortColumn,
+  type SortDirection,
+  type SortState,
+  directionIndicator,
+  filterItems,
+  nextSortState,
+  normaliseSortState,
+  sortItems,
+} from './list-sort';
+import { escapeAttr, escapeHtml } from './helpers';
+import { getListSelect, getListSort, saveListSelect, saveListSort } from './ui-settings';
+
+/** A dropdown filter, e.g. Print History's completed / failed / stopped. */
+export interface SelectFilter<T> {
+  /** Stable id — persisted under the view's key. */
+  id: string;
+  label: string;
+  /** `all` is supplied automatically as the first option and means "no filtering". */
+  options: ReadonlyArray<{ value: string; label: string }>;
+  /** Called only when the selection is not `all`. */
+  match: (item: T, value: string) => boolean;
+}
+
+export interface ListControlsOptions<T> {
+  /** Stable id for this view — the persistence key and the DOM id prefix. */
+  id: string;
+  /** A **static** element that the render pass never overwrites. */
+  container: HTMLElement;
+  columns: ReadonlyArray<SortColumn<T>>;
+  defaultSort: SortState;
+  /** Searchable text per row; a match in any returned string keeps the row. */
+  filterText: (item: T) => string | readonly string[];
+  filterPlaceholder?: string;
+  selects?: ReadonlyArray<SelectFilter<T>>;
+  /** Grouping rank applied before the sort column and never reversed (folders first). */
+  group?: (item: T) => number;
+  /** The view re-renders itself from its own state; this just says "something changed". */
+  onChange: () => void;
+  /** Noun for the count readout, e.g. `files`. Defaults to `items`. */
+  noun?: string;
+}
+
+export interface ListControls<T> {
+  /** Filter, then sort. Also updates the "n of m" readout. */
+  apply(items: readonly T[]): T[];
+  /** True when a text query or a non-`all` dropdown is narrowing the list. */
+  isFiltering(): boolean;
+  /**
+   * The empty-state HTML to show for an empty *result*. A filtered-to-nothing list says
+   * "narrow your filter"; an empty source list says the caller's own message, which is a
+   * different fact and needs different words.
+   */
+  emptyHtml(noDataMessage: string): string;
+}
+
+/** Debounced, because Files kicks off thumbnail and cache fetches on every render. */
+const FILTER_DEBOUNCE_MS = 150;
+
+export function createListControls<T>(options: ListControlsOptions<T>): ListControls<T> {
+  const { id, container, columns, filterText, group, onChange } = options;
+  const keys = columns.map((c) => c.key);
+
+  let sort: SortState = normaliseSortState(getListSort(id), keys, options.defaultSort);
+  let query = '';
+  const selectValues = new Map<string, string>();
+  for (const select of options.selects ?? []) {
+    selectValues.set(select.id, getListSelect(`${id}.${select.id}`) ?? 'all');
+  }
+
+  container.classList.add('list-controls');
+  container.innerHTML = `
+    <input type="search" class="list-filter" id="${escapeAttr(id)}-filter"
+           placeholder="${escapeAttr(options.filterPlaceholder ?? 'Filter…')}"
+           aria-label="${escapeAttr(options.filterPlaceholder ?? 'Filter list')}">
+    ${(options.selects ?? [])
+      .map(
+        (select) => `<select class="list-select" id="${escapeAttr(`${id}-${select.id}`)}"
+             aria-label="${escapeAttr(select.label)}">
+        <option value="all">${escapeHtml(select.label)}: all</option>
+        ${select.options
+          .map(
+            (opt) =>
+              `<option value="${escapeAttr(opt.value)}">${escapeHtml(select.label)}: ${escapeHtml(opt.label)}</option>`,
+          )
+          .join('')}
+      </select>`,
+      )
+      .join('')}
+    <div class="list-sort" role="group" aria-label="Sort by"></div>
+    <span class="list-count" aria-live="polite"></span>`;
+
+  const filterInput = container.querySelector('.list-filter') as HTMLInputElement;
+  const sortWrap = container.querySelector('.list-sort') as HTMLElement;
+  const countEl = container.querySelector('.list-count') as HTMLElement;
+
+  /** Repaints the sort buttons only — deliberately not the input above them. */
+  function renderSortButtons(): void {
+    sortWrap.innerHTML = columns
+      .map((column) => {
+        const active = column.key === sort.key;
+        const arrow = active ? ` ${directionIndicator(sort.dir)}` : '';
+        return `<button type="button" class="list-sort-btn${active ? ' active' : ''}"
+          data-key="${escapeAttr(column.key)}"
+          aria-pressed="${active}"
+          title="Sort by ${escapeAttr(column.label)}">${escapeHtml(column.label)}${arrow}</button>`;
+      })
+      .join('');
+  }
+
+  renderSortButtons();
+
+  for (const select of options.selects ?? []) {
+    const el = container.querySelector(`#${CSS.escape(`${id}-${select.id}`)}`) as HTMLSelectElement;
+    el.value = selectValues.get(select.id) ?? 'all';
+    el.addEventListener('change', () => {
+      selectValues.set(select.id, el.value);
+      saveListSelect(`${id}.${select.id}`, el.value);
+      onChange();
+    });
+  }
+
+  sortWrap.addEventListener('click', (event) => {
+    const btn = (event.target as HTMLElement).closest('.list-sort-btn') as HTMLElement | null;
+    if (!btn) return;
+    const column = columns.find((c) => c.key === btn.dataset.key);
+    if (!column) return;
+    sort = nextSortState(sort, column);
+    saveListSort(id, sort);
+    renderSortButtons();
+    onChange();
+  });
+
+  let debounce: ReturnType<typeof setTimeout> | null = null;
+  filterInput.addEventListener('input', () => {
+    query = filterInput.value;
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(onChange, FILTER_DEBOUNCE_MS);
+  });
+
+  function activeSelects(): Array<{ select: SelectFilter<T>; value: string }> {
+    return (options.selects ?? [])
+      .map((select) => ({ select, value: selectValues.get(select.id) ?? 'all' }))
+      .filter((entry) => entry.value !== 'all');
+  }
+
+  function isFiltering(): boolean {
+    return query.trim() !== '' || activeSelects().length > 0;
+  }
+
+  return {
+    apply(items) {
+      let result = filterItems(items, query, filterText);
+      for (const { select, value } of activeSelects()) {
+        result = result.filter((item) => select.match(item, value));
+      }
+      const column = columns.find((c) => c.key === sort.key);
+      result = sortItems(result, column, sort.dir, { group });
+
+      const noun = options.noun ?? 'items';
+      countEl.textContent =
+        items.length === 0
+          ? ''
+          : isFiltering()
+            ? `${result.length} of ${items.length} ${noun}`
+            : `${items.length} ${noun}`;
+      return result;
+    },
+    isFiltering,
+    emptyHtml(noDataMessage) {
+      return isFiltering()
+        ? '<div class="file-empty">Nothing matches your filter. Clear it or try a shorter search.</div>'
+        : `<div class="file-empty">${noDataMessage}</div>`;
+    },
+  };
+}
+
+export type { SortColumn, SortDirection, SortState };

--- a/src/ui/list-sort.ts
+++ b/src/ui/list-sort.ts
@@ -1,0 +1,158 @@
+/**
+ * List sorting and filtering — the pure half (ELEG-49).
+ *
+ * Deliberately free of DOM and localStorage so it can be unit-tested directly (the
+ * vitest environment here is `node`, with no document). `ui/list-controls.ts` owns the
+ * control bar, the storage and the event wiring; everything that decides *what the list
+ * is* lives here.
+ *
+ * All four list views this serves sort **client-side over the full set**. That is not a
+ * shortcut: files come back from 1044 in one shot, and history (1036) takes no paging
+ * parameters at all, so there is no server-side ordering to reach for even if the sets
+ * were large enough to want one.
+ */
+
+export type SortDirection = 'asc' | 'desc';
+
+/** What a single sortable column extracts from a row. */
+export interface SortColumn<T> {
+  /** Stable identifier — persisted, so renaming one resets that view's saved sort. */
+  key: string;
+  /** Button label in the control bar. */
+  label: string;
+  /**
+   * The value to order by. `undefined` sorts last in **both** directions, so a row
+   * missing a timestamp does not lead the list just because you flipped to descending.
+   */
+  value: (item: T) => string | number | undefined;
+  /** Direction applied when this column is first selected. Defaults to `'asc'`. */
+  initialDirection?: SortDirection;
+}
+
+export interface SortState {
+  key: string;
+  dir: SortDirection;
+}
+
+/** A value with nothing to order by — `undefined`, or the empty string. */
+function isMissing(value: string | number | undefined): boolean {
+  return value === undefined || value === '';
+}
+
+/**
+ * Order two extracted values. Strings compare with `localeCompare` (so `ä` lands where a
+ * Norwegian reader expects), numbers numerically, and absent values always last.
+ */
+export function compareValues(
+  a: string | number | undefined,
+  b: string | number | undefined,
+): number {
+  if (isMissing(a) || isMissing(b)) {
+    return isMissing(a) && isMissing(b) ? 0 : isMissing(a) ? 1 : -1;
+  }
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a).localeCompare(String(b));
+}
+
+export interface SortOptions<T> {
+  /**
+   * A grouping rank applied *before* the column and **never** reversed by direction.
+   * This is how Files keeps folders first no matter which column is sorted, or which
+   * way — folders-first is a grouping rule, not a sort key.
+   */
+  group?: (item: T) => number;
+}
+
+/**
+ * Sort a copy of `items` by `column` in `dir`.
+ *
+ * The tiebreak is `Array.prototype.sort`'s stability, which the spec has guaranteed
+ * since ES2019: equal keys compare 0 and keep their arrival order, so a re-render
+ * triggered by a WebSocket update does not reshuffle rows that tie.
+ */
+export function sortItems<T>(
+  items: readonly T[],
+  column: SortColumn<T> | undefined,
+  dir: SortDirection,
+  options: SortOptions<T> = {},
+): T[] {
+  const copy = [...items];
+  const { group } = options;
+  if (!column && !group) return copy;
+
+  const sign = dir === 'desc' ? -1 : 1;
+  return copy.sort((a, b) => {
+    if (group) {
+      const g = group(a) - group(b);
+      if (g !== 0) return g;
+    }
+    if (!column) return 0;
+
+    const av = column.value(a);
+    const bv = column.value(b);
+    // Missing-last is decided *before* the direction is applied, or flipping to
+    // descending would drag every row with no value to the top — a file with no print
+    // time leading the "longest print first" list is not what anyone asked for.
+    if (isMissing(av) || isMissing(bv)) return compareValues(av, bv);
+
+    return sign * compareValues(av, bv);
+  });
+}
+
+/** Case-insensitive substring match. An empty or whitespace-only query matches everything. */
+export function matchesQuery(query: string, text: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  return text.toLowerCase().includes(needle);
+}
+
+/**
+ * Keep the rows whose searchable text matches `query`. `text` may return several
+ * strings per row (filename *and* job name, say) — a match in any of them keeps the row.
+ */
+export function filterItems<T>(
+  items: readonly T[],
+  query: string,
+  text: (item: T) => string | readonly string[],
+): T[] {
+  if (!query.trim()) return [...items];
+  return items.filter((item) => {
+    const fields = text(item);
+    const list = typeof fields === 'string' ? [fields] : fields;
+    return list.some((field) => matchesQuery(query, field));
+  });
+}
+
+/**
+ * What clicking a column does: a different column adopts its own initial direction, the
+ * same column toggles. Pure, so the control bar has no branching of its own.
+ */
+export function nextSortState<T>(current: SortState, column: SortColumn<T>): SortState {
+  if (current.key !== column.key) {
+    return { key: column.key, dir: column.initialDirection ?? 'asc' };
+  }
+  return { key: current.key, dir: current.dir === 'asc' ? 'desc' : 'asc' };
+}
+
+/**
+ * Turn whatever was in storage into a sort state that is safe to apply. A saved key for
+ * a column that no longer exists falls back to the default rather than leaving the list
+ * unsorted with a control bar that highlights nothing.
+ */
+export function normaliseSortState(
+  parsed: unknown,
+  validKeys: readonly string[],
+  fallback: SortState,
+): SortState {
+  if (typeof parsed !== 'object' || parsed === null) return { ...fallback };
+  const fields = parsed as Record<string, unknown>;
+  const key = typeof fields.key === 'string' && validKeys.includes(fields.key) ? fields.key : null;
+  if (!key) return { ...fallback };
+  const dir = fields.dir === 'desc' ? 'desc' : 'asc';
+  return { key, dir };
+}
+
+/** The arrow shown on the active column's button. */
+export function directionIndicator(dir: SortDirection): string {
+  return dir === 'asc' ? '↑' : '↓';
+}

--- a/src/ui/ui-settings.ts
+++ b/src/ui/ui-settings.ts
@@ -17,6 +17,10 @@ export interface UISettings {
   logTab: string;
   /** Theme choice: 'auto' follows the OS, 'dark'/'light' override it (ELEG-34) */
   theme: string;
+  /** Per-list sort choice, keyed by the list's control id (ELEG-49) */
+  listSort: Record<string, { key: string; dir: string }>;
+  /** Per-list dropdown filter selections, keyed by `<listId>.<selectId>` (ELEG-49) */
+  listSelect: Record<string, string>;
 }
 
 const defaults: UISettings = {
@@ -27,6 +31,8 @@ const defaults: UISettings = {
   slogMethod: 'all',
   logTab: 'structured',
   theme: 'auto',
+  listSort: {},
+  listSelect: {},
 };
 
 let cached: UISettings | null = null;
@@ -67,4 +73,36 @@ export function saveChartWindow(canvasId: string, seconds: number): void {
 /** Get saved chart window or undefined for default */
 export function getChartWindow(canvasId: string): number | undefined {
   return loadUISettings().chartWindows[canvasId];
+}
+
+/**
+ * Save one list view's sort choice (ELEG-49).
+ *
+ * Sort lives here rather than in `persistence.ts`, which the parent issue pointed at:
+ * that key holds chart and layer data for the *current print* and is cleared when the
+ * print changes, so a sort preference stored there would quietly evaporate.
+ */
+export function saveListSort(listId: string, sort: { key: string; dir: string }): void {
+  const s = loadUISettings();
+  const listSort = s.listSort ?? {};
+  listSort[listId] = sort;
+  saveUISettings({ listSort });
+}
+
+/** Get a saved list sort, or undefined — the caller supplies and validates the default. */
+export function getListSort(listId: string): unknown {
+  return loadUISettings().listSort?.[listId];
+}
+
+/** Save one dropdown filter selection, keyed `<listId>.<selectId>` (ELEG-49). */
+export function saveListSelect(key: string, value: string): void {
+  const s = loadUISettings();
+  const listSelect = s.listSelect ?? {};
+  listSelect[key] = value;
+  saveUISettings({ listSelect });
+}
+
+/** Get a saved dropdown filter selection, or undefined for "all". */
+export function getListSelect(key: string): string | undefined {
+  return loadUISettings().listSelect?.[key];
 }


### PR DESCRIPTION
Closes ELEG-49. First of ELEG-22's four children — the other three (ELEG-50/51/52) adopt what this establishes.

## What this adds

| File | Role |
| --- | --- |
| `src/ui/list-sort.ts` | **New, pure.** Comparators, missing-value ordering, the grouping hook, the filter predicate, the click→next-sort rule, stored-state normalisation. |
| `src/ui/list-controls.ts` | **New, DOM.** The control bar: filter box, optional dropdowns, sort buttons, `n of m` readout, the two empty states. |
| `src/ui/files.ts` | Adopts it — sort by name / size / print time / layers / added, plus a text filter. |
| `index.html` | `#file-list-controls`, a static sibling of `#file-list`. |
| `src/ui/ui-settings.ts` | `listSort` + `listSelect` persistence. |
| `src/styles/main.css` | Control-bar styling, using the existing custom properties so it themes with ELEG-34. |

The split into a pure half and a DOM half is deliberate: vitest runs `environment: "node"` here, so a module that imports the DOM cannot be tested at all. `src/ui/card-layout.ts` (ELEG-44) is the shape being copied.

## The focus trap is solved structurally, not carefully

ELEG-22 called this out as "most likely to be got wrong and least likely to be caught by a test": these views re-render on every WebSocket message, so a filter input rebuilt as part of the render loses focus and selection under anyone typing while a 1036/1044 response lands.

Rather than saving and restoring focus, **the control bar is mounted once into a static container that the render pass never touches**. Clicking a sort button repaints `.list-sort` alone. Nothing restores focus because nothing takes it away. Filter input is debounced 150 ms, because a Files re-render kicks off thumbnail and cache fetches.

## Judgement calls

- **Folders-first is a `group` rank, not a comparator** — applied before the sort column and never negated by direction, so it holds for every column *and* both directions. Tested both ways.
- **Missing values sort last in both directions.** The first implementation negated this along with everything else; the test caught it (see below).
- **Sort and dropdown state persist; the text query does not.** A restored search box makes a card look empty for a reason the user has forgotten. Sort and dropdowns are labelled controls that show their own state at a glance, and `slogDirection`/`slogType` set the precedent for persisting those.
- **Storage is `ui-settings.ts`, not `persistence.ts`** — the issue pointed at the latter, but that key holds chart/layer data for the *current print* and is cleared when the print changes.
- **Extensionless relative imports** in the new `src/ui` modules. The tree is a clean split — 78/78 `.js` under `src/server`, 0/120 in the vite-bundled browser half — and AGENTS.md's own rationale for the rule is the tsx-executed service. AGENTS.md now says so explicitly.

## What actually verified what

**A test covers this** — everything in `src/ui/list-sort.ts`, via `src/__tests__/list-sort.test.ts`: ascending/descending, no input mutation, ties holding arrival order in both directions, missing-last in both directions, grouping surviving a direction change *and* a column change, case-insensitive substring matching, multi-field matching, the toggle-vs-switch rule, and junk in storage.

That suite is not decoration: **the missing-last-in-both-directions case failed on the first run and caught a real bug** — direction was being applied to the missing-value branch, so flipping to descending dragged every value-less row to the top. Fixed in `sortItems`, which now decides missing-ness before applying the sign.

**Nothing covers this** — `src/ui/list-controls.ts` and the `files.ts` wiring. There is no DOM test environment in this repo (no jsdom, no happy-dom, `environment: "node"`), so the focus-preservation invariant, the button repaint scoping and the two empty states are held up by code review and the structural argument above. Green gates here mean the pure half is right and the whole thing compiles — not that the card renders. Filed **ELEG-61** to add jsdom and assert the focus invariant properly.

**Not run:** I could not open a browser in this pass, so the rendered card has not been looked at. `pnpm dev:web` is the check to run — it opens no printer connection.

**No printer interaction.** Sorting and filtering data the app already holds; no method is sent that was not sent before.

## Gates

`pnpm gates` green — biome ci, both typechecks, vite build, vitest (165 tests).