### PR TITLE
feat(monitoring): tell the two broker_only states apart (ELEG-59)

### DIFF
--- a/.agents/deployment.md
+++ b/.agents/deployment.md
@@ -154,7 +154,7 @@ sudo systemctl stop elegooweb
 **Verify at the receiver, not at the exit code** — a successful `cp` proves nothing:
 
 ```bash
-curl -s localhost:8088/api/health | jq .          # {"ok":true,"mqtt":"connected","build":{…}}
+curl -s localhost:8088/api/health | jq .          # {"ok":true,"mqtt":"connected","mqttPhase":"connected","build":{…}}
 systemctl show -p ActiveEnterTimestamp elegooweb  # did it actually restart?
 journalctl -u elegooweb -n 30 --no-pager          # startup banner: build, printer, ports, AI/Telegram state
 ```
@@ -168,6 +168,23 @@ Two fields in there carry the whole check:
 - **`mqtt":"connected"`** is the one that matters for whether it *works*: the process can
   start happily and fail to reach the printer, and the web UI then looks fine and shows
   nothing.
+
+  **If it is not `connected`, read `mqttPhase` before blaming the deploy** (ELEG-59). The
+  coarse field collapses two unrelated failures into `broker_only`, and the instinct
+  after a deploy is to roll back — which on 2026-08-08 was the wrong move, because the
+  service was fine and the printer's firmware had hung:
+
+  | `mqttPhase` | What it means | Who fixes it |
+  | --- | --- | --- |
+  | `awaiting_sn` | The broker answered but the printer has never published. Registration was **never attempted**, so `mqttRegisterAttempts` is 0. The machine's Linux side is up; its control application is not. | Power-cycle the **printer**. Not a deploy problem. |
+  | `registering` | An SN is known and registration is in flight. Watch `mqttRegisterAttempts` climb. | Wait; if it keeps climbing, the printer is not answering. |
+  | `rejected` | The printer already has its maximum of two clients. | Close another client — the vendor app, or a second copy of this service. |
+
+  `mqttMessage` carries the same thing as one sentence, which is usually all you need:
+
+  ```bash
+  curl -s localhost:8088/api/health | jq -r '.mqttPhase, .mqttRegisterAttempts, .mqttMessage'
+  ```
 
 ## What this means for the tracker
 

