### PR TITLE
feat(ui): sort, text filter and state filter for Timelapse (ELEG-52)

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,6 +525,8 @@
             <video id="timelapse-player" controls class="timelapse-video"></video>
             <button class="btn btn-sm btn-ghost timelapse-close-btn" id="timelapse-close">✕ Close</button>
           </div>
+          <!-- Sibling of the list (ELEG-52): the list is replaced on every 1036 response. -->
+          <div id="timelapse-controls"></div>
           <div id="timelapse-list" class="file-list">
             <div class="file-empty">Click refresh to load timelapse list</div>
           </div>

--- a/src/printer-state.ts
+++ b/src/printer-state.ts
@@ -98,6 +98,7 @@ export class PrinterState {
     timelapse_status: number;
     timelapse_url: string;
     timelapse_duration: number;
+    timelapse_size: number;
   }> = [];
   printHistoryTotal = 0;
   /** Auto-report sequence tracking for gap detection */
@@ -340,6 +341,9 @@ export class PrinterState {
               timelapse_status: (t.time_lapse_video_status as number) ?? 0,
               timelapse_url: (t.time_lapse_video_url as string) || '',
               timelapse_duration: (t.time_lapse_video_duration as number) || 0,
+              // On the wire per CC2_PROTOCOL_REFERENCE.md §1036 and used by the vendor
+              // app, but dropped here until ELEG-52 wanted it as a sort key.
+              timelapse_size: (t.time_lapse_video_size as number) || 0,
             }));
             this.printHistoryTotal = total ?? this.printHistory.length;
             // Populate timelapse list from history entries with video data
@@ -352,6 +356,7 @@ export class PrinterState {
                 timelapse_status: t.timelapse_status,
                 timelapse_url: t.timelapse_url,
                 timelapse_duration: t.timelapse_duration,
+                timelapse_size: t.timelapse_size,
                 begin_time: t.begin_time,
                 end_time: t.end_time,
               }));

