### PR TITLE
fix(mqtt): announce a disconnect once, not once per reconnect attempt (ELEG-74)

### DIFF
--- a/src/server/mqtt-bridge.ts
+++ b/src/server/mqtt-bridge.ts
@@ -143,6 +143,19 @@ export class MqttBridge extends EventEmitter {
     });
 
     this.client.on('close', () => {
+      // `close` fires on every FAILED RECONNECT ATTEMPT, not just on a real drop —
+      // mqtt.js retries every `reconnectPeriod` (5s) and each cycle lands here. Emitting
+      // unconditionally turned that into one `disconnected` event every ~5 seconds for as
+      // long as the printer was off, and Telegram sends one urgent message per event:
+      // ~780/hour. Measured at 7 events in 32s against a port that refuses (ELEG-74).
+      //
+      // So announce the TRANSITION, not the attempt. Captured before the flags below are
+      // reset, because they are what "was it up?" means.
+      //
+      // Fixed here rather than in telegram.ts on purpose: the same storm reaches the
+      // WebSocket broadcast and the event log, so one guard covers every consumer. The UI
+      // loses nothing — ws-transport rebroadcasts service_status on its own 5s timer.
+      const wasUp = this._connected || this._brokerConnected;
       this._connected = false;
       this._brokerConnected = false;
       this._registerAttempts = 0;
@@ -155,7 +168,9 @@ export class MqttBridge extends EventEmitter {
       this.stopRegisterRetry();
       this.stopSlowRegisterRetry();
       this.stopSilenceWatch();
-      this.emit('disconnected');
+      // Never connected in the first place? Then there is no disconnection to report —
+      // which is also the case when the printer is simply off when the service starts.
+      if (wasUp) this.emit('disconnected');
     });
   }
 


### PR DESCRIPTION
Closes ELEG-74. Reported from live use: with the printer powered off, Telegram sends `🔴 Printer disconnected` continuously.

## The chain

1. `reconnectPeriod: 5000` — mqtt.js retries every 5 seconds.
2. **`close` fires on every failed attempt**, not only on a real drop.
3. The handler emitted `disconnected` **unconditionally**, so a retry became a state-change event.
4. `state-store.ts` forwarded it as a `print_event`; `telegram.ts` sent one **urgent** message per event.

No dedupe, debounce or transition check existed anywhere on that path.

## Measured

Against a port that refuses immediately — the same fast-fail a powered-off device on a live LAN produces:

```
DISCONNECT_EVENTS=7        (32 seconds)
```

≈ one per 4.6s → ~780/hour → **~18,700 messages/day**.

The bridge in that run had **never connected**, so this also fired when the printer was simply off at startup — announcing a disconnection from a connection that never existed.

Worth noting for anyone who could not reproduce it: an address that *blackholes* packets yields only **1** event in the same window, because mqtt.js waits on a connack timeout instead. The behaviour depends on *how* the printer is unreachable, which is why it looks intermittent.

## The fix

Announce the **transition**, not the attempt — capturing "was it up?" before the flags are reset.

Fixed in the bridge rather than `telegram.ts` deliberately: the same storm reached the WebSocket broadcast and the event log, so one guard covers every consumer. The UI loses nothing, because `ws-transport` rebroadcasts `service_status` on its own 5s timer regardless.

**No rate limiter**, on purpose. That would paper over this and any future emitter bug; the defect is that a retry was being reported as a state change.

## Verification — both directions

| Scenario | Before | After |
| --- | --- | --- |
| Unreachable printer, 32s (`127.0.0.1:1883`, nothing listening) | **7** | **0** |
| Genuine connected → dropped | 1 (+ a storm after) | **1**, then silent |

The second is the one that matters, since the easy mistake here is silencing the feature. It runs against a minimal fake broker that accepts the CONNECT, replies CONNACK, then destroys the socket — a real `connected → dropped` transition, confirmed by `brokerConnected: true` beforehand. Exactly one event, and the following 17 seconds of retries produced none.

Both are scripted and repeatable without a printer.

`pnpm gates` green (223 tests) — but to be plain about what that covers: **nothing in the suite exercises `MqttBridge`**, as `.agents/testing.md` records, so the gates say nothing about this change. The two measurements above are the evidence.

No printer interaction: reproduced entirely against a closed local port and a fake broker on loopback.