### PR TITLE
docs(agents): do the reads yourself before filing an OPERATOR issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,29 @@ Actions minutes (the private siblings do not, hence their self-hosted runners).
   as starting it.** Stopping a runaway notification loop or disabling a feature flag is
   the safe, reversible direction; arming something — or touching the printer — is the
   direction that needs a human.
+
+  **Do the reads yourself first, then hand over only what is left.** "This needs a
+  human" is a claim about *each command*, not about the issue, and bundling them is how
+  an errand gets handed over that was mostly answerable. Both `OPERATOR:` issues filed
+  in the 2026-08-08 pass turned out to be over-scoped:
+
+  - **ELEG-68** ("confirm the deploy stamp") — `curl localhost:8088/api/health` is on
+    the *reads are fine and encouraged* list two rules above; only `sudo cat
+    /opt/elegooweb/build-info.json` needs privilege. Running the read answered all of
+    it but one line — and answered it *better*, because `/api/health` also reported
+    `mqttPhase: null`, which corroborated the stamp's claim from **behaviour** rather
+    than trusting the file's own say-so.
+  - **ELEG-67** ("does the compat layer still work") — "no test exercises the route
+    table" and "does Mainsail still work" are two questions. The first is answerable
+    with the isolated local service in [`.agents/testing.md`](.agents/testing.md)
+    (TEST-NET `PRINTER_IP`, blanked integrations, non-default ports); only the second
+    needs a client.
+
+  So before filing: **go through the commands one at a time** and ask whether *that
+  one* needs privilege, a physical presence, or software you do not have. Run the ones
+  that do not, put the results on the issue, and cross those steps off the
+  instructions. An `OPERATOR:` issue reduced to one command gets done; a ten-step one
+  that is mostly already answerable gets postponed, and deservedly.
 - **Follow-ups become issues — never inline TODO text.** Any deferred work,
   degradation or "later" item is filed via `issues_create_issue`, after a **duplicate
   search**: `issues_list_issues {project: "elegoo-web", q: "<distinctive word>",


### PR DESCRIPTION
No issue key: this is a convention correction found while working the ELEG-63…48 `/auto` pass, in the same shape as #43.

## What went wrong

Both `OPERATOR:` issues I filed during the pass — ELEG-67 and ELEG-68 — were over-scoped, and identically so: **"this needs a human" was treated as a property of the issue rather than of each individual command.**

**ELEG-68** asked someone to confirm the deploy stamp. But `curl localhost:8088/api/health` is on the *"reads are fine and encouraged"* list two rules above it in AGENTS.md; only `sudo cat /opt/elegooweb/build-info.json` actually needs privilege. Running the read answered everything except one line — and answered it *better* than the file would have, because `/api/health` also reported `mqttPhase: null`, which corroborated the stamp's claim (`1fbb3d0`, pre-ELEG-59) from **behaviour** instead of trusting the file's own say-so.

**ELEG-67** bundled two different questions. *"Nothing exercises the route table"* is answerable with the isolated local service already documented in `.agents/testing.md` — TEST-NET `PRINTER_IP`, blanked integrations, non-default ports. Only *"does Mainsail still work"* needs a client. Probing locally verified both transports and confirmed no fabricated credential survives anywhere:

```
access.login          ERROR: This service has no authentication and i…
access.oneshot_token  result: "no-auth-required"
>>> any fabricated credential left?  no
```

Both issues have been updated with the results and their remaining scope cut down — ELEG-68 to a single `sudo cat`, ELEG-67 to the client check alone.

## The rule

Go through the commands **one at a time** and ask whether *that one* needs privilege, a physical presence, or software you do not have. Run the rest, put the results on the issue, and cross those steps off the instructions.

The practical argument, which is the part worth remembering: an `OPERATOR:` issue reduced to one command gets done. A ten-step one that is mostly already answerable gets postponed, and deservedly.

## Verification

`pnpm gates` green (documentation-only change; biome is scoped to `src/**` and does not reach `AGENTS.md`). The two claims about what is runnable are not theoretical — both were actually run during the pass, and the outputs are recorded on ELEG-67 and ELEG-68.