### PR TITLE
test(ui): add a jsdom environment and assert the list bar's focus invariant (ELEG-61)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -51,8 +51,9 @@ diff — a missing `ctx.clip()`, a coordinate outside the plot rect, a label dra
 canvas edge (ELEG-16 had all three).
 
 What it cannot tell you is whether the result **looks** right: colour, font, overlap and
-layout need eyes on `pnpm dev:web`. Reach for jsdom only if you need real layout — it is
-a dependency and an environment switch, not a free upgrade.
+layout need eyes on `pnpm dev:web`. This stub approach is still the right one for canvas
+work — jsdom gives you a DOM, not a renderer, and `getContext('2d')` under it does
+nothing useful.
 
 **Where a new test file goes is decided by the typechecks, not by taste.** A test that
 imports `src/server/**` belongs under `src/server/__tests__/` — `tsconfig.json` excludes
@@ -67,11 +68,39 @@ pnpm test:coverage
 pnpm gates             # the whole set — see .claude/commands/local/gates.md
 ```
 
-`vitest.config.ts` runs in the **node** environment and picks up
-`src/**/*.test.ts` **and `test/**/*.test.ts`**, so a new suite can live in either
-place. There is no jsdom/happy-dom and no browser: a test that touches `document`
-needs a new environment configured, which is a decision to make deliberately rather
-than by adding a `// @vitest-environment` line and moving on.
+`vitest.config.ts` runs in the **node** environment by default and picks up
+`src/**/*.test.ts` **and `test/**/*.test.ts`**, so a new suite can live in either place.
+
+## There IS a DOM environment now — opt in per file (ELEG-61)
+
+`jsdom` is a devDependency, and a test that needs `document` opts in with a **docblock on
+its first line**:
+
+```ts
+// @vitest-environment jsdom
+```
+
+That is the whole mechanism. **There is no config change** — no `environment` key, no
+glob, no setup file — which is deliberate: the pure tests keep running in the faster
+`node` env, and there is nothing for the next person to find and misread. Copy the
+docblock, not a config entry.
+
+`src/__tests__/list-controls-dom.test.ts` is the pattern. Read its header before writing
+another; the two things it establishes:
+
+- **Assert the invariant *and* its counterfactual.** It asserts focus/caret/selection
+  survive a list re-render, and then, in a separate `describe`, mounts the bar *inside*
+  the re-rendered container and asserts focus **is** lost. A test that cannot go red is
+  not coverage, so the failure mode is encoded permanently rather than demonstrated once
+  by hand. Verified: moving the bar inside turns three of the focus tests red.
+- **There is no `localStorage`** — `bare`, `window.` and `globalThis.` are all
+  `undefined` under jsdom 30 on Node 26. `ui-settings.ts` catches and falls back to
+  defaults, so a persistence test would **pass for the wrong reason**. Give each case a
+  unique list id instead, and do not assert persistence until **ELEG-64** lands.
+
+What jsdom still does not give you: layout, paint, real fonts, or `getContext('2d')`.
+Colour, overlap and appearance are still `pnpm dev:web` and eyes, and there is still no
+browser or screenshot in any gate.
 
 ## The typechecks are the real safety net, and one of them is easy to miss
 
@@ -98,13 +127,13 @@ carry the protocol's hard-won knowledge:
   state object into a fixed third-party JSON shape. Pure input → output, and a client
   like Mainsail breaks silently when a field's shape drifts.
 
-**There is no DOM environment at all** — vitest runs `environment: "node"` and neither
-`jsdom` nor `happy-dom` is a dependency, so a test cannot import a module that touches
-`document`. That is why the frontend is written as pure-half / DOM-half pairs:
+**The pure-half / DOM-half split stays, even though jsdom now exists** —
 `card-layout.ts` + `settings.ts`, `list-sort.ts` + `list-controls.ts`. **Put the
-decisions in the pure half** — it is the only half a test can reach — and keep the DOM
-half to markup and wiring. ELEG-61 tracks adding jsdom so the wiring can be asserted
-too; until it lands, "gates green" says nothing whatsoever about anything that renders.
+decisions in the pure half**: those tests are faster, they read better, and they do not
+depend on an environment. What ELEG-61 changed is that the DOM half is no longer
+*unreachable* — wiring, focus behaviour and event handling can now be asserted, and the
+one invariant that had been held up by code review alone now has a test. Everything else
+that renders is still asserted by nothing.
 
 Build fixtures from **captured real payloads** (the debug panel exports the state tree,
 and `${DATA_DIR}/state.json` is a real snapshot) rather than hand-writing an idealised
