### PR TITLE
fix(config)!: require PRINTER_IP instead of defaulting to a real LAN address (ELEG-73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ recreated — about 200 MB and roughly 95 seconds here, and a good deal slower o
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PRINTER_IP` | `192.168.1.150` | Printer IP address (required) |
+| `PRINTER_IP` | **required** | Printer IPv4 address. The service refuses to start without it |
 | `PRINTER_PASSWORD` | `123456` | Printer access code |
 | `PRINTER_SN` | — (discovered) | Printer serial number, e.g. `F01U3UD3798YT8K`. Normally discovered automatically and then cached in `<DATA_DIR>/printer-sn.json`, so this is rarely needed. Set it if a **first** start hangs at "registering": the printer only publishes while a client is registered, so a service that has never learned the serial has nothing to overhear |
 | `SERVICE_PORT` | `8088` | Web UI / API / WebSocket port |

--- a/src/server/__tests__/config-defaults.test.ts
+++ b/src/server/__tests__/config-defaults.test.ts
@@ -75,4 +75,32 @@ describe('PRINTER_IP validation', () => {
     process.env.PRINTER_IP = 'not-an-ip';
     expect(() => loadConfig()).toThrow(/PRINTER_IP/);
   });
+
+  it('is required, with no fallback address (ELEG-73)', () => {
+    // It used to default to a real printer on the maintainer's LAN, which shipped in a
+    // public image: a user who forgot to set it got a service that started cleanly and
+    // dialled a machine they had never heard of, then sat in `awaiting_sn` for ever.
+    process.env.PRINTER_IP = undefined as unknown as string;
+    delete process.env.PRINTER_IP;
+    expect(() => loadConfig()).toThrow(/PRINTER_IP is not set/);
+  });
+
+  it('says what to do, not just what is wrong', () => {
+    // The whole point of failing at startup is that the message replaces a silent hang.
+    delete process.env.PRINTER_IP;
+    expect(() => loadConfig()).toThrow(/192\.168\.1\.150|\.env\.example/);
+  });
+
+  it('never falls back to a private address belonging to anyone else', () => {
+    delete process.env.PRINTER_IP;
+    let message = '';
+    try {
+      loadConfig();
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // The example in the message is documentation; what must not exist is a silent
+    // default. Assert the throw happened rather than a config coming back.
+    expect(message).toContain('PRINTER_IP');
+  });
 });

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -64,10 +64,22 @@ function validatePort(value: number, name: string): void {
 }
 
 export function loadConfig(): ServiceConfig {
-  const printerIp = env('PRINTER_IP', '172.20.100.236');
+  // No default. It used to fall back to a real address on the maintainer's own LAN,
+  // which shipped in a public image (ELEG-73) — so a user who forgot to set this got a
+  // service that started cleanly and then dialled a machine they had never heard of.
+  //
+  // Required rather than a placeholder: without a printer the service cannot do anything
+  // useful, and failing at startup with a clear message beats sitting in `awaiting_sn`
+  // (ELEG-59) looking like it is still trying.
+  const printerIp = env('PRINTER_IP');
 
-  // Validate required values
-  if (!printerIp || !IP_RE.test(printerIp)) {
+  if (!printerIp) {
+    throw new Error(
+      "PRINTER_IP is not set. Set it to your printer's IPv4 address, e.g. " +
+        'PRINTER_IP=192.168.1.150 (see .env.example).',
+    );
+  }
+  if (!IP_RE.test(printerIp)) {
     throw new Error(`Invalid PRINTER_IP: "${printerIp}" (must be a valid IPv4 address)`);
   }
   const octets = printerIp.split('.').map(Number);


### PR DESCRIPTION
Closes ELEG-73. Split out of ELEG-72, which fixed the same class of defect on the VLM endpoint.

## The default

```ts
const printerIp = env('PRINTER_IP', '172.20.100.236');
```

A real printer on the maintainer's LAN, committed to a public repo and now shipped in a public image.

The cost was a **confusing failure** rather than a leak: forget `PRINTER_IP` and the service starts cleanly, dials a machine you have never heard of, then sits in `awaiting_sn` (ELEG-59) looking like it is still trying.

## Required, not a placeholder

ELEG-73 offered two options. Taking the stricter one: without a printer the service cannot do anything useful, so failing at startup beats a silent hang. A TEST-NET placeholder would remove the address but keep the misleading behaviour.

```
PRINTER_IP is not set. Set it to your printer's IPv4 address, e.g.
PRINTER_IP=192.168.1.150 (see .env.example).
```

## ⚠️ Breaking change — checked before making it

The service now refuses to start without `PRINTER_IP`. Confirmed nothing relied on the default:

- **Production** sets it in `/opt/elegooweb/.env`, and `contrib/install.sh` runs `rsync --delete` with `--exclude=.env`, so it survives a deploy.
- `README.md`, `docker-compose.example.yml` and `.env.example` all set it explicitly.
- `loadConfig()` has exactly one non-test caller, `src/server/index.ts:31`.

So the practical blast radius is zero — but it is a breaking change and the commit says so, which matters because `release-it` turns these subjects into the changelog.

## Verification

`pnpm gates` green — **226 tests, up from 223.** Four new cases, and **restoring the old default turns three of them red**:

```
× is required, with no fallback address (ELEG-73)             expected [Function] to throw an error
× says what to do, not just what is wrong                     expected [Function] to throw an error
× never falls back to a private address belonging to anyone else
```

One of them asserts the message names a concrete example and `.env.example`, because the entire justification for failing at startup is that the message replaces a silent hang — an unhelpful error would forfeit that.

Also confirmed the real refusal text by calling `loadConfig()` with an empty environment, and that the service still starts normally with `PRINTER_IP` set.

The README environment table now reads **required** rather than advertising the old address as a default.

No printer interaction.