### PR TITLE
fix(ai): stop VLM defaulting on, aimed at a hardcoded private address (ELEG-72)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,9 +27,9 @@ AI_ENABLED=false
 
 # VLM (Vision Language Model) — OpenAI-compatible API
 # Works with OpenAI, Ollama, or any compatible endpoint
-AI_VLM_ENABLED=true
+AI_VLM_ENABLED=false
 AI_VLM_API_KEY=
-AI_VLM_BASE_URL=http://172.20.100.9:3000/v1
+AI_VLM_BASE_URL=http://192.168.1.100:11434/v1
 AI_VLM_MODEL=llava
 
 # Local analysis (frame differencing, no external deps)

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Elegoo CC2 Service Configuration
 
 # Printer connection
-PRINTER_IP=172.20.100.236
+PRINTER_IP=192.168.1.150
 PRINTER_PASSWORD=123456
 
 # Service port (WebSocket + REST API)
@@ -9,7 +9,7 @@ SERVICE_PORT=8088
 
 # Camera (MJPEG stream from printer)
 CAMERA_ENABLED=true
-# CAMERA_URL=http://172.20.100.236:8080  # defaults to http://<PRINTER_IP>:8080
+# CAMERA_URL=http://192.168.1.150:8080  # defaults to http://<PRINTER_IP>:8080
 
 # Telegram Bot (optional — leave empty to disable)
 # Get a bot token from @BotFather on Telegram
@@ -23,14 +23,14 @@ PROGRESS_INTERVAL=25
 
 # ---- AI Monitoring (optional) ----
 # Enable AI print monitoring
-AI_ENABLED=false
+AI_ENABLED=true
 
 # VLM (Vision Language Model) — OpenAI-compatible API
 # Works with OpenAI, Ollama, or any compatible endpoint
 AI_VLM_ENABLED=false
 AI_VLM_API_KEY=
 AI_VLM_BASE_URL=http://192.168.1.100:11434/v1
-AI_VLM_MODEL=llava
+AI_VLM_MODEL=llama3.2-vision:11b
 
 # Local analysis (frame differencing, no external deps)
 AI_LOCAL_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run -d \
   --restart unless-stopped \
   -p 8088:8088 \
   -p 7125:7125 \
-  -e PRINTER_IP=172.20.100.236 \
+  -e PRINTER_IP=192.168.1.150 \
   -v elegoo-data:/app/data \
   ghcr.io/runnane/elegoo-web:latest
 ```
@@ -78,7 +78,7 @@ docker run -d \
   --restart unless-stopped \
   -p 8088:8088 \
   -p 7125:7125 \
-  -e PRINTER_IP=172.20.100.236 \
+  -e PRINTER_IP=192.168.1.150 \
   -v ./elegoo-data/reports:/app/data/reports \
   -v ./elegoo-data/gcode-cache:/app/data/gcode-cache \
   -v ./elegoo-data/logs:/app/data/logs \
@@ -115,7 +115,7 @@ status dropdown, which is the first thing to quote when reporting a problem.
 
 ```bash
 docker build -t ghcr.io/runnane/elegoo-web:local .
-docker run -d -p 8088:8088 -p 7125:7125 -e PRINTER_IP=172.20.100.236 ghcr.io/runnane/elegoo-web:local
+docker run -d -p 8088:8088 -p 7125:7125 -e PRINTER_IP=192.168.1.150 ghcr.io/runnane/elegoo-web:local
 ```
 
 A locally built image reports its version as `unknown`, which is expected: the stamp is
@@ -136,7 +136,7 @@ recreated — about 200 MB and roughly 95 seconds here, and a good deal slower o
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PRINTER_IP` | `172.20.100.236` | Printer IP address (required) |
+| `PRINTER_IP` | `192.168.1.150` | Printer IP address (required) |
 | `PRINTER_PASSWORD` | `123456` | Printer access code |
 | `PRINTER_SN` | — (discovered) | Printer serial number, e.g. `F01U3UD3798YT8K`. Normally discovered automatically and then cached in `<DATA_DIR>/printer-sn.json`, so this is rarely needed. Set it if a **first** start hangs at "registering": the printer only publishes while a client is registered, so a service that has never learned the serial has nothing to overhear |
 | `SERVICE_PORT` | `8088` | Web UI / API / WebSocket port |

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ recreated — about 200 MB and roughly 95 seconds here, and a good deal slower o
 | `PROGRESS_INTERVAL` | `25` | Notify every N% progress |
 | `DATA_DIR` | `./data` | Data directory for state, reports, logs |
 | `AI_ENABLED` | `false` | Enable AI print monitoring |
-| `AI_VLM_ENABLED` | `true` | Enable VLM analysis (when AI enabled) |
+| `AI_VLM_ENABLED` | `false` | Enable VLM analysis. Opt-in: `AI_ENABLED` alone does **not** turn this on |
 | `AI_VLM_PROVIDER` | `ollama` | VLM provider: `ollama` or `openai` |
 | `AI_VLM_API_KEY` | — | API key for OpenAI VLM provider |