--- a/src/__tests__/service-status-dom.test.ts
+++ b/src/__tests__/service-status-dom.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+/**
+ * The MQTT phase as a human actually sees it (ELEG-59), using the jsdom environment
+ * ELEG-61 added. See `list-controls-dom.test.ts` for the conventions.
+ *
+ * The pure decisions — which phase, whether to warn — are tested in `types.test.ts`.
+ * What is asserted here is the wiring: that the phase reaches the badge and the banner,
+ * that the two previously-indistinguishable states now read differently on the page, and
+ * that a browser holding a pre-ELEG-59 payload still renders something sensible.
+ *
+ * This is the layer where the incident actually happened: the classifier could have been
+ * perfect and it would still have cost a journal read if the page kept saying
+ * `registering…`.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type ServiceStatus, updateServiceStatus } from '../ui/service-status';
+
+/** The ids `renderServiceStatus` looks up, and nothing more. */
+function mountShell() {
+  document.body.innerHTML = `
+    <div id="svc-header-wrap">
+      <div id="svc-header-badge"><span id="svc-header-dots"></span><span id="svc-header-count"></span></div>
+      <div id="svc-dropdown" class="hidden"><div id="service-status"></div></div>
+    </div>`;
+  return document.querySelector('#service-status') as HTMLElement;
+}
+
+const BASE: ServiceStatus = {
+  uptime: 120,
+  mqtt: 'broker_only',
+  mqttRegisterAttempts: 0,
+  printerSn: null,
+  printerIp: '192.0.2.10',
+  wsClients: 1,
+  telegram: 'disabled',
+  ai: 'disabled',
+  camera: 'available',
+};
+
+const render = (over: Partial<ServiceStatus>) =>
+  updateServiceStatus({ ...BASE, ...over } as unknown as Record<string, unknown>);
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('the two broker_only states no longer look identical', () => {
+  it('says the printer is not responding when no SN was ever discovered', () => {
+    const panel = mountShell();
+    render({ mqttPhase: 'awaiting_sn', mqttRegisterAttempts: 0 });
+
+    // The incident: registration was never even attempted, so attempts is 0.
+    expect(panel.textContent).toContain('waiting for printer');
+    expect(panel.textContent).toContain('Printer not responding');
+    expect(panel.textContent).toMatch(/power cycle/i);
+    // And crucially it must NOT claim to be registering, which is what sent the
+    // 2026-08-08 diagnosis at the service instead of at the printer.
+    expect(panel.textContent).not.toContain('registering...');
+  });
+
+  it('says the registration was refused, and why, when the printer said code 3', () => {
+    const panel = mountShell();
+    render({ mqttPhase: 'rejected', mqttRegisterAttempts: 4 });
+
+    expect(panel.textContent).toContain('refused');
+    expect(panel.textContent).toContain('Registration refused');
+    expect(panel.textContent).toMatch(/two clients/i);
+  });
+
+  it('renders the two phases differently — the whole point of the change', () => {
+    const panel = mountShell();
+    render({ mqttPhase: 'awaiting_sn' });
+    const awaiting = panel.textContent ?? '';
+    render({ mqttPhase: 'rejected' });
+    const rejected = panel.textContent ?? '';
+
+    expect(awaiting).not.toBe(rejected);
+  });
+});
+
+describe('the banner threshold', () => {
+  it('stays quiet during a normal young registration', () => {
+    const panel = mountShell();
+    render({ mqttPhase: 'registering', mqttRegisterAttempts: 1 });
+
+    expect(panel.textContent).toContain('registering...');
+    expect(panel.querySelector('.svc-firmware-warning')).toBeNull();
+  });
+
+  it('warns once registration has been retried enough to be a problem', () => {
+    const panel = mountShell();
+    render({ mqttPhase: 'registering', mqttRegisterAttempts: 7 });
+
+    expect(panel.querySelector('.svc-firmware-warning')).not.toBeNull();
+    expect(panel.textContent).toContain('7 registration attempts');
+  });
+
+  it('shows no banner at all when connected', () => {
+    const panel = mountShell();
+    render({ mqtt: 'connected', mqttPhase: 'connected', printerSn: 'ABC123' });
+
+    expect(panel.querySelector('.svc-firmware-warning')).toBeNull();
+    expect(panel.textContent).toContain('connected');
+  });
+});
+
+describe('a browser holding a payload from before this shipped', () => {
+  it('falls back to the coarse mqtt field rather than rendering undefined', () => {
+    const panel = mountShell();
+    // No mqttPhase key at all — exactly what an old server sends.
+    render({ mqttPhase: undefined, mqtt: 'broker_only', mqttRegisterAttempts: 0 });
+
+    expect(panel.textContent).toContain('registering...');
+    expect(panel.textContent).not.toContain('undefined');
+  });
+
+  it('still reports a plain disconnect', () => {
+    const panel = mountShell();
+    render({ mqttPhase: undefined, mqtt: 'disconnected' });
+
+    expect(panel.textContent).toContain('disconnected');
+    expect(panel.querySelector('.svc-firmware-warning')).toBeNull();
+  });
+});

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -9,6 +9,9 @@ import {
   BUSY_ERROR_CODES,
   REJECTED_ERROR_CODES,
   powerLossState,
+  mqttPhase,
+  mqttPhaseMessage,
+  mqttBannerHeadline,
 } from '../types';
 
 describe('detectZone', () => {
@@ -145,5 +148,80 @@ describe('powerLossState', () => {
     // 2401/2402 are an ordinary resume and never accompany status 15.
     expect(powerLossState(2, 2401)).toBe('none');
     expect(powerLossState(15, 2401)).toBe('awaiting_decision');
+  });
+});
+
+describe('mqttPhase — telling the two broker_only cases apart (ELEG-59)', () => {
+  const base = { brokerConnected: true, registered: false, snKnown: false, rejected: false };
+
+  it('reports disconnected whenever the broker is down, whatever else is set', () => {
+    // Guards against a stale flag outliving the connection it described.
+    expect(mqttPhase({ ...base, brokerConnected: false })).toBe('disconnected');
+    expect(mqttPhase({ ...base, brokerConnected: false, snKnown: true })).toBe('disconnected');
+    expect(mqttPhase({ ...base, brokerConnected: false, rejected: true })).toBe('disconnected');
+    expect(mqttPhase({ ...base, brokerConnected: false, registered: true })).toBe('disconnected');
+  });
+
+  it('separates "printer never spoke" from "registering" by whether an SN is known', () => {
+    // THE distinction this exists for. Both were `broker_only`, and the UI said
+    // `registering…` for both — pointing the diagnosis at the service when the fault was
+    // a printer whose control application had stopped.
+    expect(mqttPhase({ ...base, snKnown: false })).toBe('awaiting_sn');
+    expect(mqttPhase({ ...base, snKnown: true })).toBe('registering');
+  });
+
+  it('reports rejected in preference to registering, because a refusal is more specific', () => {
+    expect(mqttPhase({ ...base, snKnown: true, rejected: true })).toBe('rejected');
+  });
+
+  it('lets a successful registration win over a stale rejection', () => {
+    // A refusal followed by a slow-retry that succeeded must read `connected`, not
+    // `rejected` — otherwise a working service reports a fault forever.
+    expect(mqttPhase({ ...base, snKnown: true, rejected: true, registered: true })).toBe(
+      'connected',
+    );
+  });
+});
+
+describe('mqttBannerHeadline — the warning that could never fire (ELEG-59)', () => {
+  it('warns immediately when the printer never spoke, with zero attempts', () => {
+    // The regression this pins. The old rule was `broker_only && attempts >= 3`, but in
+    // this phase registration is never attempted, so the counter stays 0 for ever and the
+    // banner was structurally unreachable for the one case that most needed it.
+    expect(mqttBannerHeadline('awaiting_sn', 0)).toBe('Printer not responding');
+  });
+
+  it('warns immediately on a refusal, which does not improve by waiting', () => {
+    expect(mqttBannerHeadline('rejected', 0)).toBe('Registration refused');
+  });
+
+  it('stays quiet while registration is merely young, then speaks up', () => {
+    // A few seconds of registering is normal startup and must not shout.
+    expect(mqttBannerHeadline('registering', 0)).toBeNull();
+    expect(mqttBannerHeadline('registering', 2)).toBeNull();
+    expect(mqttBannerHeadline('registering', 3)).toBe('Printer not answering');
+    expect(mqttBannerHeadline('registering', 12)).toBe('Printer not answering');
+  });
+
+  it('never warns about the two phases that are not problems', () => {
+    for (const attempts of [0, 3, 99]) {
+      expect(mqttBannerHeadline('connected', attempts)).toBeNull();
+      expect(mqttBannerHeadline('disconnected', attempts)).toBeNull();
+    }
+  });
+});
+
+describe('mqttPhaseMessage', () => {
+  it('gives every phase a distinct, non-empty sentence', () => {
+    const phases = ['disconnected', 'awaiting_sn', 'registering', 'rejected', 'connected'] as const;
+    const seen = new Set(phases.map((p) => mqttPhaseMessage(p)));
+    expect(seen.size).toBe(phases.length);
+    for (const p of phases) expect(mqttPhaseMessage(p).length).toBeGreaterThan(0);
+  });
+
+  it('tells the operator what to actually do in the two actionable phases', () => {
+    // These two sentences are the entire content of the 2026-08-08 incident.
+    expect(mqttPhaseMessage('awaiting_sn')).toMatch(/power cycle/i);
+    expect(mqttPhaseMessage('rejected')).toMatch(/two clients/i);
   });
 });

