### PR TITLE
chore(ci): move the three actions off the deprecated Node 20 runtime (ELEG-62)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -44,12 +44,12 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # No `version:` on purpose — see the note in ci.yml (ELEG-4).
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,25 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # No `version:` on purpose — action-setup then reads `packageManager` from
       # package.json, so CI uses the exact pnpm developers use. `version: latest`
       # silently moved CI to pnpm 11 while everyone here was on 10.x, which broke
-      # the frozen install two different ways (ELEG-4).
-      - uses: pnpm/action-setup@v4
+      # the frozen install two different ways (ELEG-4). Still optional-when-
+      # packageManager-is-present in v6, so the bump did not reintroduce it.
+      #
+      # Stay on `pnpm/action-setup`. Its successor `pnpm/setup` requires pnpm v11+,
+      # and moving there is ELEG-9's deliberate decision, not a side effect of a
+      # runtime bump.
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      # `cache: pnpm` is explicit and must stay. setup-node v5 added automatic
+      # caching driven by `packageManager`, then v6 narrowed that to npm only — so
+      # the automatic path does not cover pnpm and dropping this line would silently
+      # lose the store cache. This step must also stay AFTER action-setup: the cache
+      # resolution shells out to pnpm.
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
Closes ELEG-62.

## The issue's target versions were themselves stale

It asked for the `v5` majors. Checked rather than assumed:

| Action | Was | Now | Runtime |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v7** | node24 |
| `actions/setup-node` | v4 | **v7** | node24 |
| `pnpm/action-setup` | v4 | **v6** | node24 |

v5 would clear the deprecation and immediately leave three actions two majors behind — and ELEG-63 just added the `github-actions` ecosystem to `dependabot.yml`, so that gap would come back as PRs within the week. All three confirmed `using: node24` by reading each `action.yml` at the tag, which is the fact the deprecation actually turns on.

## Changelogs, since the issue rightly insists on reading them

- **`setup-node` v5** added automatic caching driven by `packageManager`; **v6** then narrowed it to **npm only**. So the automatic path does not cover pnpm and the explicit `cache: pnpm` line is **not** redundant — dropping it as tidy-up would silently lose the store cache. Commented in place, along with the fact that this step must stay *after* `action-setup`, because the cache resolution shells out to pnpm.
- **`checkout` v7** blocks checking out fork PRs for `pull_request_target` / `workflow_run`. This workflow triggers on `pull_request`, so it is unaffected.
- **`setup-node` v7** is an ESM migration plus dependency bumps; no input changes that reach us.
- **`pnpm/action-setup` v6** adds pnpm v11 support, and — the part that mattered — still treats `version:` as **optional when `packageManager` is present**. ELEG-4's arrangement survives the bump and **no `version:` key was reintroduced**.

## Deliberately not done

`pnpm/action-setup` is superseded by **`pnpm/setup`**, which **requires pnpm v11+**. This repo is on 10.33.3 and the move to pnpm 11 is ELEG-9's deliberate decision. A runtime bump is not the place to smuggle in a package-manager major, so this stays on `action-setup@v6`. Noted in the workflow comment so ELEG-9 finds it.

## Verification

The issue is explicit that local gates prove nothing here, and that is right — this touches no application code. `pnpm gates` was run and is green, but the real check is the CI run on this branch: **green, and the Node 20 deprecation annotation gone.** Confirmed on the run before merge.

`audit.yml` (added yesterday in ELEG-63) got the same bump so the two workflows do not drift.