### PR TITLE
feat(ui): sort, text filter and outcome filter for Print Reports (ELEG-51)

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,6 +481,8 @@
             <h3>📊 Print Reports</h3>
             <button id="btn-reports-refresh" class="btn btn-sm btn-ghost" title="Refresh reports">⟳ Refresh</button>
           </div>
+          <!-- Sibling of the list (ELEG-51): the entries are replaced wholesale. -->
+          <div id="print-reports-controls"></div>
           <div id="print-reports-entries">
             <div class="file-empty">Click refresh to load reports</div>
           </div>

--- a/src/ui/print-reports.ts
+++ b/src/ui/print-reports.ts
@@ -3,6 +3,8 @@
  */
 
 import { $, escapeHtml, formatTime, fetchTimeout } from './helpers';
+import { type ListControls, createListControls } from './list-controls';
+import { nonZero } from './list-sort';
 
 interface ReportSummary {
   id: string;
@@ -14,6 +16,61 @@ interface ReportSummary {
 }
 
 let reportsLoaded = false;
+/**
+ * The last fetched payload, kept so that changing the sort or the filter re-renders from
+ * memory instead of re-fetching `/api/reports` — the controls change what you see, not
+ * what the server has.
+ */
+let reportData: { reports: ReportSummary[]; active: boolean } | null = null;
+
+/** Kept outside the render function — see `list-controls.ts` on why that matters. */
+let reportControls: ListControls<ReportSummary> | null = null;
+
+function ensureReportControls(): ListControls<ReportSummary> {
+  if (reportControls) return reportControls;
+  reportControls = createListControls<ReportSummary>({
+    id: 'print-reports',
+    container: $('print-reports-controls'),
+    noun: 'reports',
+    filterPlaceholder: 'Filter reports…',
+    // `.report-filename` carries the full name in its `title` (ELEG-43), so matching the
+    // full string is right even where the display is ellipsised.
+    filterText: (r) => r.filename,
+    columns: [
+      { key: 'name', label: 'Name', value: (r) => r.filename },
+      // startedAt/endedAt are epoch *milliseconds* here (Date.now()), unlike print
+      // history's seconds — it only matters if you compare the two, which nothing does.
+      {
+        key: 'started',
+        label: 'Started',
+        value: (r) => nonZero(r.startedAt),
+        initialDirection: 'desc',
+      },
+      {
+        key: 'duration',
+        label: 'Duration',
+        value: (r) => nonZero(r.duration),
+        initialDirection: 'desc',
+      },
+      { key: 'outcome', label: 'Outcome', value: (r) => r.outcome },
+    ],
+    defaultSort: { key: 'started', dir: 'desc' },
+    selects: [
+      {
+        id: 'outcome',
+        label: 'Outcome',
+        options: [
+          { value: 'completed', label: 'completed' },
+          { value: 'failed', label: 'failed' },
+          { value: 'stopped', label: 'stopped' },
+        ],
+        match: (r, value) => r.outcome === value,
+      },
+    ],
+    onChange: () => renderReportList(),
+  });
+  return reportControls;
+}
 
 export function renderReports(): void {
   const container = $('print-reports-entries');
@@ -29,28 +86,44 @@ async function loadReports(): Promise<void> {
   try {
     const res = await fetchTimeout('/api/reports');
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = (await res.json()) as { reports: ReportSummary[]; active: boolean };
+    reportData = (await res.json()) as { reports: ReportSummary[]; active: boolean };
+    reportsLoaded = true;
+    renderReportList();
+  } catch {
+    container.innerHTML = '<div class="file-empty">Failed to load reports</div>';
+  }
+}
 
-    if (data.reports.length === 0 && !data.active) {
-      container.innerHTML =
-        '<div class="file-empty">No print reports yet. Reports are automatically generated when prints complete.</div>';
-      reportsLoaded = true;
-      return;
-    }
+/** Renders whatever was last fetched, through the current sort and filter. */
+function renderReportList(): void {
+  const container = $('print-reports-entries');
+  const data = reportData;
+  if (!container || !data) return;
 
-    let html = '';
-    if (data.active) {
-      html += '<div class="report-active">📊 Report collection in progress…</div>';
-    }
+  const controls = ensureReportControls();
+  const reports = controls.apply(data.reports);
 
-    for (const r of data.reports) {
-      const statusIcon = r.outcome === 'completed' ? '✅' : r.outcome === 'failed' ? '❌' : '⏹';
-      const statusClass =
-        r.outcome === 'completed' ? 'success' : r.outcome === 'failed' ? 'danger' : 'warning';
-      const date = new Date(r.startedAt).toLocaleString();
-      const duration = formatTime(r.duration);
+  if (reports.length === 0 && !data.active) {
+    // "No reports yet" and "nothing matches your filter" are different facts.
+    container.innerHTML = controls.emptyHtml(
+      'No print reports yet. Reports are automatically generated when prints complete.',
+    );
+    return;
+  }
 
-      html += `<div class="report-entry">
+  let html = '';
+  if (data.active) {
+    html += '<div class="report-active">📊 Report collection in progress…</div>';
+  }
+
+  for (const r of reports) {
+    const statusIcon = r.outcome === 'completed' ? '✅' : r.outcome === 'failed' ? '❌' : '⏹';
+    const statusClass =
+      r.outcome === 'completed' ? 'success' : r.outcome === 'failed' ? 'danger' : 'warning';
+    const date = new Date(r.startedAt).toLocaleString();
+    const duration = formatTime(r.duration);
+
+    html += `<div class="report-entry">
         <div class="report-entry-main">
           <span class="history-status ${statusClass}">${statusIcon}</span>
           <span class="report-filename" title="${escapeHtml(r.filename)}">${escapeHtml(r.filename)}</span>
@@ -65,32 +138,28 @@ async function loadReports(): Promise<void> {
           <button class="btn btn-sm btn-danger report-delete-btn" data-report-id="${escapeHtml(r.id)}" title="Delete report">🗑</button>
         </div>
       </div>`;
-    }
-
-    container.innerHTML = html;
-    reportsLoaded = true;
-
-    // Bind delete buttons
-    container.querySelectorAll('.report-delete-btn').forEach((btn) => {
-      btn.addEventListener('click', async () => {
-        const id = (btn as HTMLElement).dataset.reportId;
-        if (!id || !confirm(`Delete report for this print?`)) return;
-        try {
-          const res = await fetchTimeout(`/api/reports/${encodeURIComponent(id)}`, {
-            method: 'DELETE',
-          });
-          if (res.ok) {
-            reportsLoaded = false;
-            loadReports();
-          }
-        } catch {
-          /* ignore */
-        }
-      });
-    });
-  } catch {
-    container.innerHTML = '<div class="file-empty">Failed to load reports</div>';
   }
+
+  container.innerHTML = html;
+
+  // Bind delete buttons. Rebound on every render because the rows are replaced.
+  container.querySelectorAll('.report-delete-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const id = (btn as HTMLElement).dataset.reportId;
+      if (!id || !confirm(`Delete report for this print?`)) return;
+      try {
+        const res = await fetchTimeout(`/api/reports/${encodeURIComponent(id)}`, {
+          method: 'DELETE',
+        });
+        if (res.ok) {
+          reportsLoaded = false;
+          loadReports();
+        }
+      } catch {
+        /* ignore */
+      }
+    });
+  });
 }
 
 export function refreshReports(): void {


### PR DESCRIPTION
Closes ELEG-51. Third of ELEG-22's four children; builds on ELEG-49 (#39) and ELEG-50 (#40), both merged.

## What the record actually carries

The issue asked me to check rather than assume. `listReports()` in `src/server/print-report-collector.ts` returns exactly `{ id, filename, outcome, startedAt, endedAt, duration }`, and the frontend's `ReportSummary` matches it — so **duration and outcome are both real sort keys**, and both are already rendered on each row.

Columns: name, started, duration, outcome. Default: started, descending.

## Changes

- **`src/ui/print-reports.ts`** adopts `createListControls`, and `loadReports()` is split: it now caches the payload in `reportData` and `renderReportList()` renders from that. Changing a sort or a filter re-renders **from memory** rather than re-fetching `/api/reports` — the controls change what you see, not what the server has.
- **`index.html`** gains `#print-reports-controls`, a static sibling of `#print-reports-entries`.
- Empty states are now distinct: "No print reports yet…" vs "Nothing matches your filter".

## Judgement call: the outcome dropdown

This issue asked only for sort + text filter; the status dropdown was scoped to ELEG-50. I added one here anyway. It is six lines against machinery that already exists, and "show me the failures" is the same question whether asked of history or of reports. Filing a separate issue for that seemed worse than doing it, and leaving it as a prose TODO is not allowed. **Easy to revert if unwanted** — it is one `selects` entry.

## A detail worth knowing

`startedAt`/`endedAt` here are epoch **milliseconds** (`Date.now()` server-side), whereas print history's `begin_time`/`end_time` are epoch **seconds**. Noted in a comment at the column rather than reconciled, because nothing compares values across the two views. `nonZero()` works on either.

## What actually verified what

**A test covers this** — only indirectly: the comparator, filter predicate and `nonZero()` this view leans on are unit-tested in `src/__tests__/list-sort.test.ts` (landed in #39/#40). This PR adds no new pure logic, which is the point of a shared helper — the third adoption should be configuration, not code.

**Nothing covers this** — the `print-reports.ts` restructure itself: that the cached-payload path renders the same rows as the old fetch-and-render did, that the delete button still rebinds after a filtered re-render, that the active-collection banner still shows when a report is in progress with zero saved reports. There is no DOM test environment in this repo (ELEG-61). Green gates mean it compiles and the shared logic is right.

I did re-check the empty-state branch by hand against the original: previously `reports.length === 0 && !data.active` printed the "no reports yet" message, and active-with-zero-reports printed just the banner. Both still hold, with the filtered case now taking a different message.

**Not run:** no browser was opened in this unattended pass. `pnpm dev:web` is the check; it opens no printer connection.

**No printer interaction.** This view talks to `/api/reports` only, and no request shape changed.

## Gates

`pnpm gates` green — biome ci, both typechecks, vite build, vitest.