### PR TITLE
fix(docs): correct three commented options in the compose example (ELEG-77)

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -27,9 +27,14 @@ services:
       # AI_ENABLED: "false"              # Enable AI monitoring (default: false)
       # AI_LOCAL_ENABLED: "true"         # Local CLIP/SigLIP model (default: true)
       # AI_LOCAL_MODEL: "Xenova/siglip-base-patch16-224"
-      # AI_VLM_ENABLED: "true"           # Vision LLM analysis (default: true)
+      # AI_VLM_ENABLED: "true"           # Vision LLM analysis (default: FALSE — opt-in;
+      #                                  # AI_ENABLED alone does not turn this on)
       # AI_VLM_PROVIDER: "ollama"        # ollama or openai (default: ollama)
       # AI_VLM_BASE_URL: "http://host.docker.internal:11434"
+      #   ⚠ On LINUX, host.docker.internal does not resolve unless you also uncomment the
+      #   `extra_hosts` block below — it is provided automatically only on Docker Desktop
+      #   (macOS/Windows). Without it the VLM fails with a name-resolution error that
+      #   looks nothing like the actual cause. A plain host IP works too.
       # AI_VLM_MODEL: "llava"
       # AI_VLM_API_KEY: ""               # Required for openai provider
       # AI_INTERVAL: "60"                # Seconds between AI checks (default: 60)
@@ -38,16 +43,26 @@ services:
 
       # ── Optional: Data persistence ────────────────────
       # DATA_DIR: "./data"               # Data directory (default: ./data)
+
+    # Needed on Linux for AI_VLM_BASE_URL=http://host.docker.internal:… (see above).
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway"
+
     volumes:
       # Option A: Single named volume (simplest)
       #- elegoo-data:/app/data
 
-      # Option B: Host paths for granular access (uncomment and remove Option A)
-      # - ./data/reports:/app/data/reports       # Print reports + snapshots
+      # Option B: Per-directory host paths (uncomment and remove Option A)
+      # - ./data/reports:/app/data/reports          # Print reports + snapshots
       # - ./data/gcode-cache:/app/data/gcode-cache  # Downloaded gcode files
-      # - ./data/logs:/app/data/logs             # MQTT capture logs
-      # - ./data/state.json:/app/data/state.json # Persisted printer state
-      # - ./data/moonraker-db.json:/app/data/moonraker-db.json  # Moonraker database
+      # - ./data/logs:/app/data/logs                # MQTT capture logs
+      #
+      # Directories only. Do NOT bind the individual files (state.json,
+      # moonraker-db.json): Docker creates a DIRECTORY for a bind source that does not
+      # exist yet, so the service finds a directory where it expects a file. It does not
+      # crash — the container stays Up and the UI works — it just logs
+      # `EISDIR: illegal operation on a directory` and silently never persists anything
+      # (ELEG-76). Option C avoids the question entirely.
 
       # Option C: Single host path for everything (easy to access data)
       - ./elegoo-data:/app/data


### PR DESCRIPTION
Closes ELEG-77. Found by running `docker-compose.example.yml` end to end against the published image, then reading every commented line for whether it would work if uncommented.

## The default path is fine — verified, not assumed

Copy the file, change `PRINTER_IP`, `docker compose up -d`:

```
elegoo-web  Up
health HTTP 200 · frontend HTTP 200 · moonraker HTTP 200
version v0.2.1-74-g90e66de · errors 0
state.json + moonraker-db.json written as FILES, survive `down`/`up`
```

So this PR is about the **commented options**, each offered as a supported choice and none of which worked as written.

## 1. `AI_VLM_ENABLED` documented the old default

It said `default: true`. **ELEG-72 changed it to `false`**, precisely so `AI_ENABLED` alone stops sending camera frames to an endpoint the user never configured. The comment told the reader the opposite of the code.

## 2. Option B carried the ELEG-76 bind trap

The same `state.json` / `moonraker-db.json` file binds fixed in the README: Docker creates a **directory** for a missing bind source → `EISDIR` → container stays `Up`, UI works, nothing persists.

ELEG-76 recorded compose as "unaffected because Option B is commented out". True of the default path, and the wrong conclusion to leave standing — it only defers the trap to whoever picks that option. Now directories-only, with the reason stated.

## 3. `host.docker.internal` does not resolve on Linux

The one example given for reaching a local ollama. Verified inside the image:

```
host.docker.internal does NOT resolve without extra_hosts
```

It is provided automatically only on Docker Desktop (macOS/Windows). **Linux is the likely host here** — this runs next to a printer, often on a Pi — so the example fails for most of the audience, as a name-resolution error that looks nothing like the cause.

Adds the mapping, commented alongside, and says so plainly.

## Verification

- Corrected file still comes up clean: `HTTP 200`.
- `docker compose config` still validates.
- **Uncommenting `extra_hosts` makes it resolve**, proven inside the running container:

```
10.249.0.1      host.docker.internal
RESOLVES with extra_hosts
```

Documentation only; `pnpm gates` green.