### PR TITLE
fix(ci): point :latest at main, because nothing cuts releases (ELEG-75)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,19 @@ name: Publish image
 #
 # WHAT PUBLISHES WHEN
 #
+#   push to main     → latest
 #   push tag v*      → x.y.z, x.y, latest      (a release)
-#   push to main     → edge                    (newest main, NOT latest)
 #   workflow_dispatch→ whatever the ref implies
 #
-# `latest` deliberately tracks the newest RELEASE tag, not main. Someone pulling
-# `:latest` should get a version that was released on purpose; `:edge` is there for
-# anyone who wants the tip.
+# `latest` tracks MAIN. It originally tracked the newest release tag, on the reasoning
+# that `:latest` should mean "released on purpose" — which is right in a repo that cuts
+# releases, and wrong in this one. The last tag here is v0.2.1 from 2026-04-14, so that
+# policy left `latest` frozen on April code: precisely the failure this workflow was
+# added to fix, where three people opened issue #9 over a stale image (ELEG-75).
+#
+# A promise nothing enforces is just a way for the tag to rot, and a stale `latest` is
+# worse than a moving one because users cannot tell. If a release cadence is ever
+# established, revisit — the semver tags below already publish on `v*`.
 
 on:
   push:
@@ -72,8 +78,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
       - uses: docker/build-push-action@v7
         with:

--- a/README.md
+++ b/README.md
@@ -103,9 +103,8 @@ See [`docker-compose.example.yml`](docker-compose.example.yml) for all available
 
 | Tag | What it is |
 |-----|------------|
-| `latest` | the newest **released** version — use this unless you have a reason not to |
-| `x.y.z`, `x.y` | a specific release |
-| `edge` | the tip of `main`; newer, less settled |
+| `latest` | the newest build of `main` — use this unless you have a reason not to |
+| `x.y.z`, `x.y` | a specific release, pinned |
 
 Images are built for **linux/amd64 and linux/arm64**, so a Raspberry Pi next to the
 printer works. Each image carries its own build stamp — the version shows in the web UI's


### PR DESCRIPTION
Closes ELEG-75. A defect in the workflow **ELEG-69 itself added** — found by checking whether the published image actually carried the fixes merged after it. It did not.

## Measured

With `main` at `2cef4c7`:

```
latest  → v0.2.1-68-g225bd79      grep -c wasUp src/server/mqtt-bridge.ts → 0
edge    → built from 2cef4c7
```

So `:latest` was missing ELEG-70, ELEG-73 and **ELEG-74 — the Telegram spam fix**. Anyone pulling the documented tag today gets an image that still floods Telegram when the printer is off.

## Why the original policy was wrong here

I wrote `latest` to track the newest release tag, reasoning that `:latest` should mean "a version released on purpose". That is correct **in a repo that cuts releases**. This one does not — the last tag is `v0.2.1` from 2026-04-14 and `release-it` has not run in four months.

So the policy froze `latest` on April code: *precisely the failure the workflow was added to fix*, where three people opened #9 over a stale image. A promise nothing enforces is just a way for the tag to rot, and a stale `latest` is worse than a moving one because users cannot tell it is stale.

## The change

- `latest` now publishes on pushes to `main` **and** on `v*` tags.
- `x.y.z` / `x.y` still publish on releases, so pinning a version still works.
- `edge` dropped — it would now name the same thing twice. One day old, nothing depends on it.
- README tag table updated; it documented the rejected policy.

## The alternative, recorded rather than silently discarded

Establish a release cadence and keep `latest` on releases. Better practice, and the workflow comment says to revisit if that ever happens. But it is a commitment about how the project is run, not a code change — and until it exists the tag should describe what actually happens.

## Verification

`pnpm gates` green (workflow/docs only). The real check is after merge: `latest` and the newest `main` build must resolve to the **same digest**, queried anonymously, which is how a user sees it. Reported on the issue once this lands.