### PR TITLE
feat(ui): show the running version as x.y.z+aa, the way RCP does (ELEG-48)

### DIFF
--- a/src/__tests__/service-status-dom.test.ts
+++ b/src/__tests__/service-status-dom.test.ts
@@ -123,3 +123,50 @@ describe('a browser holding a payload from before this shipped', () => {
     expect(panel.querySelector('.svc-firmware-warning')).toBeNull();
   });
 });
+
+describe('the running version in the panel (ELEG-48)', () => {
+  it('renders x.y.z+aa from the deploy stamp', () => {
+    const panel = mountShell();
+    render({
+      mqtt: 'connected',
+      mqttPhase: 'connected',
+      build: { describe: 'v0.2.1-58-g5b00442', version: '0.2.1' },
+    });
+
+    expect(panel.textContent).toContain('Version');
+    expect(panel.textContent).toContain('0.2.1+58');
+  });
+
+  it('says "unknown" on an unstamped build, and never renders null', () => {
+    // Normal for `pnpm dev`, and for a deploy where the installer never re-ran. The
+    // issue is explicit that this must not render `null+null`.
+    const panel = mountShell();
+    render({ mqtt: 'connected', mqttPhase: 'connected', build: null });
+
+    expect(panel.textContent).toContain('unknown');
+    expect(panel.textContent).not.toContain('null');
+  });
+
+  it('marks an unstamped build as not-ok, because it is a real gap', () => {
+    const panel = mountShell();
+    render({ mqtt: 'connected', mqttPhase: 'connected', build: null });
+    const rows = [...panel.querySelectorAll('.svc-item')];
+    const versionRow = rows.find((r) => r.textContent?.includes('Version'));
+    expect(versionRow?.querySelector('.status-dot-err')).not.toBeNull();
+  });
+
+  it('marks a stamped build ok', () => {
+    const panel = mountShell();
+    render({ mqtt: 'connected', mqttPhase: 'connected', build: { describe: 'v0.3.0' } });
+    const rows = [...panel.querySelectorAll('.svc-item')];
+    const versionRow = rows.find((r) => r.textContent?.includes('Version'));
+    expect(versionRow?.querySelector('.status-dot-ok')).not.toBeNull();
+    expect(versionRow?.textContent).toContain('0.3.0');
+  });
+
+  it('survives a browser holding a payload from before this shipped', () => {
+    const panel = mountShell();
+    render({ mqtt: 'connected', mqttPhase: 'connected', build: undefined });
+    expect(panel.textContent).toContain('unknown');
+  });
+});

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -12,6 +12,9 @@ import {
   mqttPhase,
   mqttPhaseMessage,
   mqttBannerHeadline,
+  formatBuildVersion,
+  buildVersionLabel,
+  UNKNOWN_VERSION_LABEL,
 } from '../types';
 
 describe('detectZone', () => {
@@ -223,5 +226,76 @@ describe('mqttPhaseMessage', () => {
     // These two sentences are the entire content of the 2026-08-08 incident.
     expect(mqttPhaseMessage('awaiting_sn')).toMatch(/power cycle/i);
     expect(mqttPhaseMessage('rejected')).toMatch(/two clients/i);
+  });
+});
+
+describe('formatBuildVersion — x.y.z+aa, the way RCP renders it (ELEG-48)', () => {
+  it('emits the commit DISTANCE, not a short sha', () => {
+    // The issue described `+aa` as "a short build/commit suffix", which is what it looks
+    // like. RCP's formatVersion actually emits the number of commits since the tag, and
+    // a near-miss would defeat the point of the request.
+    expect(formatBuildVersion({ describe: 'v0.2.1-58-g5b00442' })).toBe('0.2.1+58');
+  });
+
+  it('drops the suffix when sitting exactly on a tag', () => {
+    // Matches RCP, which returns the bare version rather than `+0`.
+    expect(formatBuildVersion({ describe: 'v0.3.0' })).toBe('0.3.0');
+    expect(formatBuildVersion({ describe: 'v0.3.0-0-gabc1234' })).toBe('0.3.0');
+  });
+
+  it('strips a leading v so the result is valid semver', () => {
+    expect(formatBuildVersion({ describe: 'v1.2.3-4-gdeadbee' })).toBe('1.2.3+4');
+    expect(formatBuildVersion({ describe: '1.2.3-4-gdeadbee' })).toBe('1.2.3+4');
+  });
+
+  it('records a dirty install, which RCP never sees', () => {
+    // contrib/install.sh runs `describe --tags --always --dirty`; RCP uses `--long`.
+    // Installed from a modified checkout is worth surfacing, and `+58.dirty` is still
+    // valid semver build metadata.
+    expect(formatBuildVersion({ describe: 'v0.2.1-58-g5b00442-dirty' })).toBe('0.2.1+58.dirty');
+    expect(formatBuildVersion({ describe: 'v0.3.0-dirty' })).toBe('0.3.0+dirty');
+  });
+
+  it('keeps a prerelease tag intact', () => {
+    expect(formatBuildVersion({ describe: 'v1.2.3-rc.1' })).toBe('1.2.3-rc.1');
+  });
+
+  it('falls back to package.json rather than rendering a bare sha as a version', () => {
+    // `--always` with no reachable tag yields just a sha. That is not a version, and
+    // showing it as one would be exactly the silently-wrong string this exists to avoid.
+    expect(formatBuildVersion({ describe: '5b00442', version: '0.2.1' })).toBe('0.2.1');
+    expect(formatBuildVersion({ describe: 'not-a-version', version: '0.2.1' })).toBe('0.2.1');
+  });
+
+  it('returns null when there is nothing trustworthy to show', () => {
+    // The all-null stamp the issue calls out: normal for `pnpm dev`, and for any deploy
+    // predating ELEG-10. Absent beats wrong.
+    expect(formatBuildVersion({ describe: null, version: null })).toBeNull();
+    expect(formatBuildVersion({})).toBeNull();
+    expect(formatBuildVersion(null)).toBeNull();
+    expect(formatBuildVersion(undefined)).toBeNull();
+    expect(formatBuildVersion({ describe: '   ', version: '  ' })).toBeNull();
+  });
+
+  it('never renders the string "null"', () => {
+    // The specific failure the issue names: `null+null` reaching the page.
+    for (const stamp of [null, undefined, {}, { describe: null, version: null }]) {
+      expect(String(formatBuildVersion(stamp))).not.toContain('null+');
+    }
+  });
+});
+
+describe('buildVersionLabel', () => {
+  it('always gives the caller something renderable', () => {
+    expect(buildVersionLabel({ describe: 'v0.2.1-58-g5b00442' })).toBe('0.2.1+58');
+    expect(buildVersionLabel(null)).toBe(UNKNOWN_VERSION_LABEL);
+    expect(buildVersionLabel({})).toBe(UNKNOWN_VERSION_LABEL);
+  });
+
+  it('says "unknown" rather than "dev", because it cannot tell them apart', () => {
+    // An all-null stamp means pnpm dev, OR a deploy predating ELEG-10, OR an installer
+    // that failed to write the file. Claiming "dev" for the last two would be a lie.
+    expect(UNKNOWN_VERSION_LABEL).toBe('unknown');
+    expect(buildVersionLabel({})).not.toMatch(/dev/i);
   });
 });

