### PR TITLE
fix(server): honour DATA_DIR for the gcode cache and debug captures (ELEG-70)

### DIFF
--- a/src/server/__tests__/data-paths.test.ts
+++ b/src/server/__tests__/data-paths.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  captureLogDir,
+  gcodeCacheDir,
+  getDataDir,
+  initDataPaths,
+  resetDataPathsForTest,
+} from '../data-paths.js';
+
+/**
+ * DATA_DIR is honoured by the gcode cache and the debug captures (ELEG-70).
+ *
+ * Both used to be built from the working directory — `join(process.cwd(), 'data', …)`
+ * and the relative `join('data', 'logs', …)`. That coincides with `DATA_DIR` at its
+ * default and only at its default, so the bug was invisible on metal and in the
+ * container alike, and appeared only for someone who set `DATA_DIR` elsewhere — which
+ * the README documents as supported.
+ *
+ * The assertions below are therefore written against a directory that is deliberately
+ * NOT `$CWD/data`; against the old code every one of them fails.
+ */
+
+afterEach(() => {
+  resetDataPathsForTest();
+});
+
+describe('gcodeCacheDir', () => {
+  it('follows DATA_DIR rather than the working directory', () => {
+    initDataPaths('/srv/elegoo-data');
+    expect(gcodeCacheDir()).toBe('/srv/elegoo-data/gcode-cache');
+  });
+
+  it('does not smuggle the process cwd into the path', () => {
+    // The precise regression: `join(process.cwd(), 'data', 'gcode-cache')` produced an
+    // absolute path under the checkout no matter what DATA_DIR said.
+    initDataPaths('/srv/elegoo-data');
+    expect(gcodeCacheDir()).not.toContain(process.cwd());
+  });
+
+  it('handles a relative DATA_DIR without rewriting it', () => {
+    initDataPaths('./custom-data');
+    expect(gcodeCacheDir()).toBe('custom-data/gcode-cache');
+  });
+});
+
+describe('captureLogDir', () => {
+  it('follows DATA_DIR', () => {
+    initDataPaths('/srv/elegoo-data');
+    expect(captureLogDir()).toBe('/srv/elegoo-data/logs');
+  });
+
+  it('lands in the same place initLogger writes service.log', () => {
+    // Both are diagnostics a user is told to go and fetch, so they must agree — the
+    // capture endpoint writing somewhere else is how a capture becomes unretrievable.
+    initDataPaths('/srv/elegoo-data');
+    expect(captureLogDir()).toBe('/srv/elegoo-data/logs');
+    expect(captureLogDir().startsWith(getDataDir())).toBe(true);
+  });
+});
+
+describe('the default, which is what made this invisible', () => {
+  it("matches config.dataDir's own default when never initialised", () => {
+    // Not an accident: an uninitialised read must behave exactly as the old code did,
+    // so importing a helper without calling initDataPaths cannot throw inside a request.
+    expect(getDataDir()).toBe('./data');
+    expect(gcodeCacheDir()).toBe('data/gcode-cache');
+  });
+
+  it('treats an empty DATA_DIR as unset rather than writing to the filesystem root', () => {
+    initDataPaths('');
+    expect(gcodeCacheDir()).toBe('data/gcode-cache');
+  });
+});