@@ -220,13 +249,17 @@ because nothing answered is worse than no check.
 
 ## What nothing checks — say so instead of implying otherwise
 
-- **Layout and the actual UI.** No browser test, no screenshot, no playwright. A card
-  that renders empty, overlaps, or throws in the console is invisible to every gate.
-  Look at the page.
+- **Layout and appearance.** No browser test, no screenshot, no playwright. jsdom (above)
+  can now assert *wiring* — that an element exists, keeps focus, responds to a click —
+  but it does no layout and no paint, so a card that renders empty, overlaps, or throws
+  in the console is still invisible to every gate. Look at the page.
 - **The WebSocket contract.** `ws-transport.ts` broadcasts and `ws-client.ts` consumes;
   nothing asserts they agree. Renaming a message `type` on one side is silent.
-- **The MCP surface.** Neither the tool list nor `MCP.md`'s accuracy is verified — the
-  doc can be wrong and no gate notices (see [mcp.md](mcp.md)).
+- **The MCP surface's *behaviour*.** `mcp-doc-parity.test.ts` does check that `MCP.md`
+  lists exactly the registered tools and resources, by standing the server up and asking
+  it — so a renamed tool without a doc edit is caught. But that is a **documentation**
+  check: it never invokes a handler, so a tool that is listed, documented and completely
+  broken passes (see [mcp.md](mcp.md)).
 - **The compatibility layers against a real client.** Mainsail/Fluidd/KlipperScreen
   compatibility is only ever proven by pointing one of them at `:7125`.
 - **Anything about the deployed service.** The gates run in the checkout;

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",
     "@release-it/conventional-changelog": "^12.0.0",
+    "@types/jsdom": "^30.0.0",
     "@types/pdfkit": "^0.17.6",
     "@types/three": "0.178.1",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.10",
     "concurrently": "^10.0.4",
+    "jsdom": "^30.0.1",
     "release-it": "^21.0.1",
     "simple-git-hooks": "^2.11.1",
     "typescript": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@release-it/conventional-changelog':
         specifier: ^12.0.0
         version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.2)(release-it@21.0.1(@types/node@25.9.0)(magicast@0.5.3))
+      '@types/jsdom':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/pdfkit':
         specifier: ^0.17.6
         version: 0.17.6
@@ -82,6 +85,9 @@ importers:
       concurrently:
         specifier: ^10.0.4
         version: 10.0.4
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1(@noble/hashes@1.8.0)
       release-it:
         specifier: ^21.0.1
         version: 21.0.1(@types/node@25.9.0)(magicast@0.5.3)