--- a/src/server/ws-transport.ts
+++ b/src/server/ws-transport.ts
@@ -23,6 +23,7 @@ import type { MqttBridge } from './mqtt-bridge.js';
 import type { TelegramIntegration } from './telegram.js';
 import type { AIMonitor } from './ai-monitor.js';
 import { getLogger } from './logger.js';
+import { getBuildInfo } from './build-info.js';
 
 const log = getLogger('WS');
 
@@ -142,6 +143,10 @@ export class WebSocketTransport {
 
     return {
       uptime: Math.floor((Date.now() - this.startTime) / 1000),
+      // Which build is serving this (ELEG-48). Already on /api/health, but nothing in
+      // the browser fetches that, and the UI is where "which build am I looking at?"
+      // actually gets asked. Cached per process, so this costs nothing per broadcast.
+      build: getBuildInfo(),
       mqtt: mqttState,
       // The coarse `mqtt` above is kept as-is for any existing consumer; `mqttPhase`
       // splits its `broker_only` into awaiting_sn / registering / rejected, which is the

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,89 @@ export function isFilamentChangeSubStatus(subStatus: number): boolean {
   return false;
 }
 
+// ─── Running version ─────────────────────────────────────────────────
+
+/**
+ * The fields of the deploy stamp this formatter needs. Structural on purpose: the real
+ * `BuildInfo` lives in `src/server/build-info.ts`, which `tsconfig.json` excludes from
+ * the browser half, so the UI cannot import it. `BuildInfo` satisfies this by shape.
+ */
+export interface VersionStampish {
+  /** `git describe --tags --always --dirty` at install time. */
+  describe?: string | null;
+  /** `version` from the deployed `package.json`. */
+  version?: string | null;
+}
+
+/** `1.2.3`, `1.2.3-rc.1` — a leading `v` having already been stripped. */
+const SEMVER_PREFIX = /^\d+\.\d+\.\d+/;
+
+/** The `--long`-style shape: `<tag>-<distance>-g<sha>`. */
+const DESCRIBE_LONG = /^(.+)-(\d+)-g[0-9a-f]+$/;
+
+function versionFromTag(tag: string): string | null {
+  const version = tag.replace(/^v/, '');
+  return SEMVER_PREFIX.test(version) ? version : null;
+}
+
+/**
+ * `x.y.z+aa`, matching how RCP renders its running version (ELEG-48).
+ *
+ * **The `+aa` is the commit distance since the tag, not a short sha.** ELEG-48 described
+ * it as "semver plus a short build/commit suffix", which is what it looks like — but
+ * RCP's `formatVersion` parses `git describe` and emits the *number of commits* since
+ * the last tag, and drops the suffix entirely when that number is 0. Read RCP before
+ * changing this; a near-miss defeats the point of the request, which was that the two
+ * look the same.
+ *
+ * **Adapted rather than copied, because the two repos run different `describe` flags.**
+ * RCP uses `--long`, which always yields `<tag>-<n>-g<sha>` — deliberately, so there is
+ * one shape to parse. `contrib/install.sh` here runs `--tags --always --dirty`, which
+ * yields four:
+ *
+ * | `describe` | Result | Why |
+ * | --- | --- | --- |
+ * | `v0.2.1-58-g5b00442` | `0.2.1+58` | the common case |
+ * | `v0.3.0` | `0.3.0` | exactly on a tag; RCP drops the `+0` too |
+ * | `v0.2.1-58-g5b00442-dirty` | `0.2.1+58.dirty` | installed from a modified checkout — worth saying, and still valid semver |
+ * | `5b00442` | falls back | `--always` with no reachable tag: a bare sha is not a version |
+ *
+ * Anything unrecognised falls back to `package.json`'s version, and then to `null`.
+ * **Absent beats wrong**: a version string that is silently incorrect is worse than none,
+ * and this one exists to answer "which build am I looking at?".
+ */
+export function formatBuildVersion(stamp: VersionStampish | null | undefined): string | null {
+  const fallback = stamp?.version?.trim() || null;
+  const raw = stamp?.describe?.trim();
+  if (!raw) return fallback;
+
+  const dirty = raw.endsWith('-dirty');
+  const clean = dirty ? raw.slice(0, -'-dirty'.length) : raw;
+
+  const long = DESCRIBE_LONG.exec(clean);
+  const base = long ? versionFromTag(long[1]) : versionFromTag(clean);
+  if (base === null) return fallback;
+
+  const distance = long ? Number(long[2]) : 0;
+  const parts = [distance > 0 ? String(distance) : null, dirty ? 'dirty' : null].filter(Boolean);
+  return parts.length > 0 ? `${base}+${parts.join('.')}` : base;
+}
+
+/** What to show when there is no usable stamp. An unstamped deploy is normal (ELEG-10). */
+export const UNKNOWN_VERSION_LABEL = 'unknown';
+
+/**
+ * Never returns null, so a caller can render it directly.
+ *
+ * `unknown` rather than `dev`: an all-null stamp means `pnpm dev` from a checkout **or**
+ * a deploy that predates ELEG-10 **or** one where the installer failed to write the file.
+ * Those are not the same thing and this cannot tell them apart, so it does not pretend
+ * to — the whole point of ELEG-48 is that a version you cannot trust is worse than none.
+ */
+export function buildVersionLabel(stamp: VersionStampish | null | undefined): string {
+  return formatBuildVersion(stamp) ?? UNKNOWN_VERSION_LABEL;
+}
+
 // ─── MQTT connection phase ───────────────────────────────────────────
 
 /**

--- a/src/ui/service-status.ts
+++ b/src/ui/service-status.ts
@@ -2,7 +2,14 @@
 
 import { $, escapeHtml } from './helpers';
 import type { PrinterState } from '../printer-state';
-import { type MqttPhase, mqttBannerHeadline, mqttPhaseMessage } from '../types';
+import {
+  type MqttPhase,
+  type VersionStampish,
+  UNKNOWN_VERSION_LABEL,
+  buildVersionLabel,
+  mqttBannerHeadline,
+  mqttPhaseMessage,
+} from '../types';
 
 export interface ServiceStatus {
   uptime: number;
@@ -14,6 +21,11 @@ export interface ServiceStatus {
    */
   mqttPhase?: MqttPhase;
   mqttRegisterAttempts: number;
+  /**
+   * The deploy stamp (ELEG-48). Optional for the same reason as `mqttPhase`: a browser
+   * can be holding a `service_status` from before this shipped.
+   */
+  build?: VersionStampish | null;
   printerSn: string | null;
   printerIp: string;
   wsClients: number;
@@ -132,6 +144,12 @@ export function renderServiceStatus(): void {
   const phase = phaseOf(s);
   const mqttLabel = PHASE_LABELS[phase];
 
+  // `x.y.z+aa`, the way RCP renders it — see formatBuildVersion. The dot is grey on an
+  // unstamped build rather than green, because "unknown" is a real gap: production runs
+  // from /opt/elegooweb, and a deploy where the installer never re-ran shows exactly
+  // this (ELEG-48).
+  const version = buildVersionLabel(s.build);
+
   // The banner used to fire on `broker_only && attempts >= 3`, which meant it could
   // never fire for the case that most needed it: when the printer never speaks, no SN is
   // learned, registration is never attempted and `mqttRegisterAttempts` stays 0 forever
@@ -154,6 +172,7 @@ export function renderServiceStatus(): void {
       <div class="svc-item">${dotHtml(!!s.printerSn)}<span class="svc-label">Printer</span><span class="svc-value">${s.printerSn || 'unknown'}</span></div>
       <div class="svc-item">${dotHtml(true)}<span class="svc-label">WS Clients</span><span class="svc-value">${s.wsClients}</span></div>
       <div class="svc-item">${dotHtml(true)}<span class="svc-label">Uptime</span><span class="svc-value">${formatUptime(s.uptime)}</span></div>
+      <div class="svc-item">${dotHtml(version !== UNKNOWN_VERSION_LABEL)}<span class="svc-label">Version</span><span class="svc-value">${escapeHtml(version)}</span></div>
     </div>
   `;
 }


### PR DESCRIPTION
Closes ELEG-48. Files ELEG-68.

## Reading RCP first was the instruction, and it changed the implementation

This issue describes the format as *"semver from `package.json` plus a short build/commit suffix"*, and says `shortCommit` makes it "a formatting job over data that is already on the wire".

**The `+aa` is not a sha.** RCP's `formatVersion` parses `git describe` and emits **the number of commits since the last tag**, dropping the suffix entirely when that number is 0. `0.6.0+25` means *25 commits past v0.6.0*. Building this from `shortCommit` would have produced precisely the near-miss the issue's own final bullet warns against — and it would have looked right.

## Adapted, not copied, because the two repos run different flags

RCP runs `git describe --long`, which **always** yields `<tag>-<n>-g<sha>`; its comment says that is deliberate, *"so there is one shape to parse rather than two"*. `contrib/install.sh` here runs `--tags --always --dirty`, which yields four. Verified against this repo's real output (`v0.2.1-58-g5b00442`):

| `describe` | Renders | Why |
| --- | --- | --- |
| `v0.2.1-58-g5b00442` | `0.2.1+58` | the common case |
| `v0.3.0` | `0.3.0` | exactly on a tag — RCP drops `+0` too |
| `v0.2.1-58-g5b00442-dirty` | `0.2.1+58.dirty` | installed from a modified checkout; a case RCP never sees, and still valid semver |
| `5b00442` | falls back | `--always` with no reachable tag: a bare sha is not a version |

The *output* matches RCP exactly; the parser could not. That is the "adapt, don't copy" rule doing real work.

## The all-null case the issue asked me to decide

Renders **`unknown`**, not `dev`. An all-null stamp means `pnpm dev` from a checkout **or** a deploy predating ELEG-10 **or** an installer that failed to write the file. Nothing can distinguish those, so it does not pretend to. Its status dot is **red**, because on a deployed service an unstamped build is a genuine gap rather than a cosmetic one.

Anything unrecognised falls back to `package.json`'s version, then to null. **Absent beats wrong** for a string whose entire job is answering "which build am I looking at?".

## Plumbing

The stamp reaches the browser on the **existing** `service_status` broadcast rather than a new fetch — nothing in the UI was fetching `/api/health`. `getBuildInfo()` is cached per process, so this costs nothing per message. Rendered as a Version row at the bottom of the service-status dropdown, which is where the issue suggested and where service-level rather than printer-level facts already live.

## Verification

`pnpm gates` green — **216 tests, up from 201.** 15 new cases: 10 on the pure formatter, 5 in jsdom on the render.

**Shown to fail in the failing direction.** Changing `distance > 0` to `distance >= 0` — i.e. emitting `+0` and diverging from RCP — turns three tests red:

```
× drops the suffix when sitting exactly on a tag
    expected '0.3.0+0' to be '0.3.0'
× records a dirty install, which RCP never sees
    expected '0.3.0+0.dirty' to be '0.3.0+dirty'
× keeps a prerelease tag intact
```

Reverted with an inverse patch. There is also an explicit test that the string `null+` never reaches the page, which is the exact failure the issue named.

**The render is covered too**, thanks to the jsdom environment ELEG-61 landed earlier in this pass — including that an unstamped build gets the error dot and that a browser holding a pre-this-change payload still shows `unknown` rather than `undefined`. The issue said "the rendering needs eyes on `pnpm dev:web`; nothing in this repo checks appearance" — that is now only half true: the *content* is asserted, the *appearance* still is not.

## The deploy half

**ELEG-68**, `OPERATOR:`-titled, as this issue instructs. Read-only commands, and the three states to tell apart — including the one this issue rightly calls worst: a stamp that is present but **stale**, which is confidently wrong rather than obviously absent, and which now shows up in the UI rather than only in a `curl`.