### PR TITLE
fix(docs): stop the README bind-mount example destroying persistence (ELEG-76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,23 +69,28 @@ docker run -d \
 
 Web UI: `http://localhost:8088` · Moonraker API: `http://localhost:7125`
 
-To mount specific data directories as host paths instead of a named volume:
+To keep the data on a host path you can browse, instead of a named volume:
 
 ```bash
-mkdir -p ./elegoo-data/{reports,gcode-cache,logs}
+mkdir -p ./elegoo-data
 docker run -d \
   --name elegoo-web \
   --restart unless-stopped \
   -p 8088:8088 \
   -p 7125:7125 \
   -e PRINTER_IP=192.168.1.150 \
-  -v ./elegoo-data/reports:/app/data/reports \
-  -v ./elegoo-data/gcode-cache:/app/data/gcode-cache \
-  -v ./elegoo-data/logs:/app/data/logs \
-  -v ./elegoo-data/state.json:/app/data/state.json \
-  -v ./elegoo-data/moonraker-db.json:/app/data/moonraker-db.json \
+  -v ./elegoo-data:/app/data \
   ghcr.io/runnane/elegoo-web:latest
 ```
+
+Everything then appears under `./elegoo-data` — `reports/`, `gcode-cache/`, `logs/`,
+`state.json`, `moonraker-db.json`.
+
+> **Mount the directory, not the individual files.** A bind mount whose source does not
+> exist yet is created by Docker as a **directory**, so `-v ./elegoo-data/state.json:
+> /app/data/state.json` gives the service a directory where it expects a file. It does
+> not crash — the container stays `Up` and the UI works — it just logs
+> `EISDIR: illegal operation on a directory` and silently never persists anything.
 
 ### Docker Compose
 


### PR DESCRIPTION
Closes ELEG-76. Found by running the README's Docker instructions **verbatim** against the published image.

## The bug

```bash
mkdir -p ./elegoo-data/{reports,gcode-cache,logs}   # three directories
...
-v ./elegoo-data/state.json:/app/data/state.json          # ← file, never created
-v ./elegoo-data/moonraker-db.json:/app/data/moonraker-db.json
```

Docker creates a **directory** for a missing bind source. Reproduced:

```
drwxr-xr-x root root  state.json          ← directory
drwxr-xr-x root root  moonraker-db.json   ← directory

[Persistence]  Failed to load: EISDIR: illegal operation on a directory, read
[MoonrakerSrv] Failed to load database:
[MoonrakerSrv] Failed to save database:
```

## Why it is worse than a crash

**The container stays `Up`.** Both failures are caught and logged as warnings, so the service runs and the UI works — while `state.json` and the Moonraker database are never written. The user loses persisted state on every restart with no reason to suspect it.

And it is the example aimed at people who want host-path access rather than a named volume — the more involved user, and the one most likely to use it.

## The fix

Mount the directory. That is what the section actually wanted (*"mount specific data directories as host paths"*), with fewer flags and no trap:

```bash
-v ./elegoo-data:/app/data
```

Plus a note explaining the file-vs-directory behaviour, because the failure is silent and someone will otherwise reinvent the per-file version.

## Verification

Corrected block run against the published image:

```
.rw-r--r--  moonraker-db.json      ← a FILE, 525 bytes
drwxr-xr-x  logs/  reports/

EISDIR / "failed to save" / "failed to load" in the log: 0
```

`state.json` is absent, and that is expected rather than a residual failure: the probe used a TEST-NET printer IP, so there is no connection and no state to persist. What the test proves is the defect that was there — a directory where a file belongs — and `moonraker-db.json` being written as a real file exercises exactly that path.

`docker-compose.example.yml` is unaffected: its equivalent option is commented out, and its active option already mounts the directory.