--- a/src/server/data-paths.ts
+++ b/src/server/data-paths.ts
@@ -1,0 +1,64 @@
+/**
+ * Where the service writes, derived from one place (ELEG-70).
+ *
+ * Most of the service already builds its paths from `config.dataDir` — reports,
+ * `state.json`, `moonraker-db.json`, `printer-sn.json`, `ai-labels.json`, and the logs
+ * via `initLogger(config.dataDir)`. Two did not: the gcode cache was
+ * `join(process.cwd(), 'data', 'gcode-cache')` and the debug-capture endpoint used the
+ * relative `join('data', 'logs', …)`.
+ *
+ * **That was invisible because the default makes them coincide.** `DATA_DIR` defaults to
+ * `./data`, so `$CWD/data` is the same directory — on metal (`WorkingDirectory=
+ * /opt/elegooweb`) and in the container (`WORKDIR /app`) alike. It only diverges when
+ * `DATA_DIR` points elsewhere, which `README.md` and `docker-compose.example.yml` both
+ * document as supported. Then those two write somewhere nobody mounted or backs up: in a
+ * container, into an unmounted layer that is discarded on every recreate.
+ *
+ * This module exists rather than threading `config` through the call sites because the
+ * consumers are functions like `ensureCacheDir()`, `getCachedGcode(fileName)` and the
+ * exported `cacheGcodeBuffer(fileName, data)` — adding a parameter to each would change
+ * an exported signature to move a value that never varies within a process. `logger.ts`
+ * already solves the identical problem the identical way, and `initDataPaths` is called
+ * on the line below `initLogger` so the two stay together.
+ */
+
+import { join } from 'path';
+
+/**
+ * Deliberately seeded with the same default as `config.dataDir`, so a caller that never
+ * initialises (a test importing one of these helpers directly) behaves exactly as the
+ * code did before rather than throwing from inside a request handler. `index.ts` sets it
+ * for the real process.
+ */
+const DEFAULT_DATA_DIR = './data';
+
+let dataDir: string = DEFAULT_DATA_DIR;
+
+/** Call once at startup, beside `initLogger`. */
+export function initDataPaths(dir: string): void {
+  dataDir = dir || DEFAULT_DATA_DIR;
+}
+
+/** The configured data directory. Exported mainly so a test can assert the wiring. */
+export function getDataDir(): string {
+  return dataDir;
+}
+
+/** Downloaded/uploaded gcode, kept for the preview and the layer estimates. */
+export function gcodeCacheDir(): string {
+  return join(dataDir, 'gcode-cache');
+}
+
+/**
+ * Where `POST /api/debug/capture` writes, and where the capture list and reader look.
+ * The same directory `initLogger` writes `service.log` into — deliberately, since both
+ * are diagnostics a user is told to go and fetch.
+ */
+export function captureLogDir(): string {
+  return join(dataDir, 'logs');
+}
+
+/** Reset to the default. For tests only. */
+export function resetDataPathsForTest(): void {
+  dataDir = DEFAULT_DATA_DIR;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,10 +26,14 @@ import { PrintReportCollector } from './print-report-collector.js';
 import { getBuildInfo } from './build-info.js';
 import { applyCors, corsHeaders } from './cors.js';
 import { initLogger, getLogger } from './logger.js';
+import { initDataPaths } from './data-paths.js';
 import { readCachedSn, writeCachedSn } from './sn-cache.js';
 
 const config = loadConfig();
 initLogger(config.dataDir);
+// Beside initLogger on purpose: both exist so DATA_DIR is honoured from one place, and
+// keeping them adjacent is what stops the next path from drifting back to cwd (ELEG-70).
+initDataPaths(config.dataDir);
 const log = getLogger('Service');
 
 // Read the deploy stamp here so it is in the startup banner and in the process cache

--- a/src/server/rest-api.ts
+++ b/src/server/rest-api.ts
@@ -29,6 +29,7 @@ import type { MqttBridge } from './mqtt-bridge.js';
 import { generateReportPDF } from './print-report-pdf.js';
 import { getBuildInfo } from './build-info.js';
 import { applyCors, corsHeaders } from './cors.js';
+import { captureLogDir, gcodeCacheDir } from './data-paths.js';
 import { getLogger } from './logger.js';
 import {
   STATUS_NAMES,
@@ -54,7 +55,8 @@ let fetchInFlight: Promise<Buffer | null> | null = null;
 let activeCapture: { file: string } | null = null;
 
 // ── Gcode file cache ────────────────────────────────────────────
-const GCODE_CACHE_DIR = join(process.cwd(), 'data', 'gcode-cache');
+// Path helpers live in data-paths.ts so DATA_DIR is honoured — this used to be
+// join(process.cwd(), 'data', 'gcode-cache'), which ignored it (ELEG-70).
 const GCODE_CACHE_MAX = 10; // keep at most N cached files
 
 function gcodeCacheKey(fileName: string): string {
@@ -62,14 +64,14 @@ function gcodeCacheKey(fileName: string): string {
 }
 
 async function ensureCacheDir(): Promise<void> {
-  await mkdir(GCODE_CACHE_DIR, { recursive: true });
+  await mkdir(gcodeCacheDir(), { recursive: true });
 }
 
 /** Cache a gcode file from a Buffer (e.g. after upload) */
 export async function cacheGcodeBuffer(fileName: string, data: Buffer): Promise<void> {
   try {
     await ensureCacheDir();
-    const cachePath = join(GCODE_CACHE_DIR, gcodeCacheKey(fileName));
+    const cachePath = join(gcodeCacheDir(), gcodeCacheKey(fileName));
     await writeFile(cachePath, data);
     await evictOldCache();
     log.info(`Cached uploaded gcode: ${fileName} (${data.length} bytes)`);
@@ -80,7 +82,7 @@ export async function cacheGcodeBuffer(fileName: string, data: Buffer): Promise<
 
 async function getCachedGcode(fileName: string): Promise<string | null> {
   try {
-    const cached = join(GCODE_CACHE_DIR, gcodeCacheKey(fileName));
+    const cached = join(gcodeCacheDir(), gcodeCacheKey(fileName));
     const s = await stat(cached);
     if (s.size > 0) return cached;
   } catch {
@@ -91,11 +93,11 @@ async function getCachedGcode(fileName: string): Promise<string | null> {
 
 async function evictOldCache(): Promise<void> {
   try {
-    const files = await readdir(GCODE_CACHE_DIR);
+    const files = await readdir(gcodeCacheDir());
     if (files.length <= GCODE_CACHE_MAX) return;
     const entries = await Promise.all(
       files.map(async (f) => {
-        const p = join(GCODE_CACHE_DIR, f);
+        const p = join(gcodeCacheDir(), f);
         const s = await stat(p).catch(() => null);
         return { path: p, mtime: s?.mtimeMs ?? 0 };
       }),
@@ -175,7 +177,7 @@ async function handleFileDownload(
 
       // For gcode files, tee the stream to a cache file
       if (isGcode) {
-        const cachePath = join(GCODE_CACHE_DIR, gcodeCacheKey(fileName));
+        const cachePath = join(gcodeCacheDir(), gcodeCacheKey(fileName));
         const cacheStream = createWriteStream(cachePath);
         const tee = new PassThrough();
         tee.pipe(res);
@@ -247,7 +249,7 @@ export async function precacheGcodeAsync(
     const dlPath = pathMap[source] ?? '/download';
     log.info(`Precache: downloading ${fileName} from ${dlPath}`);
 
-    const cachePath = join(GCODE_CACHE_DIR, gcodeCacheKey(fileName));
+    const cachePath = join(gcodeCacheDir(), gcodeCacheKey(fileName));
 
     const size = await new Promise<number>((resolve, reject) => {
       const proxyReq = httpRequest(
@@ -1052,7 +1054,7 @@ export function createRestRouter(
         setTimeout(async () => {
           store.off('raw', listener);
           activeCapture = null;
-          const filePath = join('data', 'logs', filename);
+          const filePath = join(captureLogDir(), filename);
           await writeFile(filePath, JSON.stringify(messages, null, 2));
           debugLog.info(`Capture saved: ${filename} (${messages.length} messages, ${duration}s)`);
         }, duration * 1000);
@@ -1071,7 +1073,7 @@ export function createRestRouter(
 
     // List available captures
     if (url === '/api/debug/captures' && req.method === 'GET') {
-      readdir(join('data', 'logs'))
+      readdir(captureLogDir())
         .then((files) => {
           const captures = files
             .filter((f) => f.startsWith('mqtt-capture-'))
@@ -1100,7 +1102,7 @@ export function createRestRouter(
         res.end(JSON.stringify({ error: 'Invalid filename' }));
         return;
       }
-      readFile(join('data', 'logs', filename), 'utf-8')
+      readFile(join(captureLogDir(), filename), 'utf-8')
         .then((content) => {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(content);
@@ -1185,7 +1187,7 @@ export function createRestRouter(
       void (async () => {
         try {
           await ensureCacheDir();
-          const cacheFiles = await readdir(GCODE_CACHE_DIR);
+          const cacheFiles = await readdir(gcodeCacheDir());
           const cacheHashes = new Set(cacheFiles.map((f) => f.replace(/\.gcode$/, '')));
           const params = new URL(req.url || '', 'http://localhost').searchParams;
           const checkFiles = params.getAll('file');


### PR DESCRIPTION
Closes ELEG-70. Found while auditing every filesystem write path for ELEG-69.

## The bug

```ts
const GCODE_CACHE_DIR = join(process.cwd(), 'data', 'gcode-cache');  // ignores DATA_DIR
const filePath = join('data', 'logs', filename);                     // relative to cwd
```

Everything else derives from `config.dataDir` — reports, logs, `state.json`, `moonraker-db.json`, `printer-sn.json`, `ai-labels.json`.

**It was invisible because the default makes them coincide.** `DATA_DIR` defaults to `./data`, so `$CWD/data` is the same directory on metal (`WorkingDirectory=/opt/elegooweb`) and in the container (`WORKDIR /app`). It only diverges when `DATA_DIR` points elsewhere — which `README.md` and `docker-compose.example.yml` both document as supported. Then both write somewhere nobody mounted and nobody backs up; in a container, an unmounted layer discarded on every recreate.

## A correction to the issue

It called the capture path *"a genuine one-liner"*. It is **three** sites — the write, the listing (`readdir`) and the reader (`readFile`). Fixing only the write would have left `/api/debug/captures` looking in the old place: a capture written but unlistable, which is worse than the bug it replaced.

Final tally: **8** cache usages and **3** capture paths.

## Why a module, not a parameter

Threading `config` was considered and rejected. The consumers are `ensureCacheDir()`, `getCachedGcode(fileName)`, `evictOldCache()` and the **exported** `cacheGcodeBuffer(fileName, data)` — so it would mean changing an exported signature to carry a value that never varies within a process. That is exactly the problem `initLogger(config.dataDir)` already solves in this codebase, so `data-paths.ts` follows it, and `initDataPaths` is called on the line directly below `initLogger` so the two cannot drift apart.

The module is seeded with `./data`, **the same default `config.dataDir` uses**, so a caller that never initialises behaves exactly as the old code did rather than throwing from inside a request handler.

## Verification

`pnpm gates` green — **233 tests, up from 226.**

**Seven new unit tests, and restoring either old path turns all seven red:**

```
× follows DATA_DIR rather than the working directory
    expected '/home/jon/dev/elegoo-web/data/gcode-cache' to be '/srv/elegoo-data/gcode-cache'
× does not smuggle the process cwd into the path
× handles a relative DATA_DIR without rewriting it
× follows DATA_DIR                                    (captures)
× lands in the same place initLogger writes service.log
× matches config.dataDir's own default when never initialised
× treats an empty DATA_DIR as unset rather than writing to the filesystem root
```

Reverted with an inverse patch, not `git checkout`.

**But unit tests on the helpers would not catch `rest-api.ts` reverting to a constant**, so the check this issue actually specifies was run too — a real service with `DATA_DIR` set outside `$CWD/data`, on non-default ports with a TEST-NET printer IP:

```
$DATA_DIR/gcode-cache                                   ← created by /api/files/cached
$DATA_DIR/logs/mqtt-capture-2026-08-09T12-33-05-744Z.json ← written by /api/debug/capture
$DATA_DIR/logs/{service,error,events}.log

GET /api/debug/captures
{"captures":["mqtt-capture-2026-08-09T12-33-05-744Z.json"],"active":null}
```

That last line is the one that matters: the **listing** resolves to the new location too, so write, list and read all agree.

## What still is not covered

`rest-api.ts` has no route tests, so nothing automated asserts the wiring — the behavioural run above is the evidence, and it is manual. That gap is pre-existing and recorded in `.agents/testing.md`.

No printer interaction: the probe used a TEST-NET address, so the MQTT attempt goes nowhere. Production untouched.