--- a/src/server/mqtt-bridge.ts
+++ b/src/server/mqtt-bridge.ts
@@ -7,6 +7,7 @@ import mqtt from 'mqtt';
 import { EventEmitter } from 'events';
 import WebSocket from 'ws';
 import { getLogger } from './logger.js';
+import { type MqttPhase, mqttPhase } from '../types.js';
 
 const log = getLogger('MQTT');
 
@@ -33,7 +34,17 @@ export class MqttBridge extends EventEmitter {
   private _connected = false;
   private _brokerConnected = false;
   private _registerAttempts = 0;
+  private _rejected = false;
   private heartbeatMissed = 0;
+  private silenceTimer: ReturnType<typeof setTimeout> | null = null;
+  private sawPrinterMessage = false;
+
+  /**
+   * How long to wait after the broker connects before saying out loud that the printer
+   * has not spoken. Long enough not to fire during a normal startup handshake, short
+   * enough to beat a human reaching for the journal.
+   */
+  private static readonly SILENCE_WARN_MS = 30_000;
 
   /**
    * @param initialSn Serial number already known from config or the cache. When set,
@@ -66,6 +77,23 @@ export class MqttBridge extends EventEmitter {
   }
   get registerAttempts(): number {
     return this._registerAttempts;
+  }
+  /** True once the printer has answered `register_response` with `code: 3`. */
+  get registrationRejected(): boolean {
+    return this._rejected;
+  }
+  /**
+   * The five-state phase, which is what a human should be shown. `isConnected` and
+   * `brokerConnected` are kept because the coarse `broker_only` contract on `/api/health`
+   * and `/ws` still reports them — see ELEG-59.
+   */
+  get phase(): MqttPhase {
+    return mqttPhase({
+      brokerConnected: this._brokerConnected,
+      registered: this._connected,
+      snKnown: this.sn !== '',
+      rejected: this._rejected,
+    });
   }
   get serialNumber(): string {
     return this.sn;
@@ -103,6 +131,7 @@ export class MqttBridge extends EventEmitter {
         log.info('No known SN — waiting for the printer to publish. This can hang if the');
         log.info('printer is idle and nothing is registered; set PRINTER_SN to skip it.');
       }
+      this.startSilenceWatch();
     });
 
     this.client.on('message', (topic: string, payload: Buffer) => {
@@ -117,9 +146,15 @@ export class MqttBridge extends EventEmitter {
       this._connected = false;
       this._brokerConnected = false;
       this._registerAttempts = 0;
+      // Cleared with the connection: a refusal describes one session's client count, and
+      // carrying it across a reconnect would report `rejected` for a printer that has
+      // since freed a slot.
+      this._rejected = false;
+      this.sawPrinterMessage = false;
       this.stopHeartbeat();
       this.stopRegisterRetry();
       this.stopSlowRegisterRetry();
+      this.stopSilenceWatch();
       this.emit('disconnected');
     });
   }
