### PR TITLE
fix(server): stop Moonraker compat fabricating JWTs and user accounts (ELEG-53)

### DIFF
--- a/src/server/__tests__/compat-auth.test.ts
+++ b/src/server/__tests__/compat-auth.test.ts
@@ -3,6 +3,8 @@ import {
   octoprintApiSettings,
   octoprintLoginPayload,
   NO_API_KEY_MESSAGE,
+  NO_SESSIONS_MESSAGE,
+  ONESHOT_TOKEN,
   MOONRAKER_NO_API_KEY_CODE,
 } from '../compat-auth.js';
 
@@ -63,5 +65,39 @@ describe('the no-API-key answer', () => {
 
   it('uses a JSON-RPC error code, not a success code', () => {
     expect(MOONRAKER_NO_API_KEY_CODE).toBeLessThan(0);
+  });
+});
+
+describe('the no-sessions answer (ELEG-53)', () => {
+  it('explains itself, and points at the field that says login is unnecessary', () => {
+    // A client's UI shows this string. "Unauthorized" would send someone hunting for a
+    // password that does not exist; naming access.info tells them where to look instead.
+    expect(NO_SESSIONS_MESSAGE).toMatch(/no authentication/i);
+    expect(NO_SESSIONS_MESSAGE).toMatch(/login_required/);
+    expect(NO_SESSIONS_MESSAGE.length).toBeGreaterThan(20);
+  });
+
+  it('mentions no credential and no user account', () => {
+    // The regression this exists to catch, in the shape ELEG-26 used for the API key:
+    // a token reintroduced under any name at all.
+    expect(NO_SESSIONS_MESSAGE).not.toMatch(/elegoo-compat/i);
+    expect(NO_SESSIONS_MESSAGE).toMatch(/issues no tokens/i);
+  });
+});
+
+describe('the oneshot token, which is deliberately still issued', () => {
+  it('is a non-empty string, because withdrawing it could break the WebSocket', () => {
+    // Real Moonraker uses this where a header cannot be set (WebSocket, camera stream),
+    // and a client may fetch one BEFORE reading access.info. Refusing it would be a
+    // regression, not a security improvement — nothing validates it either way.
+    expect(typeof ONESHOT_TOKEN).toBe('string');
+    expect(ONESHOT_TOKEN.length).toBeGreaterThan(0);
+  });
+
+  it('does not read like a credential when it shows up in a URL or a log', () => {
+    // It lands in query strings, proxy logs and browser network tabs. Anyone who sees it
+    // should be able to tell at a glance that nothing is being authenticated.
+    expect(ONESHOT_TOKEN).not.toMatch(/token|key|secret|jwt|auth[^-]/i);
+    expect(ONESHOT_TOKEN).toBe('no-auth-required');
   });
 });