--- a/src/ui/files.ts
+++ b/src/ui/files.ts
@@ -4,6 +4,7 @@ import type { FileEntry } from '../types';
 import {
   $,
   escapeHtml,
+  formatBytes,
   escapeAttr,
   formatTime,
   applyDarkThumbnailCheck,
@@ -413,13 +414,6 @@ function ensureFileDelegation(container: HTMLElement): void {
 
 function _bindFilePopovers(_container: HTMLElement): void {
   // No-op: popovers now handled by delegation in ensureFileDelegation
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return bytes + ' B';
-  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-  return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
 }
 
 function renderBreadcrumb(_client: CommandSender): string {

--- a/src/ui/helpers.ts
+++ b/src/ui/helpers.ts
@@ -2,6 +2,14 @@ export function $(id: string): HTMLElement {
   return document.getElementById(id)!;
 }
 
+/** Byte count in the largest unit that keeps it readable. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+  return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
+}
+
 /** Fetch with AbortController timeout (default 15s). Throws on timeout. */
 export function fetchTimeout(
   input: RequestInfo | URL,

--- a/src/ui/timelapse.ts
+++ b/src/ui/timelapse.ts
@@ -11,7 +11,9 @@
 
 import type { CommandSender } from '../ws-client';
 import type { PrinterState } from '../printer-state';
-import { $, escapeHtml, escapeAttr } from './helpers';
+import { $, escapeHtml, escapeAttr, formatBytes } from './helpers';
+import { type ListControls, createListControls } from './list-controls';
+import { nonZero } from './list-sort';
 
 let playerClient: CommandSender | null = null;
 
@@ -19,30 +21,97 @@ export function setTimelapseClient(client: CommandSender): void {
   playerClient = client;
 }
 
+/** The list is `Record<string, unknown>[]`, so each field is read through an accessor. */
+type TimelapseEntry = Record<string, unknown>;
+
+const entryName = (v: TimelapseEntry): string => String(v.filename || 'Unknown');
+const entryStatus = (v: TimelapseEntry): number => (v.timelapse_status as number) ?? 0;
+const entrySize = (v: TimelapseEntry): number | undefined =>
+  nonZero(v.timelapse_size as number | undefined);
+const entryDuration = (v: TimelapseEntry): number | undefined =>
+  nonZero(v.timelapse_duration as number | undefined);
+const entryBegin = (v: TimelapseEntry): number | undefined =>
+  nonZero(v.begin_time as number | undefined);
+
+/** Status codes, from the file header: 0=NotCaptured, 1=NotExported, 2=Exported, 3=Failed */
+const STATUS_EXPORTED = 2;
+const STATUS_FAILED = 3;
+
+/** Kept outside the render function — see `list-controls.ts` on why that matters. */
+let timelapseControls: ListControls<TimelapseEntry> | null = null;
+let lastTimelapseState: PrinterState | null = null;
+
+function ensureTimelapseControls(): ListControls<TimelapseEntry> {
+  if (timelapseControls) return timelapseControls;
+  timelapseControls = createListControls<TimelapseEntry>({
+    id: 'timelapse',
+    container: $('timelapse-controls'),
+    noun: 'videos',
+    filterPlaceholder: 'Filter timelapses…',
+    filterText: entryName,
+    columns: [
+      { key: 'name', label: 'Name', value: entryName },
+      { key: 'time', label: 'Recorded', value: entryBegin, initialDirection: 'desc' },
+      { key: 'duration', label: 'Length', value: entryDuration, initialDirection: 'desc' },
+      { key: 'size', label: 'Size', value: entrySize, initialDirection: 'desc' },
+    ],
+    defaultSort: { key: 'time', dir: 'desc' },
+    selects: [
+      {
+        // The timelapse analogue of Print History's failures filter, which this issue
+        // asked to fold in if it was cheap. It was — the helper already does dropdowns.
+        id: 'state',
+        label: 'State',
+        options: [
+          { value: 'ready', label: 'ready to play' },
+          { value: 'pending', label: 'needs export' },
+          { value: 'failed', label: 'generation failed' },
+        ],
+        match: (v, value) => {
+          const status = entryStatus(v);
+          if (value === 'ready') return status === STATUS_EXPORTED && !!v.timelapse_url;
+          if (value === 'failed') return status === STATUS_FAILED;
+          return status !== STATUS_EXPORTED && status !== STATUS_FAILED;
+        },
+      },
+    ],
+    onChange: () => {
+      if (lastTimelapseState) renderTimelapse(lastTimelapseState);
+    },
+  });
+  return timelapseControls;
+}
+
 export function renderTimelapse(state: PrinterState): void {
   const container = $('timelapse-list');
   if (!container) return;
+  lastTimelapseState = state;
 
-  const videos = state.timelapseList;
-  if (!videos || !videos.length) {
-    container.innerHTML =
-      '<div class="file-empty">No timelapse videos found. Click Refresh to load print history.</div>';
+  const controls = ensureTimelapseControls();
+  const videos = controls.apply(state.timelapseList ?? []);
+
+  if (!videos.length) {
+    // "No timelapses at all" and "none match your filter" are different facts.
+    container.innerHTML = controls.emptyHtml(
+      'No timelapse videos found. Click Refresh to load print history.',
+    );
     return;
   }
 
   let html = '';
   for (const video of videos) {
-    const name = String(video.filename || 'Unknown');
-    const status = video.timelapse_status as number;
+    const name = entryName(video);
+    const status = entryStatus(video);
     const videoUrl = (video.timelapse_url as string) || '';
-    const videoDuration = (video.timelapse_duration as number) || 0;
-    const beginTime = video.begin_time as number | undefined;
-    const time = beginTime ? new Date(beginTime * 1000).toLocaleString() : '';
-    const durStr = videoDuration > 0 ? `${videoDuration}s` : '';
-    const meta = [time, durStr].filter(Boolean).join(' · ');
+    const time = entryBegin(video) ? new Date(entryBegin(video)! * 1000).toLocaleString() : '';
+    const videoDuration = entryDuration(video);
+    const durStr = videoDuration ? `${videoDuration}s` : '';
+    const size = entrySize(video);
+    const sizeStr = size ? formatBytes(size) : '';
+    const meta = [time, durStr, sizeStr].filter(Boolean).join(' · ');
 
     // Status 2 = already exported (has URL), status 1 = captured but needs export
-    const isExported = status === 2 && videoUrl;
+    const isExported = status === STATUS_EXPORTED && videoUrl;
     const actionBtn = isExported
       ? `<button class="btn btn-sm btn-primary timelapse-play-btn" data-url="${escapeAttr(videoUrl)}">▶ Play</button>`
       : `<button class="btn btn-sm btn-ghost timelapse-export-btn" data-url="${escapeAttr(videoUrl || name)}">⬆ Export</button>`;


### PR DESCRIPTION
Closes ELEG-52 — the last of ELEG-22's four children. Builds on ELEG-49 (#39), ELEG-50 (#40) and ELEG-51 (#41), all merged.

## The "size is already available" claim, settled

The issue said `time_lapse_video_size` and `time_lapse_video_duration` "are therefore already available as sort keys and are currently unused". Half of that was true:

| | On the wire | In this codebase |
| --- | --- | --- |
| `time_lapse_video_duration` | yes | yes — already mapped |
| `time_lapse_video_size` | **yes** | **no — dropped** |

Size is documented in `data/CC2_PROTOCOL_REFERENCE.md` §1036's task shape and the vendor bundle reads it (`TimeLapseVideoSize: …time_lapse_video_size`), but `src/printer-state.ts`'s 1036 handler mapped status, url and duration and never touched size — so it reached neither `printHistory` nor `timelapseList`. That is one line of plumbing, not a blocker, so it is now mapped, sorted on, and shown in each row's meta line.

## What changed

- **`src/ui/timelapse.ts`** adopts `createListControls`: sort by name / recorded / length / size, text filter on video name, and a **state dropdown** — ready to play (status 2 with a URL) / needs export / generation failed (status 3).
- **`src/printer-state.ts`** carries `timelapse_size` through both mappings.
- **`index.html`** gains `#timelapse-controls`, a static sibling of `#timelapse-list`.
- **`src/ui/helpers.ts`** gains `formatBytes`, moved out of `files.ts` where it was private, since this view needs it too.
- The magic status numbers get names (`STATUS_EXPORTED`, `STATUS_FAILED`) where the filter and the button logic both use them.

The state dropdown is the "has a video vs generation failed" filter the issue asked me to fold in **if cheap** and file otherwise. It was cheap — the helper already does dropdowns — so it is in this PR and there is no follow-up issue.

## The state-merge question, checked

I touched `printer-state.ts`, so: the 1036 handler **rebuilds the whole list** from the response rather than merging a delta into it, so there is no "absent field means unchanged, not cleared" hazard here. A size the printer does not report arrives as `0`, which `nonZero()` maps to absent, so it sorts **last** rather than as a zero-byte video.

## What actually verified what

**A test covers this** — the shared pure logic this view leans on (`nonZero`, the comparators, the missing-last rule, the filter predicate) is unit-tested in `src/__tests__/list-sort.test.ts`. 171 tests pass.

**Nothing covers this** — the `timelapse.ts` wiring, the state dropdown's three-way predicate, the new size column rendering, and the empty-state swap. No DOM test environment exists in this repo (ELEG-61 filed to add one). The `printer-state.ts` change is likewise typechecked but not asserted: nothing in the suite exercises the 1036 handler.

**Not run:** no browser was opened in this unattended pass, so no timelapse row has been looked at with a real size on it. `pnpm dev:web` is the check; it opens no printer connection.

**No printer interaction.** Listing and sorting only. The export path (1051) is a write and was left exactly as it was — not called, not changed.

## Gates

`pnpm gates` green — biome ci, both typechecks, vite build, vitest.