@@ -96,9 +102,17 @@ importers:
         version: 8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.9.0)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3))
 
 packages:
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -182,6 +196,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
@@ -201,6 +219,42 @@ packages:
   '@conventional-changelog/template@1.2.1':
     resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
     engines: {node: '>=22'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
@@ -366,6 +420,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@grammyjs/types@4.0.0':
     resolution: {integrity: sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==}
@@ -911,6 +974,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/jsdom@30.0.0':
+    resolution: {integrity: sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==}
+
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
@@ -932,6 +998,9 @@ packages:
 
   '@types/three@0.178.1':
     resolution: {integrity: sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -1173,6 +1242,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bl@6.1.6:
     resolution: {integrity: sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==}
 
@@ -1360,9 +1432,17 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   data-uri-to-buffer@8.0.0:
     resolution: {integrity: sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==}
     engines: {node: '>= 20'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1372,6 +1452,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
@@ -1439,6 +1522,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1676,6 +1763,10 @@ packages:
     resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1731,6 +1822,9 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -1783,6 +1877,15 @@ packages:
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1911,6 +2014,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -1936,6 +2043,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2087,6 +2197,9 @@ packages:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2178,6 +2291,10 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
@@ -2260,6 +2377,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -2408,6 +2529,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
@@ -2436,12 +2560,27 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2488,6 +2627,9 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
 
   undici@8.10.0:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
@@ -2601,12 +2743,32 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -2671,6 +2833,13 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2701,6 +2870,21 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2754,6 +2938,10 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.7':
     optional: true
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@colors/colors@1.6.0': {}
 
   '@conventional-changelog/git-client@3.1.1(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.2)':
@@ -2766,6 +2954,30 @@ snapshots:
       conventional-commits-parser: 7.1.2
 
   '@conventional-changelog/template@1.2.1': {}
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -2857,6 +3069,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@exodus/bytes@1.15.1(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@grammyjs/types@4.0.0': {}
 
@@ -3304,6 +3520,13 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/jsdom@30.0.0':
+    dependencies:
+      '@types/node': 25.9.0
+      '@types/tough-cookie': 4.0.5
+      parse5: 8.0.1
+      undici-types: 8.10.0
+
   '@types/node@25.5.2':
     dependencies:
       undici-types: 7.18.2
@@ -3335,6 +3558,8 @@ snapshots:
       '@webgpu/types': 0.1.69
       fflate: 0.8.2
       meshoptimizer: 0.18.1
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/triple-beam@1.3.5': {}
 
@@ -3416,7 +3641,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.9.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@25.9.0)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3516,6 +3741,10 @@ snapshots:
   basic-ftp@5.3.1: {}
 
   before-after-hook@4.0.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bl@6.1.6:
     dependencies:
@@ -3727,11 +3956,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   data-uri-to-buffer@8.0.0: {}
+
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   default-browser-id@5.0.1: {}
 
@@ -3788,6 +4031,8 @@ snapshots:
   enabled@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  entities@8.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -4071,6 +4316,12 @@ snapshots:
 
   hono@4.13.1: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
@@ -4125,6 +4376,8 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-ssh@1.4.1:
@@ -4171,6 +4424,32 @@ snapshots:
   js-sdsl@4.3.0: {}
 
   js-tokens@10.0.0: {}
+
+  jsdom@30.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-schema-traverse@1.0.0: {}
 
@@ -4268,6 +4547,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@7.18.3: {}
 
   macos-release@3.5.1: {}
@@ -4291,6 +4572,8 @@ snapshots:
       escape-string-regexp: 4.0.0
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -4467,6 +4750,10 @@ snapshots:
       '@types/parse-path': 7.1.0
       parse-path: 7.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -4548,6 +4835,8 @@ snapshots:
       - supports-color
 
   proxy-from-env@2.1.0: {}
+
+  punycode@2.3.1: {}
 
   qs@6.15.3:
     dependencies:
@@ -4679,6 +4968,10 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   semver-compare@1.0.0: {}
 
@@ -4856,6 +5149,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   text-hex@1.0.0: {}
 
   three@0.178.0: {}
@@ -4878,9 +5173,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
   toidentifier@1.0.1: {}
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -4939,6 +5248,8 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici-types@8.10.0: {}
+
   undici@8.10.0: {}
 
   unicode-properties@1.4.1:
@@ -4976,7 +5287,7 @@ snapshots:
       tsx: 4.23.11
       yaml: 2.8.3
 
-  vitest@4.1.10(@types/node@25.9.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@25.9.0)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.8.3))
@@ -5001,12 +5312,37 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 30.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -5089,6 +5425,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/src/__tests__/list-controls-dom.test.ts
+++ b/src/__tests__/list-controls-dom.test.ts
@@ -1,0 +1,271 @@
+// @vitest-environment jsdom
+/**
+ * The first DOM tests in this repo (ELEG-61).
+ *
+ * Everything else runs in vitest's default `node` environment, which is faster and is
+ * where the pure halves belong — `list-sort.ts`, `card-layout.ts`, `layer-chart.ts`. The
+ * docblock above opts THIS FILE ALONE into jsdom, which is why there is no config change
+ * anywhere: no `environment` key, no glob, nothing for the next person to discover.
+ * Copy the docblock, not a config entry.
+ *
+ * What is under test is the one invariant `list-controls.ts` is built around and that
+ * ELEG-22 called out as most likely to be got wrong and least likely to be caught:
+ *
+ *   the control bar is mounted once into a STATIC container that is a sibling of the
+ *   list, so re-rendering the list never rebuilds the filter input, and typing survives
+ *   a WebSocket update landing mid-keystroke.
+ *
+ * These views assign `container.innerHTML` wholesale on every 1036 response. If the bar
+ * were built inside that container, an input would be destroyed and recreated under
+ * whoever was typing — losing focus, the caret and any selection.
+ *
+ * NOTE ON THE FAILING DIRECTION. A test that cannot go red is not coverage, so the
+ * counterfactual is encoded here permanently rather than demonstrated once by hand and
+ * described in a commit message: `describe('the failure mode ...')` mounts the bar INSIDE
+ * the re-rendered container and asserts that focus IS lost. If someone "simplifies"
+ * list-controls into the list container, the sibling tests go red — and if someone
+ * weakens these assertions so they pass either way, the counterfactual test goes red
+ * instead, because it would then be asserting a failure that no longer happens.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createListControls } from '../ui/list-controls';
+
+interface Row {
+  name: string;
+  size: number;
+  state: string;
+}
+
+const ROWS: Row[] = [
+  { name: 'benchy.gcode', size: 300, state: 'done' },
+  { name: 'calibration-cube.gcode', size: 100, state: 'failed' },
+  { name: 'vase.gcode', size: 200, state: 'done' },
+];
+
+const COLUMNS = [
+  { key: 'name', label: 'Name', value: (r: Row) => r.name },
+  { key: 'size', label: 'Size', value: (r: Row) => r.size },
+] as const;
+
+/**
+ * Unique per test. Two independent reasons, both worth knowing before writing more of
+ * these:
+ *
+ *  1. `ui-settings.ts` memoises the whole settings object in a module-level `cached`, so
+ *     clearing storage between tests would not reset it — a persisted sort from one test
+ *     would leak into the next.
+ *  2. **There is no `localStorage` in this environment at all.** Measured: `localStorage`,
+ *     `window.localStorage` and `globalThis.localStorage` are all `undefined` under
+ *     jsdom 30 on Node 26. `ui-settings.ts` wraps every access in try/catch, so it
+ *     degrades silently to defaults rather than throwing — which means a test that
+ *     *appeared* to assert persistence would be vacuous. Do not write one until the
+ *     environment actually provides storage (ELEG-64).
+ *
+ * Distinct ids sidestep both, and are cheaper and less brittle than resetting modules.
+ */
+let seq = 0;
+const nextId = () => `test-list-${++seq}`;
+
+/** The real shape from index.html: a static controls div beside the re-rendered list. */
+function mountSiblingLayout() {
+  document.body.innerHTML = `<div id="controls"></div><div id="list"></div>`;
+  return {
+    controls: document.querySelector('#controls') as HTMLElement,
+    list: document.querySelector('#list') as HTMLElement,
+  };
+}
+
+/** What every one of these views does on a WebSocket update. */
+function renderList(list: HTMLElement, rows: readonly Row[]) {
+  list.innerHTML = rows.map((r) => `<div class="row">${r.name}</div>`).join('');
+}
+
+function makeControls(container: HTMLElement, id: string, onChange = () => {}) {
+  return createListControls<Row>({
+    id,
+    container,
+    columns: [...COLUMNS],
+    defaultSort: { key: 'name', dir: 'asc' },
+    filterText: (r) => r.name,
+    noun: 'files',
+    onChange,
+    selects: [
+      {
+        id: 'state',
+        label: 'State',
+        options: [
+          { value: 'done', label: 'Done' },
+          { value: 'failed', label: 'Failed' },
+        ],
+        match: (r, v) => r.state === v,
+      },
+    ],
+  });
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('the focus invariant', () => {
+  it('keeps focus, caret and selection through a list re-render', () => {
+    const { controls, list } = mountSiblingLayout();
+    const api = makeControls(controls, nextId());
+    renderList(list, api.apply(ROWS));
+
+    const input = controls.querySelector('.list-filter') as HTMLInputElement;
+    input.focus();
+    input.value = 'calibration';
+    input.setSelectionRange(4, 9); // mid-word selection, the fragile case
+
+    expect(document.activeElement).toBe(input);
+
+    // A 1036 response lands mid-keystroke.
+    renderList(list, ROWS);
+
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe('calibration');
+    expect(input.selectionStart).toBe(4);
+    expect(input.selectionEnd).toBe(9);
+    // Same node, not a rebuilt one that merely looks the same.
+    expect(controls.querySelector('.list-filter')).toBe(input);
+  });
+
+  it('survives many re-renders, as a burst of updates would cause', () => {
+    const { controls, list } = mountSiblingLayout();
+    makeControls(controls, nextId());
+
+    const input = controls.querySelector('.list-filter') as HTMLInputElement;
+    input.focus();
+    input.value = 'vase';
+
+    for (let i = 0; i < 25; i++) renderList(list, ROWS);
+
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe('vase');
+  });
+
+  it('repaints only the sort buttons when one is clicked, never the input', () => {
+    const { controls } = mountSiblingLayout();
+    makeControls(controls, nextId());
+
+    const input = controls.querySelector('.list-filter') as HTMLInputElement;
+    const sortWrap = controls.querySelector('.list-sort') as HTMLElement;
+    input.focus();
+    input.value = 'ben';
+    input.setSelectionRange(3, 3);
+
+    const sizeBtn = sortWrap.querySelector('[data-key="size"]') as HTMLButtonElement;
+    sizeBtn.click();
+
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe('ben');
+    expect(input.selectionStart).toBe(3);
+    expect(controls.querySelector('.list-filter')).toBe(input);
+
+    // The buttons themselves DID repaint — otherwise this test would pass on a
+    // control bar that simply never updates, which is not the invariant.
+    expect(sortWrap.querySelector('[data-key="size"]')).not.toBe(sizeBtn);
+    expect(
+      (sortWrap.querySelector('[data-key="size"]') as HTMLElement).getAttribute('aria-pressed'),
+    ).toBe('true');
+  });
+
+  it('keeps focus when a dropdown filter changes', () => {
+    const { controls, list } = mountSiblingLayout();
+    const api = makeControls(controls, nextId(), () => renderList(list, api.apply(ROWS)));
+
+    const input = controls.querySelector('.list-filter') as HTMLInputElement;
+    const select = controls.querySelector('.list-select') as HTMLSelectElement;
+    input.focus();
+    input.value = 'a';
+
+    select.value = 'failed';
+    select.dispatchEvent(new Event('change'));
+
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe('a');
+  });
+});
+
+describe('the failure mode the sibling layout prevents', () => {
+  /**
+   * Deliberately WRONG: the control bar is mounted inside the container the render pass
+   * overwrites. This asserts the bug is real, which is what makes the tests above
+   * meaningful — if this ever passes, `renderList` has stopped destroying its children
+   * and the sibling requirement no longer has teeth.
+   */
+  it('loses focus and the caret when the bar is inside the re-rendered container', () => {
+    document.body.innerHTML = `<div id="list"></div>`;
+    const list = document.querySelector('#list') as HTMLElement;
+
+    const bar = document.createElement('div');
+    list.appendChild(bar); // <- the mistake
+    makeControls(bar, nextId());
+
+    const input = bar.querySelector('.list-filter') as HTMLInputElement;
+    input.focus();
+    input.value = 'calibration';
+    input.setSelectionRange(4, 9);
+    expect(document.activeElement).toBe(input);
+
+    renderList(list, ROWS);
+
+    expect(document.activeElement).not.toBe(input);
+    expect(document.body.contains(input)).toBe(false);
+    expect(list.querySelector('.list-filter')).toBeNull();
+  });
+});
+
+describe('the count readout', () => {
+  it('reads "n files" unfiltered and "n of m files" when narrowing', () => {
+    const { controls } = mountSiblingLayout();
+    const api = makeControls(controls, nextId());
+    const count = controls.querySelector('.list-count') as HTMLElement;
+
+    api.apply(ROWS);
+    expect(count.textContent).toBe('3 files');
+
+    const input = controls.querySelector('.list-filter') as HTMLInputElement;
+    input.value = 'gcode';
+    input.dispatchEvent(new Event('input'));
+    api.apply(ROWS);
+    expect(count.textContent).toBe('3 of 3 files');
+
+    input.value = 'vase';
+    input.dispatchEvent(new Event('input'));
+    api.apply(ROWS);
+    expect(count.textContent).toBe('1 of 3 files');
+  });
+
+  it('says nothing at all when there is no data', () => {
+    const { controls } = mountSiblingLayout();
+    const api = makeControls(controls, nextId());
+    const count = controls.querySelector('.list-count') as HTMLElement;
+
+    api.apply([]);
+    expect(count.textContent).toBe('');
+  });
+});
+
+describe('the two empty states', () => {
+  it('distinguishes "no data" from "filtered to nothing"', () => {
+    const { controls } = mountSiblingLayout();
+    const api = makeControls(controls, nextId());
+
+    expect(api.isFiltering()).toBe(false);
+    expect(api.emptyHtml('No files on the printer.')).toContain('No files on the printer.');
+
+    const input = controls.querySelector('.list-filter') as HTMLInputElement;
+    input.value = 'zzzz';
+    input.dispatchEvent(new Event('input'));
+
+    expect(api.isFiltering()).toBe(true);
+    const filtered = api.emptyHtml('No files on the printer.');
+    expect(filtered).toContain('Nothing matches your filter');
+    // The caller's message must NOT leak into the filtered state — they are different
+    // facts and that is the whole point of having two.
+    expect(filtered).not.toContain('No files on the printer.');
+  });
+});


### PR DESCRIPTION
Closes ELEG-61. Files ELEG-64.

## The mechanism: a docblock, and no config at all

`jsdom` is a devDependency and a test opts in with one line:

```ts
// @vitest-environment jsdom
```

That is the whole thing — the option this issue marked as preferred. Worth spelling out why it is more than a style choice: there is **no `test` block in `vite.config.ts`, no glob, no setup file**. The pure tests keep the faster `node` env, and the mechanism is visible at the top of the file that uses it rather than in config someone has to go find.

## The eight cases

**The focus invariant** — the trap ELEG-22 named:

- focus, caret **and selection** survive a list re-render (mid-word selection, the fragile case), and it is the *same node* afterwards rather than a rebuilt one that looks the same
- survives 25 consecutive re-renders, as a burst of updates would cause
- clicking a sort button repaints the buttons and **not** the input — and asserts the buttons genuinely did repaint, so it cannot pass on a bar that simply never updates
- focus survives a dropdown filter change

**The counterfactual** — see below. **The count readout** — `n files` vs `n of m files`, and empty when there is no data. **The two empty states** — including that the caller's "no data" message must *not* leak into the filtered-to-nothing case, which is the whole reason there are two.

## The failing direction, which this issue is right to insist on

Rather than break it by hand once and describe it in a commit message, **the counterfactual is a permanent test**: a separate `describe` mounts the bar *inside* the re-rendered container and asserts focus **is** lost. Two benefits over a one-off demonstration — it stays checkable, and it guards the guard: if someone later weakens the focus assertions until they pass either way, the counterfactual is the test that goes red.

The by-hand mutation was done as well. Moving the shared mount helper to nest the bar inside the list turns **three of the four focus tests red**, on exactly the assertion that matters:

```
× keeps focus, caret and selection through a list re-render
× survives many re-renders, as a burst of updates would cause
× keeps focus when a dropdown filter changes
AssertionError: expected <body><div id="list">…</div></body> to be <input type="search" …>
```

The sort-button test stays **green**, and that is correct rather than a gap: it covers `renderSortButtons` touching only `.list-sort`, which is a different mechanism and is unaffected by where the bar is mounted. Reverted with an inverse patch.

## Something the environment does not do — measured, and filed

**There is no `localStorage` under jsdom 30 on Node 26.** `localStorage`, `window.localStorage` and `globalThis.localStorage` are all `undefined`:

```
bare=undefined | window=undefined | globalThis=undefined | node=v26.5.0
```

This matters more than it looks. `ui-settings.ts` wraps every access in `try/catch` and falls back to defaults, so nothing throws and nothing is logged — a test asserting "the sort choice is persisted and restored" would exercise the catch branch and **pass for the wrong reason**, since the defaults (`{}` and `'all'`) are what such a test would likely expect anyway.

So these tests give each case a **unique list id** instead of clearing storage, assert nothing about persistence, and say why in a comment. **ELEG-64** filed for the environment gap, with the acceptance check it needs (a test that stores, re-reads, and fails if storage is absent).

## Docs

`.agents/testing.md` rewritten where it said the frontend cannot be tested — now documents the docblock, points at this file as the pattern, and records both the counterfactual convention and the localStorage limit.

It also **corrected a wrong claim** found while editing: it said "neither the tool list nor `MCP.md`'s accuracy is verified", but `mcp-doc-parity.test.ts` has checked exactly that since ELEG-7. Fixed to say what is true — it is a *documentation* check, so a tool that is listed, documented and completely broken still passes.

## Verification

`pnpm gates` green: 16 files / 179 tests, up from 15 / 171. The eight new cases are real coverage of a previously untested invariant, shown by the mutation above.

What this still does not cover: jsdom does layout-free, paint-free DOM. Appearance, overlap, colour and `getContext('2d')` remain `pnpm dev:web` and eyes. No e2e was added — explicitly out of scope here.