### PR TITLE
feat(ui): sort, text filter and status filter for Print History (ELEG-50)

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,6 +466,9 @@
             <h3>📜 Print History</h3>
             <button id="btn-history-refresh" class="btn btn-sm btn-ghost" title="Refresh print history">⟳ Refresh</button>
           </div>
+          <!-- Sibling of the list (ELEG-50), for the same reason as Files: the entries
+               are replaced wholesale whenever a 1036 response lands. -->
+          <div id="print-history-controls"></div>
           <div id="print-history-entries" class="print-history-entries">
             <div class="file-empty">Click refresh to load history</div>
           </div>

--- a/src/__tests__/list-sort.test.ts
+++ b/src/__tests__/list-sort.test.ts
@@ -6,8 +6,10 @@ import {
   filterItems,
   matchesQuery,
   nextSortState,
+  nonZero,
   normaliseSortState,
   sortItems,
+  spanSeconds,
 } from '../ui/list-sort';
 
 interface Row {
@@ -197,6 +199,65 @@ describe('normaliseSortState', () => {
   it('returns a fresh object so the caller cannot mutate the default', () => {
     const out = normaliseSortState(null, keys, fallback);
     expect(out).not.toBe(fallback);
+  });
+});
+
+describe('nonZero', () => {
+  it('treats the printer zero as absent, not as 1970', () => {
+    expect(nonZero(0)).toBeUndefined();
+    expect(nonZero(undefined)).toBeUndefined();
+    expect(nonZero(Number.NaN)).toBeUndefined();
+  });
+
+  it('passes real values through, including negatives', () => {
+    expect(nonZero(1700000000)).toBe(1700000000);
+    expect(nonZero(-5)).toBe(-5);
+  });
+
+  it('keeps unrecorded rows at the bottom whichever way the column is sorted', () => {
+    interface Job {
+      name: string;
+      begin: number;
+    }
+    const jobs: Job[] = [
+      { name: 'unrecorded', begin: 0 },
+      { name: 'older', begin: 1000 },
+      { name: 'newer', begin: 2000 },
+    ];
+    const column: SortColumn<Job> = {
+      key: 'started',
+      label: 'Started',
+      value: (j) => nonZero(j.begin),
+    };
+    expect(sortItems(jobs, column, 'desc').map((j) => j.name)).toEqual([
+      'newer',
+      'older',
+      'unrecorded',
+    ]);
+    // Ascending is the case that actually needs `nonZero`: a raw 0 is the smallest
+    // number, so without the mapping the unrecorded row leads the oldest-first list.
+    expect(sortItems(jobs, column, 'asc').map((j) => j.name)).toEqual([
+      'older',
+      'newer',
+      'unrecorded',
+    ]);
+  });
+});
+
+describe('spanSeconds', () => {
+  it('measures a finished job', () => {
+    expect(spanSeconds(1000, 1600)).toBe(600);
+  });
+
+  it('has no answer for a job that has not finished or never started', () => {
+    expect(spanSeconds(1000, 0)).toBeUndefined();
+    expect(spanSeconds(0, 1600)).toBeUndefined();
+    expect(spanSeconds(undefined, undefined)).toBeUndefined();
+  });
+
+  it('rejects a nonsensical span rather than returning a negative duration', () => {
+    expect(spanSeconds(1600, 1000)).toBeUndefined();
+    expect(spanSeconds(1000, 1000)).toBeUndefined();
   });
 });
 

--- a/src/ui/list-sort.ts
+++ b/src/ui/list-sort.ts
@@ -152,6 +152,34 @@ export function normaliseSortState(
   return { key, dir };
 }
 
+/**
+ * Treat 0 as "no value" (ELEG-50).
+ *
+ * The printer sends `0` for a timestamp, size or duration it did not record, and 0 is a
+ * perfectly good number — sorted as one it means 1970, which puts every unrecorded row
+ * at the top of "newest first". Mapping it to `undefined` hands it to the missing-last
+ * rule instead, where it belongs. Also catches NaN, which `Number()` on a bad field
+ * produces and which silently poisons a comparator.
+ */
+export function nonZero(value: number | undefined): number | undefined {
+  return value === undefined || value === 0 || Number.isNaN(value) ? undefined : value;
+}
+
+/**
+ * The seconds between two epoch-second stamps, or `undefined` when either is missing or
+ * the pair does not describe a finished job (a print still running has no end time, and
+ * an end before its start is corrupt rather than negative-length).
+ */
+export function spanSeconds(
+  begin: number | undefined,
+  end: number | undefined,
+): number | undefined {
+  const from = nonZero(begin);
+  const to = nonZero(end);
+  if (from === undefined || to === undefined) return undefined;
+  return to > from ? to - from : undefined;
+}
+
 /** The arrow shown on the active column's button. */
 export function directionIndicator(dir: SortDirection): string {
   return dir === 'asc' ? '↑' : '↓';

--- a/src/ui/print-history.ts
+++ b/src/ui/print-history.ts
@@ -2,6 +2,8 @@ import type { CommandSender } from '../ws-client';
 import type { PrinterState } from '../printer-state';
 import { $, escapeHtml, escapeAttr, formatTime } from './helpers';
 import { toast } from './toast';
+import { type ListControls, createListControls } from './list-controls';
+import { nonZero, spanSeconds } from './list-sort';
 
 let historyClient: CommandSender | null = null;
 
@@ -15,13 +17,73 @@ export function requestHistory(): void {
   historyClient.sendCommand(1036, {});
 }
 
+type HistoryItem = PrinterState['printHistory'][number];
+
+/** Kept outside the render function — see `list-controls.ts` on why that matters. */
+let historyControls: ListControls<HistoryItem> | null = null;
+let lastHistoryState: PrinterState | null = null;
+
+function ensureHistoryControls(): ListControls<HistoryItem> {
+  if (historyControls) return historyControls;
+  historyControls = createListControls<HistoryItem>({
+    id: 'print-history',
+    container: $('print-history-controls'),
+    noun: 'prints',
+    filterPlaceholder: 'Filter by job name…',
+    filterText: (item) => item.filename,
+    columns: [
+      { key: 'name', label: 'Name', value: (i) => i.filename },
+      // nonZero/spanSeconds, not the raw fields: the printer sends 0 for a time it did
+      // not record, and 0 sorts as 1970 — top of "newest first" — rather than as absent.
+      {
+        key: 'started',
+        label: 'Started',
+        value: (i) => nonZero(i.begin_time),
+        initialDirection: 'desc',
+      },
+      {
+        key: 'duration',
+        label: 'Duration',
+        value: (i) => spanSeconds(i.begin_time, i.end_time),
+        initialDirection: 'desc',
+      },
+      { key: 'status', label: 'Status', value: (i) => i.status },
+    ],
+    // Newest first: the last thing you printed is the thing you are asking about.
+    defaultSort: { key: 'started', dir: 'desc' },
+    selects: [
+      {
+        id: 'status',
+        label: 'Status',
+        options: [
+          { value: 'completed', label: 'completed' },
+          { value: 'failed', label: 'failed' },
+          { value: 'stopped', label: 'stopped' },
+        ],
+        match: (item, value) => item.status === value,
+      },
+    ],
+    onChange: () => {
+      if (lastHistoryState) renderPrintHistory(lastHistoryState);
+    },
+  });
+  return historyControls;
+}
+
 export function renderPrintHistory(state: PrinterState): void {
   const container = $('print-history-entries');
   if (!container) return;
+  lastHistoryState = state;
 
-  const items = state.printHistory;
-  if (!items || items.length === 0) {
-    container.innerHTML = '<div class="file-empty">No print history</div>';
+  const controls = ensureHistoryControls();
+  // Client-side over the whole set: 1036 takes no paging parameters, so there is no
+  // server-side ordering to ask for even if there were enough entries to want one.
+  const items = controls.apply(state.printHistory ?? []);
+
+  if (items.length === 0) {
+    // Two different facts: "narrow your filter" and "you have never printed".
+    container.innerHTML = controls.emptyHtml('No print history');
+    updateHistoryTotal(state);
     return;
   }
 
@@ -70,8 +132,11 @@ export function renderPrintHistory(state: PrinterState): void {
     .join('');
 
   container.innerHTML = html;
+  updateHistoryTotal(state);
+}
 
-  // Show total count
+/** The printer's own total, which is not the same number as the filtered count. */
+function updateHistoryTotal(state: PrinterState): void {
   const totalEl = $('print-history-total');
   if (totalEl) {
     totalEl.textContent = `${state.printHistoryTotal} prints`;


### PR DESCRIPTION
Closes ELEG-50. Second of ELEG-22's four children; builds on ELEG-49 (#39, merged as `cea09e3`).

## What changed

- **`src/ui/print-history.ts`** adopts `createListControls`. Sort by name / started / duration / status; text filter on job name; **status dropdown** for completed / failed / stopped, matched against the already-normalised `mapTaskStatus` output.
- **`index.html`** gains `#print-history-controls`, a static sibling of `#print-history-entries`.
- **`src/ui/list-sort.ts`** gains two pure helpers, `nonZero()` and `spanSeconds()`.
- The two empty states are now distinct: "No print history" (you have never printed) vs "Nothing matches your filter" (narrow it).

## The zero-timestamp problem

`begin_time`/`end_time` are `0` when the printer did not record them — `printer-state.ts` coerces with `|| 0`. Zero is a perfectly good number, and sorted as one it means **1970**: every unrecorded row leads an oldest-first list, and a still-running job reports a duration measured from the epoch.

`nonZero()` maps it to `undefined` so the helper's missing-last rule takes it, and `spanSeconds()` returns nothing for a pair that does not describe a finished job (missing end, or end before start). Both went into the shared pure module rather than staying local, because ELEG-51 and ELEG-52 have the same fields with the same convention.

## Judgement calls

- **Default sort is started, descending.** The last thing you printed is the thing you are asking about.
- **The dropdown lists the three statuses the issue named**, not `printing`/`unknown` — `mapTaskStatus` can emit those, but offering a filter for states that essentially never appear in *history* is noise. Filtering by `completed` correctly excludes them either way.
- **The card's "N prints" readout still shows the printer's own total**, unchanged. The control bar carries the "n of m" filtered count next to it — two different numbers, so they get two different places rather than one that changes meaning when a filter is on.

## What actually verified what

**A test covers this** — `nonZero()` and `spanSeconds()`, in `src/__tests__/list-sort.test.ts` (28 cases in that file now), plus everything ELEG-49 already covered.

**Shown to be load-bearing, not decorative.** I broke `nonZero` to return its input unchanged and re-ran: 3 tests went red, including the sort-order case. That case initially only asserted *descending*, where a raw `0` sorts last by accident and the bug is invisible — it now asserts ascending too, which is the direction that actually needs the mapping. The break was reverted with an inverse patch and the file re-verified green.

**Nothing covers this** — the `print-history.ts` wiring, the status dropdown's effect on the rendered list, the empty-state swap, and the focus-preservation behaviour. No DOM test environment exists in this repo (ELEG-61 filed under ELEG-49 to add one). Green gates here mean the pure helpers are right and it compiles.

**Not run:** no browser was opened in this unattended pass. `pnpm dev:web` is the check; it opens no printer connection.

**No printer interaction.** Read-only over `state.printHistory`; no new method is sent, and the existing 1036 refresh and 1038 delete are untouched.

## Gates

`pnpm gates` green — biome ci, both typechecks, vite build, vitest.