@@ -136,6 +171,9 @@ export class MqttBridge extends EventEmitter {
 
     // Any message from the printer resets the heartbeat miss counter
     this.heartbeatMissed = 0;
+    // ...and proves the printer is not the silent one, which is what separates
+    // `awaiting_sn` from a genuine registration problem (ELEG-59).
+    this.sawPrinterMessage = true;
 
     // Discover SN from any elegoo/<sn>/... topic
     if (!this.sn && topic.startsWith('elegoo/')) {
@@ -154,8 +192,10 @@ export class MqttBridge extends EventEmitter {
         log.info('Registered successfully');
         this._connected = true;
         this._registerAttempts = 0;
+        this._rejected = false;
         this.stopRegisterRetry();
         this.stopSlowRegisterRetry();
+        this.stopSilenceWatch();
         this.subscribeAll();
         this.startHeartbeat();
         // Request initial data
@@ -166,6 +206,7 @@ export class MqttBridge extends EventEmitter {
         this.emit('connected', this.sn);
       } else if ((data.code as number) === 3) {
         log.warn('Registration rejected: too many clients (max 2). Will retry every 30s...');
+        this._rejected = true;
         this.stopRegisterRetry();
         this.startSlowRegisterRetry();
       }
@@ -206,6 +247,47 @@ export class MqttBridge extends EventEmitter {
     if (this.registerTimer) {
       clearInterval(this.registerTimer);
       this.registerTimer = null;
+    }
+  }
+
+  /**
+   * Say out loud that the printer has not spoken (ELEG-59).
+   *
+   * The failure this exists for produces **no log line at all**: the broker accepts the
+   * connection, `elegoo/#` is subscribed, and then nothing ever arrives — so the most
+   * informative thing in the journal is the absence of a line, which is indistinguishable
+   * from "still trying". One timer turns that silence into a sentence.
+   */
+  private startSilenceWatch(): void {
+    this.stopSilenceWatch();
+    this.silenceTimer = setTimeout(() => {
+      if (this._connected || this.sawPrinterMessage) return;
+      const secs = Math.round(MqttBridge.SILENCE_WARN_MS / 1000);
+      log.warn(
+        `Broker connected but the printer has been silent for ${secs}s — no message on ` +
+          'elegoo/# has arrived.',
+      );
+      if (!this.sn) {
+        log.warn(
+          "No SN discovered, so registration has NOT been attempted. The printer's " +
+            'control application is probably not running; a power cycle usually fixes it. ' +
+            'Set PRINTER_SN to register without waiting to overhear the printer.',
+        );
+      } else {
+        log.warn(
+          `Registering with SN ${this.sn} (${this._registerAttempts} attempts) but the ` +
+            'printer is not answering.',
+        );
+      }
+    }, MqttBridge.SILENCE_WARN_MS);
+    // Never hold the process open just to complain about silence.
+    this.silenceTimer.unref?.();
+  }
+
+  private stopSilenceWatch(): void {
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+      this.silenceTimer = null;
     }
   }
 

--- a/src/server/rest-api.ts
+++ b/src/server/rest-api.ts
@@ -30,7 +30,13 @@ import { generateReportPDF } from './print-report-pdf.js';
 import { getBuildInfo } from './build-info.js';
 import { applyCors, corsHeaders } from './cors.js';
 import { getLogger } from './logger.js';
-import { STATUS_NAMES, SUB_STATUS_NAMES, SPEED_MODE_NAMES, EXCEPTION_NAMES } from '../types.js';
+import {
+  STATUS_NAMES,
+  SUB_STATUS_NAMES,
+  SPEED_MODE_NAMES,
+  EXCEPTION_NAMES,
+  mqttPhaseMessage,
+} from '../types.js';
 import type { FanInfo } from '../types.js';
 
 const log = getLogger('REST');
@@ -744,6 +750,15 @@ export function createRestRouter(
             : _bridge?.brokerConnected
               ? 'broker_only'
               : 'disconnected',
+          // `mqtt` above stays as it was for existing consumers. These three are what
+          // make a `broker_only` diagnosable without a journal read (ELEG-59):
+          // `mqttPhase` separates "printer never spoke" from "registration refused",
+          // `mqttRegisterAttempts` separates 0 (never started) from 12 (trying and
+          // failing), and `mqttMessage` is the sentence to show a human.
+          mqttPhase: _bridge?.phase ?? 'disconnected',
+          mqttRegisterAttempts: _bridge?.registerAttempts ?? 0,
+          mqttMessage: mqttPhaseMessage(_bridge?.phase ?? 'disconnected'),
+          printerSn: _bridge?.serialNumber || null,
           clients: 0, // filled in by ws-transport if needed
           // Which commit is serving this. All-null on an unstamped deploy or a dev
           // run; cached, because this endpoint is polled.

--- a/src/server/ws-transport.ts
+++ b/src/server/ws-transport.ts
@@ -143,6 +143,10 @@ export class WebSocketTransport {
     return {
       uptime: Math.floor((Date.now() - this.startTime) / 1000),
       mqtt: mqttState,
+      // The coarse `mqtt` above is kept as-is for any existing consumer; `mqttPhase`
+      // splits its `broker_only` into awaiting_sn / registering / rejected, which is the
+      // distinction a human actually needs (ELEG-59).
+      mqttPhase: this.bridge.phase,
       mqttRegisterAttempts: this.bridge.registerAttempts,
       printerSn: this.bridge.serialNumber || null,
       printerIp: this.bridge.ip,

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,100 @@ export function isFilamentChangeSubStatus(subStatus: number): boolean {
   return false;
 }
 
+// ─── MQTT connection phase ───────────────────────────────────────────
+
+/**
+ * How far the bridge has got towards being registered with the printer.
+ *
+ * This exists because `broker_only` covered two completely different situations and the
+ * UI rendered both as `registering…` (ELEG-59). During the 2026-08-08 incident that
+ * distinction cost a journal read plus a packet-level probe:
+ *
+ * - **`awaiting_sn`** — the broker accepted us but the printer has never spoken, so no
+ *   SN was ever learned and **registration was never attempted**. `registerAttempts`
+ *   stays 0 forever. This is a *printer-side* problem: the machine's Linux side is up
+ *   (the broker answered) but its control application is not running. Nothing in the
+ *   journal marks it, because the symptom is the *absence* of a line.
+ * - **`registering`** — an SN is known and registration is genuinely in flight or being
+ *   retried. `registerAttempts` climbs.
+ * - **`rejected`** — the printer answered `register_response` with `code: 3`, i.e. it
+ *   already has its maximum of two clients. Retrying every 30s will not help until one
+ *   of them goes away.
+ *
+ * Reading `registering…` when the truth is `awaiting_sn` points the diagnosis at the
+ * service, which is the opposite of where the fault is — in the incident the service was
+ * behaving perfectly and the printer's firmware had hung.
+ */
+export type MqttPhase = 'disconnected' | 'awaiting_sn' | 'registering' | 'rejected' | 'connected';
+
+export interface MqttPhaseInput {
+  /** TCP+MQTT session with the broker is up. */
+  brokerConnected: boolean;
+  /** `register_response` came back `ok` — the only state in which commands work. */
+  registered: boolean;
+  /** An SN is known, from discovery, config or the cache. Registration needs one. */
+  snKnown: boolean;
+  /** The printer refused registration (`code: 3`, too many clients). */
+  rejected: boolean;
+}
+
+/**
+ * Pure classifier, in the shape of `powerLossState` above.
+ *
+ * Order matters: `registered` wins over everything (a stale `rejected` flag from an
+ * earlier attempt must not mask a connection that has since succeeded), and `rejected`
+ * outranks `registering` because a refusal is a more specific fact than "still trying".
+ */
+export function mqttPhase(input: MqttPhaseInput): MqttPhase {
+  if (!input.brokerConnected) return 'disconnected';
+  if (input.registered) return 'connected';
+  if (input.rejected) return 'rejected';
+  return input.snKnown ? 'registering' : 'awaiting_sn';
+}
+
+/**
+ * Whether to shout about the current phase, and what to call it.
+ *
+ * `null` means "no banner" — the two healthy-ish phases plus a registration that has only
+ * just started. The threshold applies **only** to `registering`, because that is the one
+ * phase where waiting a few seconds is normal. `awaiting_sn` and `rejected` warn
+ * immediately: neither improves by itself, and the old rule (`broker_only` **and**
+ * `attempts >= 3`) could never fire for `awaiting_sn` at all, since registration is never
+ * attempted there and the counter stays 0 forever. That was the bug (ELEG-59).
+ */
+export function mqttBannerHeadline(
+  phase: MqttPhase,
+  registerAttempts: number,
+  attemptThreshold = 3,
+): string | null {
+  switch (phase) {
+    case 'awaiting_sn':
+      return 'Printer not responding';
+    case 'rejected':
+      return 'Registration refused';
+    case 'registering':
+      return registerAttempts >= attemptThreshold ? 'Printer not answering' : null;
+    default:
+      return null;
+  }
+}
+
+/** One sentence a human can act on. The UI shows this; the incident *was* this text. */
+export function mqttPhaseMessage(phase: MqttPhase): string {
+  switch (phase) {
+    case 'connected':
+      return 'Registered with the printer.';
+    case 'disconnected':
+      return 'No MQTT connection to the printer.';
+    case 'awaiting_sn':
+      return 'The broker is reachable but the printer is not responding. Its control application may have stopped — it may need a power cycle.';
+    case 'rejected':
+      return 'The printer refused registration: it already has the maximum of two clients. Close another client (the vendor app, or a second copy of this service) and it will retry.';
+    case 'registering':
+      return 'Registering with the printer.';
+  }
+}
+
 // ─── Power loss recovery ─────────────────────────────────────────────
 
 /** Machine status the CC2 reports after a power loss with a print in progress. */

--- a/src/ui/service-status.ts
+++ b/src/ui/service-status.ts
@@ -2,10 +2,17 @@
 
 import { $, escapeHtml } from './helpers';
 import type { PrinterState } from '../printer-state';
+import { type MqttPhase, mqttBannerHeadline, mqttPhaseMessage } from '../types';
 
 export interface ServiceStatus {
   uptime: number;
   mqtt: string;
+  /**
+   * The finer split of `mqtt`'s `broker_only` (ELEG-59). Optional because a browser can
+   * outlive a server restart and still be holding a `service_status` from before this
+   * shipped; `phaseOf()` falls back to the coarse field in that case.
+   */
+  mqttPhase?: MqttPhase;
   mqttRegisterAttempts: number;
   printerSn: string | null;
   printerIp: string;
@@ -19,6 +26,27 @@ interface ServiceCheck {
   label: string;
   state: string;
   okValues: string[];
+}
+
+/** What the MQTT row reads. `registering…` is now reserved for actually registering. */
+const PHASE_LABELS: Record<MqttPhase, string> = {
+  connected: 'connected',
+  disconnected: 'disconnected',
+  awaiting_sn: 'waiting for printer',
+  registering: 'registering...',
+  rejected: 'refused — too many clients',
+};
+
+/**
+ * Prefer the server's phase; fall back to deriving one from the coarse `mqtt` field so a
+ * browser holding a pre-ELEG-59 `service_status` still renders sensibly. The fallback
+ * cannot tell `awaiting_sn` from `registering` — that is the whole point of the new
+ * field — so it reports the vaguer of the two rather than guessing.
+ */
+function phaseOf(s: ServiceStatus): MqttPhase {
+  if (s.mqttPhase) return s.mqttPhase;
+  if (s.mqtt === 'connected') return 'connected';
+  return s.mqtt === 'broker_only' ? 'registering' : 'disconnected';
 }
 
 let lastStatus: ServiceStatus | null = null;
@@ -101,13 +129,18 @@ export function renderServiceStatus(): void {
   // Dropdown detail
   if (!dropdown) return;
 
-  let mqttLabel = s.mqtt;
-  if (s.mqtt === 'broker_only') mqttLabel = 'registering...';
+  const phase = phaseOf(s);
+  const mqttLabel = PHASE_LABELS[phase];
 
-  const showFirmwareWarning = s.mqtt === 'broker_only' && s.mqttRegisterAttempts >= 3;
-  const firmwareBanner = showFirmwareWarning
+  // The banner used to fire on `broker_only && attempts >= 3`, which meant it could
+  // never fire for the case that most needed it: when the printer never speaks, no SN is
+  // learned, registration is never attempted and `mqttRegisterAttempts` stays 0 forever
+  // (ELEG-59). The decision now lives in `mqttBannerHeadline`, where it is testable.
+  const headline = mqttBannerHeadline(phase, s.mqttRegisterAttempts);
+  const firmwareBanner = headline
     ? `<div class="svc-firmware-warning">
-        ⚠️ <strong>Firmware not responding</strong> — ${s.mqttRegisterAttempts} registration attempts. Try power-cycling.
+        ⚠️ <strong>${escapeHtml(headline)}</strong> — ${escapeHtml(mqttPhaseMessage(phase))}
+        ${phase === 'registering' ? `(${s.mqttRegisterAttempts} registration attempts)` : ''}
       </div>`
     : '';
 


### PR DESCRIPTION
Closes ELEG-59.

## The bug was worse than the issue described

The issue says `registerAttempts` "already exists on the bridge and nothing surfaces it". Checked: `ws-transport.ts` **already** surfaced it, and `service-status.ts` already had a "Firmware not responding" banner gated on it:

```ts
const showFirmwareWarning = s.mqtt === 'broker_only' && s.mqttRegisterAttempts >= 3;
```

Now look at what that does in the incident's own failure mode. When the printer never speaks, no SN is learned, `register()` is never called, and `_registerAttempts` **stays 0 for the life of the process**. So `attempts >= 3` can never be true, and **the only diagnostic the UI had was structurally unreachable for precisely the case that needed it.**

Only `/api/health` was genuinely missing the field. The banner's trigger was the real defect.

## What shipped

**A pure classifier**, in `types.ts` beside `powerLossState` as the issue suggests:

```ts
mqttPhase({ brokerConnected, registered, snKnown, rejected })
//  -> 'disconnected' | 'awaiting_sn' | 'registering' | 'rejected' | 'connected'
```

`awaiting_sn` vs `registering` is decided by whether an SN is known — which is exactly the fact that separates "the printer has never spoken" from "we are trying and it is not answering".

**The bridge** tracks a `_rejected` flag beside the existing counters and exposes `.phase`. The flag is cleared on `close` and on a successful registration: a refusal describes one session's client count, and carrying it across a reconnect would report `rejected` for a printer that has since freed a slot.

**Both transports** gained `mqttPhase`; `/api/health` also gained `mqttRegisterAttempts` and a one-sentence `mqttMessage`. **The coarse `mqtt` field keeps its existing three values** so nothing reading it breaks — the UI prefers `mqttPhase` and falls back to deriving one when it is absent, which is what a browser holding a `service_status` from before this shipped will send it.

**The banner decision** moved into `mqttBannerHeadline(phase, attempts)`, where it is testable. The threshold now applies **only** to `registering`, where a few seconds is normal startup; `awaiting_sn` and `rejected` warn immediately, because neither improves by waiting.

**The silence is logged.** The failure produced *no log line at all*, so the most informative thing in the journal was the absence of one. A 30s timer after broker connect now says so — and says which of the two states it is. `unref`'d, so it never holds the process open.

## Verification

`pnpm gates` green. **17 files / 197 tests, up from 16 / 179.** Unusually for this repo, the change is genuinely covered:

- **`mqttPhase`, `mqttBannerHeadline`, `mqttPhaseMessage`** — unit tested, including the precedence rules.
- **The UI wiring** — eight jsdom tests (`service-status-dom.test.ts`), using the environment ELEG-61 landed an hour ago. This is the layer the incident actually happened at: a perfect classifier still costs a journal read if the page keeps saying `registering…`. Asserts the two states now render differently, that `awaiting_sn` does **not** say "registering...", and that the old-payload fallback renders no `undefined`.

**Both new invariants were shown to fail in the failing direction**, with inverse patches, not `git checkout`:

| Mutation | Result |
| --- | --- |
| Move `rejected` above `registered` in the classifier | `× lets a successful registration win over a stale rejection` — `expected 'rejected' to be 'connected'` |
| Reintroduce the original bug (gate `awaiting_sn` on the attempt threshold) | `× warns immediately when the printer never spoke, with zero attempts` — `expected null to be 'Printer not responding'` |

The second is the important one: the regression this PR fixes is now pinned by a named test.

`mqttPhase` verified present on both sides of the `/ws` contract (produced in `ws-transport.ts:149`, consumed in `service-status.ts:47`) — that contract is asserted by nothing, so a rename would otherwise be silent.

**Not covered by anything:** the bridge's own state transitions, including the silence timer. `MqttBridge` has no test and standing one up means a broker. The `_rejected` lifecycle and the timer were read by hand; the classifier they feed is what carries the test coverage.

## Docs

`.agents/deployment.md` — the deploy-verification section now says to read `mqttPhase` **before blaming the deploy**, with a table of phase → meaning → who fixes it. That is the operational half of this issue: the instinct after a deploy is to roll back, and on 2026-08-08 that would have been wrong.

No printer interaction anywhere in this change.