--- a/src/server/compat-auth.ts
+++ b/src/server/compat-auth.ts
@@ -26,6 +26,47 @@ export const NO_API_KEY_MESSAGE =
 export const MOONRAKER_NO_API_KEY_CODE = -32601;
 
 /**
+ * Returned in place of a fabricated JWT / refresh token / created user (ELEG-53).
+ *
+ * ELEG-26 withdrew the fake **API key** and deliberately left the session-credential
+ * surface alone, because the breakage risk was different and unassessed. This is that
+ * follow-up: `access.login`, `access.refresh_jwt` and `access.post_user` were handing
+ * back `elegoo-compat-jwt-token` / `elegoo-compat-refresh-token` and, for `post_user`, a
+ * "created" user that is stored nowhere. Nothing was ever issued, stored or checked.
+ *
+ * `post_user` was the worst of them: inventing a user implies a user store, and there is
+ * no user store.
+ *
+ * These are safe to withdraw because `access.info` reports `login_required: false`, which
+ * is how a well-behaved client learns not to log in — so a client reaching these was
+ * already off the documented path. `oneshot_token` is the exception and is kept; see
+ * `ONESHOT_TOKEN` below.
+ */
+export const NO_SESSIONS_MESSAGE =
+  'This service has no authentication and issues no tokens or user accounts. ' +
+  'See access.info: login_required is false. ' +
+  'Access is controlled by the network it is reachable from.';
+
+/**
+ * The one credential-shaped answer that is deliberately **kept**.
+ *
+ * In real Moonraker `oneshot_token` exists so a browser can open a WebSocket or a camera
+ * stream where an `Authorization` header cannot be set — the token goes in the query
+ * string instead. A client may fetch one **before** it reads `access.info`, so refusing
+ * it risks breaking the WebSocket connection outright. That is a regression, not a
+ * security improvement, and this service checks nothing either way: withdrawing it would
+ * remove no protection whatsoever, because there is none to remove.
+ *
+ * So it keeps answering — but with a string that tells the truth when it turns up in a
+ * URL, a proxy log or a browser's network tab, instead of one that reads like a
+ * credential. Any value works, since nothing validates it on the way back in.
+ *
+ * If a future change ever adds real authentication, this is one of the places that has
+ * to stop being a no-op.
+ */
+export const ONESHOT_TOKEN = 'no-auth-required';
+
+/**
  * OctoPrint's `api` block in `GET /api/settings`.
  *
  * `enabled: false` is the honest statement, and it is a statement OctoPrint clients

--- a/src/server/moonraker-server.ts
+++ b/src/server/moonraker-server.ts
@@ -40,7 +40,12 @@ import type { StateStore } from './state-store.js';
 import type { MqttBridge } from './mqtt-bridge.js';
 import type { ServiceConfig } from './config.js';
 import { applyCors, corsHeaders } from './cors.js';
-import { NO_API_KEY_MESSAGE, MOONRAKER_NO_API_KEY_CODE } from './compat-auth.js';
+import {
+  NO_API_KEY_MESSAGE,
+  NO_SESSIONS_MESSAGE,
+  ONESHOT_TOKEN,
+  MOONRAKER_NO_API_KEY_CODE,
+} from './compat-auth.js';
 import type { FanInfo } from '../types.js';
 import { MOONRAKER_VERSION, AVAILABLE_OBJECTS, queryObjects } from './moonraker-compat.js';
 import { createOctoPrintRouter } from './octoprint-compat.js';
@@ -996,67 +1001,38 @@ export class MoonrakerServer {
         break;
 
       case 'access.oneshot_token':
-        client.ws.send(rpcResult(msg.id, 'elegoo-compat-token'));
+        // Deliberately still answers — see ONESHOT_TOKEN in compat-auth.ts. A browser
+        // may fetch this for a WebSocket or camera URL before it reads `access.info`,
+        // so refusing it risks breaking the connection outright, and withdrawing it
+        // would remove no protection because nothing validates it coming back.
+        client.ws.send(rpcResult(msg.id, ONESHOT_TOKEN));
         break;
 
       case 'access.login':
-        client.ws.send(
-          rpcResult(msg.id, {
-            username: String(msg.params?.username ?? 'elegoo'),
-            token: 'elegoo-compat-jwt-token',
-            refresh_token: 'elegoo-compat-refresh-token',
-            action: 'user_logged_in',
-            source: 'moonraker',
-          }),
-        );
+        // No session is created, so no token is returned (ELEG-53). See `access.info`
+        // below: `login_required: false` is how a client learns not to come here.
+        client.ws.send(rpcError(msg.id, MOONRAKER_NO_API_KEY_CODE, NO_SESSIONS_MESSAGE));
         break;
 
       case 'access.logout':
         client.ws.send(rpcResult(msg.id, { username: 'elegoo', action: 'user_logged_out' }));
         break;
 
+      // There is no user store, so nothing here can create, delete or re-credential a
+      // user. Answering `user_created` was the worst of the fabrications: it implies a
+      // store that does not exist (ELEG-53).
       case 'access.post_user':
-        client.ws.send(
-          rpcResult(msg.id, {
-            username: String(msg.params?.username ?? 'elegoo'),
-            token: 'elegoo-compat-jwt-token',
-            refresh_token: 'elegoo-compat-refresh-token',
-            action: 'user_created',
-            source: 'moonraker',
-          }),
-        );
-        break;
-
       case 'access.delete_user':
-        client.ws.send(
-          rpcResult(msg.id, {
-            username: String(msg.params?.username ?? ''),
-            action: 'user_deleted',
-          }),
-        );
+      case 'access.user.password':
+      case 'access.refresh_jwt':
+        client.ws.send(rpcError(msg.id, MOONRAKER_NO_API_KEY_CODE, NO_SESSIONS_MESSAGE));
         break;
 
       case 'access.users.list':
-        client.ws.send(
-          rpcResult(msg.id, {
-            users: [{ username: 'elegoo', source: 'moonraker', created_on: Date.now() / 1000 }],
-          }),
-        );
-        break;
-
-      case 'access.user.password':
-        client.ws.send(rpcResult(msg.id, { username: 'elegoo', action: 'user_password_reset' }));
-        break;
-
-      case 'access.refresh_jwt':
-        client.ws.send(
-          rpcResult(msg.id, {
-            username: 'elegoo',
-            token: 'elegoo-compat-jwt-token',
-            source: 'moonraker',
-            action: 'user_jwt_refresh',
-          }),
-        );
+        // Empty, because there are no users — rather than inventing one called 'elegoo'.
+        // A list is still the right shape here: a client asking "who exists?" can be
+        // told "nobody" without an error, and Mainsail renders that fine.
+        client.ws.send(rpcResult(msg.id, { users: [] }));
         break;
 
       case 'access.get_api_key':
@@ -1659,18 +1635,17 @@ export class MoonrakerServer {
     }
 
     // --- GET /access/oneshot_token ---
+    // Kept on purpose — see ONESHOT_TOKEN in compat-auth.ts and the JSON-RPC case above.
     if (urlPath === '/access/oneshot_token' && method === 'GET') {
-      jsonResult(res, 'elegoo-compat-token');
+      jsonResult(res, ONESHOT_TOKEN);
       return;
     }
 
     // --- GET /access/user ---
+    // A read of "the current user". There is no user store and no session, so there is
+    // no current user to describe (ELEG-53).
     if (urlPath === '/access/user' && method === 'GET') {
-      jsonResult(res, {
-        username: 'elegoo',
-        source: 'moonraker',
-        created_on: Date.now() / 1000,
-      });
+      jsonError(res, NO_SESSIONS_MESSAGE, 404);
       return;
     }
 
@@ -1871,20 +1846,11 @@ export class MoonrakerServer {
     }
 
     // --- Auth endpoints ---
-    // POST /access/login
+    // POST /access/login — no session is created, so no token is returned (ELEG-53).
+    // `GET /access/info` reports login_required: false, which is where a client should
+    // have learned not to come here.
     if (urlPath === '/access/login' && method === 'POST') {
-      readBody(req)
-        .then((body) => {
-          const parsed = JSON.parse(body);
-          jsonResult(res, {
-            username: String(parsed.username ?? 'elegoo'),
-            token: 'elegoo-compat-jwt-token',
-            refresh_token: 'elegoo-compat-refresh-token',
-            action: 'user_logged_in',
-            source: 'moonraker',
-          });
-        })
-        .catch(() => jsonError(res, 'Invalid JSON'));
+      jsonError(res, NO_SESSIONS_MESSAGE, 404);
       return;
     }
 
@@ -1894,22 +1860,15 @@ export class MoonrakerServer {
       return;
     }
 
-    // GET /access/users/list
+    // GET /access/users/list — empty, because there are no users (ELEG-53).
     if (urlPath === '/access/users/list' && method === 'GET') {
-      jsonResult(res, {
-        users: [{ username: 'elegoo', source: 'moonraker', created_on: Date.now() / 1000 }],
-      });
+      jsonResult(res, { users: [] });
       return;
     }
 
-    // POST /access/refresh_jwt
+    // POST /access/refresh_jwt — nothing was issued, so nothing can be refreshed.
     if (urlPath === '/access/refresh_jwt' && method === 'POST') {
-      jsonResult(res, {
-        username: 'elegoo',
-        token: 'elegoo-compat-jwt-token',
-        source: 'moonraker',
-        action: 'user_jwt_refresh',
-      });
+      jsonError(res, NO_SESSIONS_MESSAGE, 404);
       return;
     }
 
@@ -1919,32 +1878,14 @@ export class MoonrakerServer {
       return;
     }
 
-    // POST /access/user (create user)
-    if (urlPath === '/access/user' && method === 'POST') {
-      readBody(req)
-        .then((body) => {
-          const parsed = JSON.parse(body);
-          jsonResult(res, {
-            username: String(parsed.username ?? 'elegoo'),
-            token: 'elegoo-compat-jwt-token',
-            refresh_token: 'elegoo-compat-refresh-token',
-            action: 'user_created',
-            source: 'moonraker',
-          });
-        })
-        .catch(() => jsonError(res, 'Invalid JSON'));
-      return;
-    }
-
-    // DELETE /access/user
-    if (urlPath === '/access/user' && method === 'DELETE') {
-      jsonResult(res, { username: query.username ?? '', action: 'user_deleted' });
-      return;
-    }
-
-    // POST /access/user/password
-    if (urlPath === '/access/user/password' && method === 'POST') {
-      jsonResult(res, { username: 'elegoo', action: 'user_password_reset' });
+    // POST /access/user (create) / DELETE /access/user / POST /access/user/password.
+    // There is no user store, so none of these can do anything. Reporting `user_created`
+    // for a user stored nowhere was the worst of the fabrications (ELEG-53).
+    if (
+      (urlPath === '/access/user' && (method === 'POST' || method === 'DELETE')) ||
+      (urlPath === '/access/user/password' && method === 'POST')
+    ) {
+      jsonError(res, NO_SESSIONS_MESSAGE, 404);
       return;
     }
 


### PR DESCRIPTION
Closes ELEG-53. Files ELEG-67.

Child of ELEG-2 (no authentication anywhere in the service) — that parent stays open; only this slice is done.

## The part that could not be done unattended, and was split rather than skipped

This issue's **step 1** is *"Establish the facts first. Point Mainsail, Fluidd and KlipperScreen at the service and watch which of these endpoints are actually called."* That needs a human with a client. Skipping the issue, or doing the code and quietly calling the unverified part done, were both worse options than splitting.

So the repo half lands here on the reasoned argument below, and the confirmation is **ELEG-67**, `OPERATOR:`-titled and self-contained — exact commands, what to watch, what to report, and what to do if something breaks.

## What changed

| Handler | Before | Now |
| --- | --- | --- |
| `access.login`, `access.refresh_jwt` (+ HTTP twins) | `elegoo-compat-jwt-token` / `elegoo-compat-refresh-token` | explicit error |
| `access.post_user`, `access.delete_user`, `access.user.password`, `GET /access/user` | success, and a token pair for a user stored nowhere | explicit error |
| `access.users.list` | invented a user called `elegoo` | `{ users: [] }` |
| `access.logout` | acknowledges | unchanged — harmless, and keeps clients happy |
| **`access.oneshot_token`** | `elegoo-compat-token` | **still answers**, with `no-auth-required` |

The last three rows go slightly beyond this issue's table. `delete_user` and `user.password` are the identical defect — writes to a user store that does not exist — and leaving them would have been exactly the "remainder in prose" failure the project rules warn about. `users.list` was inventing the user that `post_user` pretended to create.

## The reasoning behind the withdrawals

`access.info` reports `login_required: false`, which is precisely how a well-behaved Moonraker client learns not to log in. Anything reaching `login` / `refresh_jwt` / `post_user` was already off the documented path, and withdrawing them removes **no protection**, because there is none — nothing was issued, stored, or checked. The error message names `access.info` explicitly, so a human reading it in a client's UI is pointed at the answer rather than hunting for a password that does not exist.

## The oneshot token: kept, but no longer credential-shaped

This issue is right that it is the risky one, and I did not withdraw it. In real Moonraker it exists where an `Authorization` header cannot be set — WebSocket and camera URLs — and a client may fetch one **before** it reads `access.info`. Refusing it could break the connection outright, which is a regression rather than a security improvement.

But it does not have to keep lying. It returns **`no-auth-required`**. Nothing validates it coming back, so any string works, and this one tells the truth wherever it surfaces — query string, proxy log, browser network tab. Step 3 of this issue asked for a comment naming the client behaviour and the reason; that is in `compat-auth.ts` next to the constant.

## Verification

`pnpm gates` green — **201 tests, up from 197.** Four new cases in `src/server/__tests__/compat-auth.test.ts`, the file ELEG-26 established for exactly this.

**Shown to fail in the failing direction.** Reintroducing the original string:

```
× does not read like a credential when it shows up in a URL or a log
AssertionError: expected 'elegoo-compat-token' not to match /token|key|secret|jwt|auth[^-]/i
```

Reverted with an inverse patch. The assertion is deliberately a *pattern* rather than an equality check, so it also catches a credential reintroduced under a different name — the same belt-and-braces shape ELEG-26 used.

**What is NOT verified, and this is the important caveat:** no Moonraker client has been anywhere near this. The tests assert the constants and the message; **nothing exercises the route table**, and `moonraker-server.ts` has no test at all. Whether Mainsail still loads is unknown and is exactly what ELEG-67 exists to answer. If it turns out something did break, that is a result — the change is one small module and walks back per-endpoint.

No printer interaction: this is the compat HTTP/WebSocket surface only.