### PR TITLE
fix(docker): install fonts so the camera overlay is readable (ELEG-71)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,21 @@ LABEL org.opencontainers.image.source=https://github.com/runnane/elegoo-web
 LABEL org.opencontainers.image.description="Web frontend and service for the Elegoo Centauri Carbon 2 printer"
 LABEL org.opencontainers.image.licenses=MIT
 
+# Fonts, for the camera overlay (ELEG-71).
+#
+# `/api/stream/overlay` builds an SVG with `font-family="monospace"` and has sharp
+# composite it. node:*-slim ships NO fonts at all — not even a fallback — so librsvg has
+# nothing to resolve `monospace` to and every glyph renders as a tofu box. It looks fine
+# on metal only because the host happens to have ~2400 fonts installed.
+#
+# fonts-dejavu-core carries DejaVu Sans Mono and is ~1 MB; fontconfig is what actually
+# does the resolving. Both are needed — the font alone is not enough.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fonts-dejavu-core fontconfig \
+ && rm -rf /var/lib/apt/lists/* \
+ && fc-cache -f \
+ && fc-match monospace
+
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
Closes ELEG-71. Found by running the published image against the live printer and actually looking at the camera card.

## The bug

The status overlay rendered as `□□□□□□□□□□□□□` — a row of tofu boxes.

The overlay is composited **server-side**: `rest-api.ts` builds an SVG with `font-family="monospace"` and hands it to sharp. Resolving that name is fontconfig's job, and the container has nothing to resolve it with:

| | fonts |
| --- | --- |
| `node:26-slim` | **0** — `/usr/share/fonts` does not exist |
| this metal host | 2457 |

That is why it has never been seen: on metal the host's font set covers it. It is a packaging defect that only exists in a container, and **no gate here can catch it** — no browser, no screenshot, and the text is drawn by a native library at runtime.

## The fix

`fonts-dejavu-core` (~1 MB, carries DejaVu Sans Mono) **plus `fontconfig`** — the font package alone does nothing, because fontconfig does the resolving. The trailing `fc-match monospace` is deliberate: it makes the build log assert the resolution rather than leaving it to be discovered by a user.

## Verification

`fc-match monospace` → `DejaVuSansMono.ttf: "DejaVu Sans Mono" "Book"`, and a frame pulled from `/api/stream/overlay` against the live printer now reads:

```
Status: Idle
Nozzle: 31.0°C Bed: 29.0°C
```

Before/after on the same endpoint, same printer, same frame size.