-| `AI_VLM_BASE_URL` | `http://172.20.100.9:3000` | VLM API endpoint |
+| `AI_VLM_BASE_URL` | `http://localhost:11434` | VLM API endpoint (ollama's default port) |
 | `AI_VLM_MODEL` | `llava` | VLM model name |
 | `AI_LOCAL_ENABLED` | `true` | Enable local SigLIP zero-shot classification |
 | `AI_LOCAL_MODEL` | `Xenova/siglip-base-patch16-224` | Local classification model |
@@ -336,7 +336,7 @@ Enable with `AI_ENABLED=true`. Three detection backends run in parallel:
 
 **Motion-based stall detection**: Computes frame-to-frame pixel diff (160×120 grayscale via sharp). If motion drops below 0.5% for 3 consecutive frames while printing, injects a `print_stalled` issue.
 
-**VLM analysis** (`AI_VLM_ENABLED`): Sends camera snapshots to an external vision-language model (Ollama or OpenAI-compatible API). Can detect issues SigLIP cannot: `under_extrusion`, `nozzle_clog`, `print_stalled`.
+**VLM analysis** (`AI_VLM_ENABLED`, off by default): Sends camera snapshots to an external vision-language model (Ollama or OpenAI-compatible API). Can detect issues SigLIP cannot: `under_extrusion`, `nozzle_clog`, `print_stalled`.
 
 **Zone-aware filtering**: Analysis only runs when `sub_status === 2075` (Printing) AND `zones.current === 'print_area'`. Skipped during heating, filament changes, and when the toolhead is in the cutter/purge area.
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,7 +9,7 @@ services:
       - "7125:7125"   # Moonraker compatibility API
     environment:
       # ── Required ──────────────────────────────────────
-      PRINTER_IP: "172.20.100.236"
+      PRINTER_IP: "192.168.1.150"
 
       # ── Optional: Printer ─────────────────────────────
       # PRINTER_PASSWORD: "123456"       # Access code (default: 123456)

--- a/src/server/__tests__/config-defaults.test.ts
+++ b/src/server/__tests__/config-defaults.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../config.js';
+
+/**
+ * Defaults, which are the part of `config.ts` a user actually meets (ELEG-72).
+ *
+ * `.agents/testing.md` names this module as a high-value target with no coverage. The
+ * reason it earned a test now: two of its defaults were wrong in a way that only showed
+ * up once the Docker image went public, because the production `.env` sets every AI key
+ * explicitly and so the defaults were never exercised on the one install anyone looks at.
+ *
+ * `loadConfig()` reads `process.env` directly, so these tests swap it out wholesale
+ * rather than mutating keys — a stray value inherited from the developer's shell would
+ * otherwise make them pass or fail for reasons unrelated to the code.
+ */
+
+const ORIGINAL = process.env;
+
+beforeEach(() => {
+  // A minimal environment: only what loadConfig() refuses to start without.
+  process.env = { PRINTER_IP: '192.0.2.10' } as NodeJS.ProcessEnv;
+});
+
+afterEach(() => {
+  process.env = ORIGINAL;
+});
+
+describe('AI defaults', () => {
+  it('leaves AI off entirely unless asked', () => {
+    expect(loadConfig().aiEnabled).toBe(false);
+  });
+
+  it('does NOT enable VLM just because AI is enabled', () => {
+    // The regression. `AI_ENABLED=true` is how the README says to turn on monitoring;
+    // it used to switch the VLM on as well, which starts POSTing camera frames to a
+    // remote endpoint the user never configured.
+    process.env.AI_ENABLED = 'true';
+    const config = loadConfig();
+    expect(config.aiEnabled).toBe(true);
+    expect(config.aiVlmEnabled).toBe(false);
+  });
+
+  it('still enables VLM when explicitly asked', () => {
+    process.env.AI_ENABLED = 'true';
+    process.env.AI_VLM_ENABLED = 'true';
+    expect(loadConfig().aiVlmEnabled).toBe(true);
+  });
+
+  it('never defaults any endpoint to a private network address', () => {
+    // This shipped in a public image: the default pointed at a hardcoded address on the
+    // maintainer's own LAN, so every user who enabled AI sent pictures of their printer
+    // to whatever happened to hold that IP on THEIR network. Asserted as a pattern
+    // rather than an equality so any future private-range default is caught too.
+    const { aiVlmBaseUrl } = loadConfig();
+    expect(aiVlmBaseUrl).not.toMatch(/\/\/(10|127\.[^0]|172\.(1[6-9]|2\d|3[01])|192\.168)\./);
+    expect(aiVlmBaseUrl).toContain('localhost');
+  });
+
+  it('defaults to the port ollama actually listens on', () => {
+    // The old default was :3000, which could not have worked against a stock ollama
+    // even on the right host — so the feature was broken as well as misdirected.
+    expect(loadConfig().aiVlmProvider).toBe('ollama');
+    expect(loadConfig().aiVlmBaseUrl).toContain('11434');
+  });
+
+  it('keeps the local CLIP analyzer opt-out rather than opt-in', () => {
+    // Deliberately unchanged: the local model runs in-process and sends nothing
+    // anywhere, so defaulting it on is not the same decision as the VLM.
+    expect(loadConfig().aiLocalEnabled).toBe(true);
+  });
+});
+
+describe('PRINTER_IP validation', () => {
+  it('refuses a malformed address rather than starting and failing later', () => {
+    process.env.PRINTER_IP = 'not-an-ip';
+    expect(() => loadConfig()).toThrow(/PRINTER_IP/);
+  });
+});

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -117,10 +117,18 @@ export function loadConfig(): ServiceConfig {
 
     // AI monitoring
     aiEnabled: env('AI_ENABLED') === 'true',
-    aiVlmEnabled: env('AI_VLM_ENABLED', 'true') !== 'false',
+    // Opt-in, exactly like aiEnabled above it. It used to default ON, so setting only
+    // AI_ENABLED=true — which is how the README says to turn on AI monitoring — silently
+    // started POSTing camera frames to the VLM endpoint as well (ELEG-72).
+    aiVlmEnabled: env('AI_VLM_ENABLED') === 'true',
     aiVlmProvider: env('AI_VLM_PROVIDER', 'ollama') as 'openai' | 'ollama',
     aiVlmApiKey: env('AI_VLM_API_KEY'),
-    aiVlmBaseUrl: env('AI_VLM_BASE_URL', 'http://172.20.100.9:3000'),
+    // localhost, and ollama's actual port. The previous default was a hardcoded private
+    // LAN address on the maintainer's own network, which shipped in a public image: every
+    // user who enabled AI sent pictures of their printer to whatever held that IP on
+    // THEIR network. It also could never have worked against a stock ollama, which
+    // listens on 11434 rather than the 3000 that was hardcoded.
+    aiVlmBaseUrl: env('AI_VLM_BASE_URL', 'http://localhost:11434'),
     aiVlmModel: env('AI_VLM_MODEL', 'llava'),
     aiLocalEnabled: env('AI_LOCAL_ENABLED', 'true') !== 'false',
     aiLocalModel: env('AI_LOCAL_MODEL', 'Xenova/siglip-base-patch16-224'),


### PR DESCRIPTION
Closes ELEG-72. Found by running the **newly-public** image with `AI_ENABLED=true` and nothing else — the exact thing the README tells a user to do.

## The bug

```ts
aiEnabled:    env('AI_ENABLED') === 'true',                        // opt-in ✅
aiVlmEnabled: env('AI_VLM_ENABLED', 'true') !== 'false',           // defaults ON ❌
aiVlmBaseUrl: env('AI_VLM_BASE_URL', 'http://172.20.100.9:3000'),  // hardcoded LAN IP ❌
```

`ai-monitor.ts` POSTs a **base64 camera frame** to `${aiVlmBaseUrl}/api/chat` every `AI_INTERVAL` seconds (default 60) while a print is running.

So with the image public, anyone enabling AI as documented starts sending **pictures of their printer** to `172.20.100.9:3000` on their own network:

- on a typical `192.168.x.x` LAN → connection refused; a noisy log, no leak
- on any network using `172.20.100.0/24`, an ordinary private range → the frames reach whatever device holds that IP

Either way the user sees "VLM enabled" in the UI and believes it is working.

**Why it was never noticed:** production's `.env` sets every AI key explicitly, so these defaults are overridden on the one install anyone ever looks at. It took a container with a clean environment to expose them.

## Secondary: it could never have worked anyway

`aiVlmProvider` defaults to `ollama`, which listens on **11434**, not `3000`. So the shipped default was misdirected *and* broken.

## The fix

- `aiVlmEnabled` → opt-in, matching `aiEnabled` immediately above it.
- `aiVlmBaseUrl` → `http://localhost:11434` — the user's own machine, ollama's real port.
- README env table corrected: it advertised `AI_VLM_ENABLED` default `true` and printed the private address as documentation.

`aiLocalEnabled` **stays** defaulting on, deliberately: the local CLIP model runs in-process and sends nothing anywhere, which is a different decision from shipping frames to a remote endpoint.

## Verification

`pnpm gates` green — **223 tests, up from 216.** Seven of those are the first tests `config.ts` has ever had; `.agents/testing.md` names it as a high-value untested target, and this is precisely the class of defect it was flagged for.

They swap `process.env` wholesale rather than mutating keys, so a value inherited from a developer's shell cannot make them pass or fail for unrelated reasons.

**Shown to fail in the failing direction** — restoring both original defaults:

```
× does NOT enable VLM just because AI is enabled
    expected true to be false
× never defaults any endpoint to a private network address
    expected 'http://172.20.100.9:3000' not to match /172\.(1[6-9]|2\d|3[01])\./
× defaults to the port ollama actually listens on
    expected 'http://172.20.100.9:3000' to contain '11434'
```

Reverted with an inverse patch. The private-address assertion is a **pattern** over RFC1918 ranges rather than an equality, so any future private-range default is caught too.

## Left for a separate decision

`printerIp` still defaults to `172.20.100.236` — the same class, much lower severity (an MQTT connection attempt, not image data). Making it *required* would be the honest fix but is a behaviour change, so it is filed rather than folded in here.