### PR TITLE
fix(config): read dev-server allowedHosts from the environment (ELEG-82)

### DIFF
--- a/.agents/security.md
+++ b/.agents/security.md
@@ -106,6 +106,21 @@ get this right.
 - **There are two `.env` files** on a host that runs the service locally: the
   checkout's and production's. Neither is in git; see
   [deployment.md](deployment.md).
+- **Environment-specific hostnames are the same category, and are easier to miss than a
+  secret.** `vite.config.ts`'s `server.allowedHosts` hardcoded a deployment hostname and
+  a private RFC1918 address for the life of the repo (ELEG-82). Neither is a credential,
+  which is exactly why nobody looked twice — but a hostname naming the production
+  deployment plus an internal addressing scheme is *"infrastructure detail that could aid
+  an attacker"*, and it sat in a **public** repo. They now come from
+  `VITE_ALLOWED_HOSTS` in the gitignored `.env`, defaulting to `localhost`.
+
+  Two things worth carrying forward. First, **dev-only config still gets committed** —
+  `server.*` never reaches production, so it reads as harmless and escapes the review
+  that a runtime setting would get. Second, **the values remain in git history and that
+  is a deliberate accepted decision, not an oversight**: rewriting published history is
+  disruptive and out of proportion for a public DNS name and an unreachable LAN address.
+  Do not re-file it. If a genuine *secret* ever lands here, the calculus is different and
+  rotation — not a rewrite — is the remedy, as above.
 - Org data-protection policy applies to everything an agent writes, not just code: no
   real credentials, no personal data, no internal network detail in issue comments, PR
   bodies, commit messages or committed docs. Use placeholders, and redact before pasting

--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ pnpm dev
 
 This starts both the backend service and Vite dev server. Open `http://localhost:5173`.
 
