### PR TITLE
docs(agents): record the list-view control pattern and the missing DOM environment

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -99,6 +99,14 @@ carry the protocol's hard-won knowledge:
   state object into a fixed third-party JSON shape. Pure input → output, and a client
   like Mainsail breaks silently when a field's shape drifts.
 
+**There is no DOM environment at all** — vitest runs `environment: "node"` and neither
+`jsdom` nor `happy-dom` is a dependency, so a test cannot import a module that touches
+`document`. That is why the frontend is written as pure-half / DOM-half pairs:
+`card-layout.ts` + `settings.ts`, `list-sort.ts` + `list-controls.ts`. **Put the
+decisions in the pure half** — it is the only half a test can reach — and keep the DOM
+half to markup and wiring. ELEG-61 tracks adding jsdom so the wiring can be asserted
+too; until it lands, "gates green" says nothing whatsoever about anything that renders.
+
 Build fixtures from **captured real payloads** (the debug panel exports the state tree,
 and `${DATA_DIR}/state.json` is a real snapshot) rather than hand-writing an idealised
 message — the CC2's actual payloads are the thing worth encoding. Strip anything

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,17 @@ Actions minutes (the private siblings do not, hence their self-hosted runners).
   component library: `src/main.ts` composes modules from `src/ui/*.ts`, styling is
   CSS custom properties in `src/styles/`. Match the surrounding idiom rather than
   introducing a framework in one card.
+- **A list view's controls go in a *static sibling* of the list, never inside it.**
+  Every list card re-renders wholesale on a WebSocket update — the render function
+  assigns `container.innerHTML`. Anything interactive built inside that container is
+  therefore destroyed and rebuilt under the user: a filter input loses focus and
+  selection mid-keystroke when a 1036 response lands. Files, Print History, Print
+  Reports and Timelapse each pair `#<view>-list` with a `#<view>-controls` div beside
+  it, and `src/ui/list-controls.ts` mounts into that once (ELEG-49…52). Sort/filter
+  state lives in that module's closure, **outside** the render function, and is
+  persisted in `ui-settings.ts` — not `persistence.ts`, which is cleared when the print
+  changes. New list views follow the same shape; the pure half of any list logic belongs
+  in `src/ui/list-sort.ts`, which is the only half a test can reach.
 - **MCP tools and [`MCP.md`](MCP.md) change together.** `MCP.md` is the documented
   contract for the `/mcp` surface (resources, tools, parameters). A tool added,
   renamed, or given a new parameter without the doc edit in the same commit is drift


### PR DESCRIPTION
Docs-only. Captures two durable facts from the ELEG-49 / ELEG-50 / ELEG-51 / ELEG-52 pass under ELEG-22, so the next agent does not re-derive them.

Deliberately **not** carrying an issue key in the branch or title: ELEG-22 is a mini-epic that closes when its children do, and all four have merged. This is an addendum to that work, not a fifth slice of it, so it should move no issue status.

## 1. `AGENTS.md` — the list-view control pattern

All four list views now share one shape, and the reason for it is not guessable from the code:

> Controls go in a **static sibling** of the list, never inside it.

Every list card re-renders wholesale (`container.innerHTML = html`) when a WebSocket update lands, so anything interactive built inside that container is destroyed and rebuilt under the user — a filter input loses focus and selection mid-keystroke when a 1036 response arrives. Hence `#<view>-list` paired with `#<view>-controls`, state in the module closure rather than the render function, and persistence in `ui-settings.ts` rather than `persistence.ts` (which is cleared when the print changes).

## 2. `.agents/testing.md` — why the frontend is split in halves

The deep-dive listed good test targets but never said that **there is no DOM environment at all**: vitest runs `environment: "node"` and neither jsdom nor happy-dom is a dependency, so a test cannot import a module that touches `document`. That is the actual reason for the pure-half / DOM-half pairs (`card-layout.ts` + `settings.ts`, `list-sort.ts` + `list-controls.ts`), and the actionable consequence — put the decisions in the pure half, it is the only half a test can reach — was nowhere.

Cross-referenced to ELEG-61, which tracks adding jsdom.

## Verification

`pnpm gates` green. No code changed, so nothing to test; the claims themselves were checked against the tree while writing them (`environment: "node"` in the vitest config, no jsdom/happy-dom in `node_modules`, all four views paired with a controls div).