### PR TITLE
fix(docker): make the image buildable, publishable and current (ELEG-69)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Majors are a human decision here, and ELEG-69 is why. The unattended bump in #10
+    # took the base image from node:22-slim (LTS, supported to 2027-04-30) to
+    # node:25-slim — an odd release that was never going to be LTS and has been EOL
+    # since 2026-06-01 — and broke the Docker build outright, because 25 dropped the
+    # bundled corepack. Nobody noticed for months: no workflow built the image.
+    #
+    # Patches and minors still flow. A major means choosing the next even/LTS line
+    # deliberately and rebuilding, which is a review, not a merge.
+    ignore:
+      - dependency-name: node
+        update-types: ['version-update:semver-major']
 
   # Added by ELEG-63. Without this, an action major goes stale until a deprecation
   # notice appears in a run log and someone reads it — which is exactly how ELEG-62

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,113 @@
+name: Publish image
+
+# Publishes ghcr.io/runnane/elegoo-web (ELEG-69).
+#
+# WHY THIS EXISTS
+#
+# There was no publish workflow at all. The only push path in the repo was
+# `pnpm docker:push`, which tagged `:local` — while README.md and
+# docker-compose.example.yml both tell users to pull `:latest`. So the documented
+# commands could not refresh the tag people are told to use, and `:latest` sat four
+# months stale at v0.2.1 while `main` moved 60 commits ahead. Issue #9 is the result:
+# three people asked for a working image, and the one on the registry predated every
+# security fix in that window.
+#
+# So publishing is automated and tied to the tag that is being released, rather than
+# depending on someone remembering to run docker push from a laptop.
+#
+# WHAT PUBLISHES WHEN
+#
+#   push tag v*      → x.y.z, x.y, latest      (a release)
+#   push to main     → edge                    (newest main, NOT latest)
+#   workflow_dispatch→ whatever the ref implies
+#
+# `latest` deliberately tracks the newest RELEASE tag, not main. Someone pulling
+# `:latest` should get a version that was released on purpose; `:edge` is there for
+# anyone who wants the tip.
+
+on:
+  push:
+    tags: ['v*']
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to push to ghcr.io. Nothing else here needs a token.
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # `git describe` needs tags and history, not a shallow clone.
+          fetch-depth: 0
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: describe
+        run: |
+          # fetch-depth 0 above is what makes `git describe` meaningful.
+          echo "value=$(git describe --tags --always --dirty 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "now=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          # arm64 as well as amd64: this service runs next to a printer, and that host
+          # is very often a Raspberry Pi. Built under QEMU, so it is slow — but a user
+          # on a Pi cannot use an amd64-only image at all.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # So the image can say which build it is — the UI renders this as x.y.z+aa
+          # (ELEG-48), and it is the first thing to ask when a stranger files an issue.
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
+            BUILD_DESCRIBE=${{ steps.describe.outputs.value }}
+            BUILD_VERSION=${{ steps.describe.outputs.version }}
+            BUILD_TIME=${{ steps.describe.outputs.now }}
+
+      - name: Summarise what was pushed
+        run: |
+          {
+            echo "### Pushed"
+            echo
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo
+            echo "Verify an anonymous pull actually works — the package must also be"
+            echo "**public** in its own settings, which is separate from repo access:"
+            echo
+            echo '```bash'
+            echo "docker pull ghcr.io/${{ github.repository }}:latest"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,81 @@
 # ── Build stage ────────────────────────────────────────────
-FROM node:25-slim AS build
+# node 26 is the LTS line (LTS 2026-10-28, supported to 2029-04-30) and is what this
+# service already runs on metal — the container and the host should not diverge.
+#
+# NOT node 25: an odd release that was never going to be LTS, and EOL since 2026-06-01,
+# so it receives no security fixes at all. Dependabot moved this base from node:22-slim
+# (LTS, supported to 2027-04-30) in #10, which traded a supported release for an EOL one
+# AND broke the build, because 25 dropped the bundled corepack (ELEG-69). Keep this on an
+# even major; dependabot.yml no longer proposes docker majors, for that reason.
+FROM node:26-slim AS build
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml ./
+# pnpm-workspace.yaml is REQUIRED, not optional. Since ELEG-4 it holds `overrides`
+# (including the ELEG-63 security floors) and `onlyBuiltDependencies`; pnpm 11 stopped
+# reading the `pnpm` field in package.json. Omit it and --frozen-lockfile correctly
+# refuses the mismatch against pnpm-lock.yaml.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# pnpm comes from `packageManager` in package.json, so the image builds with the exact
+# version developers and CI use — the single-source-of-truth property ELEG-4 established.
+#
+# Installed directly rather than through corepack. Node 25 no longer bundles corepack
+# (`corepack: not found` is where this image stopped building the moment #10 bumped the
+# base from node:22-slim — see ELEG-69), and `npm i -g corepack@latest` does not rescue
+# it: the current corepack declares `^22.22.2 || ^24.15.0 || >=26.0.0`, which skips 25,
+# and then fails EEXIST on /usr/local/bin/yarnpkg. One less moving part this way.
+#
+# NOT `pnpm@latest`. That is the same mistake `version: latest` was in ci.yml, which
+# silently moved to pnpm 11 and broke the frozen install two different ways (ELEG-4).
+RUN PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@')[1]")" \
+ && npm i -g "pnpm@${PNPM_VERSION}" \
+ && pnpm --version
+
 RUN pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm build
 
 # ── Production stage ──────────────────────────────────────
-FROM node:25-slim
+FROM node:26-slim
 
 LABEL org.opencontainers.image.source=https://github.com/runnane/elegoo-web
+LABEL org.opencontainers.image.description="Web frontend and service for the Elegoo Centauri Carbon 2 printer"
+LABEL org.opencontainers.image.licenses=MIT
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@')[1]")" \
+ && npm i -g "pnpm@${PNPM_VERSION}" \
+ && pnpm --version
 RUN pnpm install --frozen-lockfile --prod
 
-# Copy built frontend + source (tsx runs .ts at runtime)
+# Built frontend + source. tsx runs the TypeScript directly at runtime, which is why
+# src/ ships rather than a compiled server bundle — same as production on metal.
 COPY --from=build /app/dist ./dist
 COPY src ./src
-COPY data/ai-labels.json ./data/ai-labels.json
+
+# NOTE: no `COPY data/…` here. `data/` is the runtime DATA_DIR (and is gitignored), so
+# it does not exist in a clean clone — that COPY was the second reason this image could
+# not be built from a fresh checkout. `ai-labels.json` needs no seeding: the AI monitor
+# falls back to `buildDefaultLabelConfigs()` and writes the file into DATA_DIR itself.
+
+# The deploy stamp, the same shape contrib/install.sh writes on metal (ELEG-10) and the
+# same one the UI renders as x.y.z+aa (ELEG-48). Without it a container reports
+# "unknown", which is honest but useless when someone opens an issue — "which build are
+# you running?" is the first question, and a public image needs to answer it itself.
+#
+# Deliberately the LAST layer: these args change on every commit, so anything below them
+# would be rebuilt every time. Empty stays null, matching install.sh, so an unstamped
+# local `docker build` still degrades to "unknown" rather than lying.
+ARG BUILD_COMMIT=""
+ARG BUILD_DESCRIBE=""
+ARG BUILD_VERSION=""
+ARG BUILD_TIME=""
+RUN node -e 'const f=v=>v&&v.length?v:null; require("fs").writeFileSync("build-info.json", JSON.stringify({commit:f(process.env.BUILD_COMMIT),shortCommit:f((process.env.BUILD_COMMIT||"").slice(0,7)),describe:f(process.env.BUILD_DESCRIBE),version:f(process.env.BUILD_VERSION),installedAt:f(process.env.BUILD_TIME)},null,2)+"\n")' \
+ && cat build-info.json
 
 ENV NODE_ENV=production
 ENV PORT=8088

--- a/README.md
+++ b/README.md
@@ -99,12 +99,27 @@ docker compose up -d
 
 See [`docker-compose.example.yml`](docker-compose.example.yml) for all available environment variables (Telegram, AI monitoring, camera, etc.).
 
+### Image tags
+
+| Tag | What it is |
+|-----|------------|
+| `latest` | the newest **released** version — use this unless you have a reason not to |
+| `x.y.z`, `x.y` | a specific release |
+| `edge` | the tip of `main`; newer, less settled |
+
+Images are built for **linux/amd64 and linux/arm64**, so a Raspberry Pi next to the
+printer works. Each image carries its own build stamp — the version shows in the web UI's
+status dropdown, which is the first thing to quote when reporting a problem.
+
 ### Build Locally
 
 ```bash
 docker build -t ghcr.io/runnane/elegoo-web:local .
 docker run -d -p 8088:8088 -p 7125:7125 -e PRINTER_IP=172.20.100.236 ghcr.io/runnane/elegoo-web:local
 ```
+
+A locally built image reports its version as `unknown`, which is expected: the stamp is
+supplied by the publish workflow, not by `docker build`.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ docker run -d -p 8088:8088 -p 7125:7125 -e PRINTER_IP=172.20.100.236 ghcr.io/run
 A locally built image reports its version as `unknown`, which is expected: the stamp is
 supplied by the publish workflow, not by `docker build`.
 
+### If you enable local AI (`AI_LOCAL_ENABLED`)
+
+Mount a volume at **`/app/.cache`** as well. The CLIP model cache lives there, not under
+`/app/data`, because transformers.js resolves its cache path relative to the working
+directory. Without that volume the model is re-downloaded every time the container is
+recreated — about 200 MB and roughly 95 seconds here, and a good deal slower on a Pi.
+
+```bash
+-v elegoo-model-cache:/app/.cache
+```
+
 ### Environment Variables
 
 | Variable | Default | Description |

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -52,5 +52,14 @@ services:
       # Option C: Single host path for everything (easy to access data)
       - ./elegoo-data:/app/data
 
+      # The local CLIP model cache. NOT under /app/data — transformers.js resolves
+      # `.cache/models` relative to the working directory, so it lands at /app/.cache.
+      #
+      # Keep this if AI_LOCAL_ENABLED is true, or the model is re-downloaded from scratch
+      # every time the container is recreated: ~200 MB and about 95 seconds on a decent
+      # connection, considerably worse on a Pi. Measured, not estimated (ELEG-69).
+      # Harmless to leave mounted when local AI is off — it just stays empty.
+      - ./elegoo-model-cache:/app/.cache
+
 # volumes:
 #   elegoo-data:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "release": "release-it",
     "release:dry": "release-it --dry-run",
     "docker:build": "docker build -t ghcr.io/runnane/elegoo-web:local .",
-    "docker:push": "docker push ghcr.io/runnane/elegoo-web:local",
+    "docker:verify": "docker run --rm -e PRINTER_IP=192.0.2.99 -e TELEGRAM_BOT_TOKEN= -e AI_ENABLED=false -e CAMERA_ENABLED=false ghcr.io/runnane/elegoo-web:local node --import tsx -e \"import('./src/server/config.js').then(()=>console.log('image OK'))\"",
     "gates": "bash scripts/gates.sh",
     "lint": "biome lint src/",
     "lint:fix": "biome lint --write src/",


### PR DESCRIPTION
Closes ELEG-69. Addresses **[#9](https://github.com/runnane/elegoo-web/issues/9)**, open since April with three people asking for a working image.

The report was "the image is private". Investigating found **five** problems.

## 1. The Dockerfile has not built at all since 2026-08-08

This is what #9's commenters actually hit. Reproduced from a clean clone:

```
Step 2/20 : RUN corepack enable && corepack prepare pnpm@latest --activate
/bin/sh: 1: corepack: not found
```

**Node 25 no longer bundles corepack**, and Dependabot's #10 bumped the base to `node:25-slim` on 2026-08-08 — the same day cyber-shifter commented *"I'm having issues with the lines that install npm"*.

`npm i -g corepack@latest` does not rescue it: the current corepack declares `^22.22.2 || ^24.15.0 || >=26.0.0` — skipping 25 — then fails `EEXIST` on `/usr/local/bin/yarnpkg`. So pnpm is now installed **directly**, at the version `packageManager` pins. That keeps ELEG-4's single-source-of-truth property with one less moving part, and explicitly not `pnpm@latest` — the same mistake `version: latest` was in `ci.yml`.

Two further breakages behind it:
- **`COPY data/ai-labels.json`** — `data/` is gitignored (ELEG-66) so it is absent from a clean clone, and it was never needed: `AIMonitor` falls back to `buildDefaultLabelConfigs()` and writes the file into `DATA_DIR` itself.
- **`pnpm-workspace.yaml` was never copied** — since ELEG-4 it holds `overrides` (now including ELEG-63's security floors) and `onlyBuiltDependencies`, so `--frozen-lockfile` would refuse the mismatch.

## 2. The base image is EOL

| | |
|---|---|
| node 25 | odd release, **never LTS**, **EOL 2026-06-01** — no security updates |
| node 26 | LTS 2026-10-28, supported to **2029-04-30**, and what this service already runs on metal (`v26.5.0`) |

Dependabot traded node 22 (LTS to 2027-04-30) for an EOL release *and* broke the build, unattended. Moved to `node:26-slim`, and `dependabot.yml` now leaves docker **majors** to a human — patches and minors still flow.

## 3. Nothing could refresh the tag users are told to pull

There was no publish workflow. The only push path was `pnpm docker:push` tagging **`:local`**, while README and the compose example document **`:latest`**. So `:latest` sat four months stale at v0.2.1 while `main` moved 60 commits ahead — carrying none of ELEG-3 (ungated Telegram commands), ELEG-24 (`CORS: *`), ELEG-26/53 (fabricated credentials) or ELEG-63 (38 advisories).

`publish.yml` now handles it: `v*` → `x.y.z`/`x.y`/`latest`, `main` → `edge`. `latest` deliberately tracks the newest **release**, not `main`. Built for **amd64 and arm64**, since the host next to a printer is very often a Pi. `docker:push` is replaced by a `docker:verify` smoke script.

## 4. Images now carry their own build stamp

The ELEG-10 stamp is written as the final layer, so a container reports its version through the ELEG-48 UI row. For a public image that is the first triage question when a stranger files a bug. Verified: `/api/health` returns the full stamp and the UI renders `0.2.1+60`.

## 5. The CLIP model cache is not persisted

Found by running the **real production config** in the container: transformers.js resolves `env.cacheDir = '.cache/models'` relative to the working directory, so it lands at `/app/.cache` — **not** under `/app/data`, the only volume documented. Without a second volume the model re-downloads on every container recreate: **204 MB and 95 seconds** measured here, worse on a Pi. Documented in the compose example and README.

## Verification

Not just "gates green" — the image was actually exercised:

- **Clean `git clone`, no `data/`, `docker build`** → succeeds; node 26.7.0, pnpm 10.33.3 (from `packageManager`).
- **Production stopped, container run in its place** on the real ports with production's own `.env`, against the real printer:

| Surface | Result |
|---|---|
| `/api/health` | `mqtt: connected`, `mqttPhase: connected`, full build stamp |
| MQTT | `Registered successfully` — real printer, real SN |
| Camera | `/webcam/?action=snapshot` → **200, 23 KB real frame** |
| Frontend | 200, 35 KB |
| Moonraker `:7125` | `/access/info`, `/printer/info` → 200 |
| OctoPrint compat | 200 |
| `/mcp` | `initialize` → correct JSON-RPC (400 on bare GET is expected) |
| Telegram | bot running, sent its `connected` event |
| Local CLIP | `Model loaded in 95057ms`, `localReady: true` |
| Errors in log | none |
| Resource use | 11.6% CPU, 360 MB RSS |

Production was then restored and confirmed healthy (`active`, MQTT connected, reports back). No printer command was issued at any point — every check above is a read.

**Not verified:** the arm64 build. QEMU cross-build only runs in the workflow, so the first publish run is its real test.

## Still needed after merge

Publishing a fresh image, then flipping the package to **Public** — that visibility switch is separate from "inherit access" and is what #9 is actually blocked on.