+The dev server answers to `localhost` only. To reach it by another name — a machine
+hostname, a LAN address, a tunnel — list them in `.env` (which is gitignored), so that
+no environment-specific hostname is committed:
+
+```bash
+VITE_ALLOWED_HOSTS=my-box.example.internal,10.0.0.5
+```
+
+This is a **dev-server** setting: `vite build` ignores it, and production never runs vite.
+
 ## Build
 
 ```bash

--- a/src/__tests__/allowed-hosts.test.ts
+++ b/src/__tests__/allowed-hosts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { allowedHostsFrom } from '../../vite.config';
+
+// ELEG-82. `server.allowedHosts` used to hardcode a deployment hostname and a
+// private LAN address in this public repo; they now come from
+// VITE_ALLOWED_HOSTS. Only the parsing is testable here — whether the dev
+// server actually answers on a host needs `pnpm dev:web`, because `vite build`
+// never reads `server.*`.
+describe('allowedHostsFrom', () => {
+  it('defaults to localhost alone when the variable is unset', () => {
+    expect(allowedHostsFrom(undefined)).toEqual(['localhost']);
+  });
+
+  it('defaults to localhost alone when the variable is empty', () => {
+    expect(allowedHostsFrom('')).toEqual(['localhost']);
+  });
+
+  it('appends each comma-separated host to localhost', () => {
+    expect(allowedHostsFrom('a.example.test,b.example.test')).toEqual([
+      'localhost',
+      'a.example.test',
+      'b.example.test',
+    ]);
+  });
+
+  it('trims whitespace and drops empty entries', () => {
+    expect(allowedHostsFrom(' a.example.test , , b.example.test ,')).toEqual([
+      'localhost',
+      'a.example.test',
+      'b.example.test',
+    ]);
+  });
+
+  it('does not repeat localhost when it is also listed explicitly', () => {
+    expect(allowedHostsFrom('localhost,a.example.test')).toEqual(['localhost', 'a.example.test']);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,38 +1,62 @@
-import { defineConfig } from 'vite';
 import path from 'path';
+import { defineConfig, loadEnv } from 'vite';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      // Ensure only one copy of three.js is loaded (gcode-preview peer dep)
-      three: path.resolve(__dirname, 'node_modules/three'),
+/**
+ * Extra hostnames the vite dev server will answer to, read from the environment
+ * so that no deployment hostname or LAN address is committed to this public repo
+ * (ELEG-82). Comma-separated, e.g.
+ *
+ *   VITE_ALLOWED_HOSTS=printer.example.internal,10.0.0.5
+ *
+ * Dev-server only: `server.*` has no effect on `vite build` or on production,
+ * which serves from /opt/elegooweb under systemd and never runs vite.
+ */
+export function allowedHostsFrom(raw: string | undefined): string[] {
+  const extra = (raw ?? '')
+    .split(',')
+    .map((host) => host.trim())
+    .filter((host) => host.length > 0);
+  return [...new Set(['localhost', ...extra])];
+}
+
+export default defineConfig(({ mode }) => {
+  // envDir is __dirname rather than process.cwd() so the value is the same
+  // whichever directory vite was invoked from.
+  const env = loadEnv(mode, __dirname, 'VITE_');
+
+  return {
+    resolve: {
+      alias: {
+        // Ensure only one copy of three.js is loaded (gcode-preview peer dep)
+        three: path.resolve(__dirname, 'node_modules/three'),
+      },
+      dedupe: ['three'],
     },
-    dedupe: ['three'],
-  },
-  server: {
-    allowedHosts: ['localhost', 'elegooweb.srv.jont.no', '172.20.100.9'],
-    host: '0.0.0.0',
-    port: 5173,
-    proxy: {
-      '/ws': {
-        target: 'ws://localhost:8088',
-        ws: true,
-      },
-      '/api': {
-        target: 'http://localhost:8088',
-      },
-      '/mcp': {
-        target: 'http://localhost:8088',
-      },
-      '/octoprint': {
-        target: 'http://localhost:8088',
-      },
-      '/moonraker': {
-        target: 'http://localhost:8088',
-      },
-      '/webcam': {
-        target: 'http://localhost:8088',
+    server: {
+      allowedHosts: allowedHostsFrom(env.VITE_ALLOWED_HOSTS),
+      host: '0.0.0.0',
+      port: 5173,
+      proxy: {
+        '/ws': {
+          target: 'ws://localhost:8088',
+          ws: true,
+        },
+        '/api': {
+          target: 'http://localhost:8088',
+        },
+        '/mcp': {
+          target: 'http://localhost:8088',
+        },
+        '/octoprint': {
+          target: 'http://localhost:8088',
+        },
+        '/moonraker': {
+          target: 'http://localhost:8088',
+        },
+        '/webcam': {
+          target: 'http://localhost:8088',
+        },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
Closes ELEG-82.

`vite.config.ts` hardcoded three `server.allowedHosts` entries: `localhost`, a deployment hostname and a private RFC1918 LAN address. The latter two are committed in a **public** repo, which `AGENTS.md` and `.agents/security.md` both forbid — *"infrastructure detail that could aid an attacker"*. The values are deliberately not restated here.

## The decision

This pass was autonomous, so the issue's three options were decided rather than asked:

- **Option 1 (chosen)** — read extra hosts from a comma-separated `VITE_ALLOWED_HOSTS`, defaulting to `localhost` alone. It is the only option that keeps the developer convenience *and* satisfies the policy, and it matches the existing idiom (`.env` is already gitignored and already carries every other environment-specific value).
- **Option 2** (`allowedHosts: true`) rejected: it trades a disclosure problem for a real, if dev-only, DNS-rebinding weakness.
- **Option 3** (accept and document) rejected on the merits: the RFC1918 address discloses an internal addressing scheme and nothing in the repo argues that is intentional.

**Git history is deliberately left alone.** Removing the values from `HEAD` does not remove them from prior commits, and rewriting published history is out of proportion for a public DNS name and an unreachable LAN address. That decision is now written into `.agents/security.md` so the next reader does not re-file this issue — which is precisely the failure mode ELEG-82 warns about.

## What the gate does and does not prove

The issue is explicit that `pnpm gates` proves **nothing** about dev-server behaviour, and `vite build` never reads `server.*`. So rather than claim coverage I do not have, I extracted the parsing as an exported pure function and put *that* under test — 5 cases in `src/__tests__/allowed-hosts.test.ts` covering unset, empty, comma-splitting, whitespace/empty-entry handling, and not duplicating `localhost`.

**Still outstanding and not claimable from CI:** that `pnpm dev:web` serves on the host a developer actually uses. That needs the developer to put their own host in `.env` and load it.

## Verification

`pnpm gates` green — all five checks:

```
  ✓ biome ci (non-writing, as CI runs it)
  ✓ typecheck: browser half (tsconfig.json)
  ✓ typecheck: service half (tsconfig.server.json)
  ✓ build (vite)
  ✓ unit tests (vitest)
```

Test count re-measured against `main`: **233 → 238**, a delta of exactly the 5 tests added.

**Failing-direction check.** Green is necessary and not sufficient, so the new guard was proved load-bearing by mutating the *implementation* (deleting the `.filter((host) => host.length > 0)` line), not an assertion:

```
     × defaults to localhost alone when the variable is unset
     × defaults to localhost alone when the variable is empty
     × trims whitespace and drops empty entries
      Tests  3 failed | 2 passed (5)
```

The named claim goes red. Restored from a copy taken immediately before the patch (not `git checkout`, which would have discarded the untracked test file), and re-confirmed 238 passing.

## Also here

- `README.md` documents `VITE_ALLOWED_HOSTS` in Quick Start, noting it is dev-server only.
- `.agents/security.md` gains the general lesson: **dev-only config still gets committed**, and escapes the scrutiny a runtime setting would get precisely because it never reaches production.

`.env.example` is deliberately untouched — reads of it are blocked by a permission rule in this environment, so I documented the variable in `README.md` rather than edit a file I could not first read.