### PR TITLE
docs(agents): record why the parallel gate split does not apply here (ELEG-78)

### DIFF
--- a/.agents/gates.md
+++ b/.agents/gates.md
@@ -169,6 +169,50 @@ sibling repos are out of minutes and need self-hosted runners, so their "no chec
 no runner" reasoning does **not** transfer here. If no run appears for a push here, it is
 a GitHub problem or a workflow-trigger problem, not a runner problem.
 
+## Running the gates concurrently — the split RCP needs, this repo does not (ELEG-78)
+
+The bundle's `/auto --parallel N` carries a gate split: **subagents run the fast gate; the
+orchestrator runs anything binding a fixed port or a fixed database name, serially,
+itself.** That rule has a specific cause, and the cause is absent here — so do not port the
+ceremony along with the command.
+
+RCP's hazard is Playwright: it binds a fixed port and `reuseExistingServer` will **adopt**
+a server another worktree already started, so two concurrent runs silently test each
+other's build and both report plausible, wrong results. A per-repo lock does not help,
+because the adoption happens outside it.
+
+**Measured here:** the five gates are `biome ci`, `tsc`, `tsc -p tsconfig.server.json`,
+`vite build` and `vitest run`. None starts a server, none binds a port, none touches a
+database. `package.json` has no `playwright` or `puppeteer` dependency and there is no e2e
+or browser-driving test of any kind. `vitest run` is in-process and finishes in a few
+hundred milliseconds.
+
+Three consequences, all of them the *opposite* of RCP's:
+
+- **There is nothing for the orchestrator to run serially.** Every worktree runs the whole
+  of `pnpm gates` concurrently and the results are independent.
+- **There is no fast gate to split off, and adding one would be inventing a field.**
+  `.agents/repo.json` lists `gates.all` and `gates.fix` and no `gates.quick`; absent means
+  absent. `pnpm gates` *is* the fast gate here.
+- **N is not capped by test-server adoption**, because nothing serialises behind the
+  orchestrator. The real ceilings are CI (a public repo on `ubuntu-latest`, so minutes are
+  free but runs still queue) and the reviewer's own capacity to verify N branches — which
+  is a human limit, not a mechanical one, and the bundle's "3 is a sane ceiling" is about
+  exactly that. Treat it as advice here rather than as a hardware constraint.
+
+**What does not relax, and is the reason this section is not simply "parallelism is free
+here":**
+
+- **The printer boundary.** `pnpm gates` cannot touch the printer, so more concurrency adds
+  no hardware risk *from the gates* — but N agents is N chances for one of them to decide a
+  `Set…` would settle a question. The boundary is per-agent and does not scale with
+  cleverness. See "The gate no script can run" below.
+- **This repo is public.** More agents writing concurrently is more chances for a hostname,
+  an address or a capture to reach a commit, a branch name or a generated file. ELEG-82 is
+  what that looks like when a single developer does it unhurried.
+- **Green still proves very little**, exactly as the honest list below says. Running five
+  green gates in parallel produces five results that each mean as little as one does.
+
 ## Warnings exit 0 here — the baseline is zero, keep it there
 
 `biome.json` sets a number of rules to `warn` rather than `error`, including

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,10 @@ data/
 .cache/
 
 # Claude Code — per-machine state only.
-# .mcp.json, AGENTS.md, .agents/ and .claude/commands/ ARE committed: they are the
-# shared agent instructions for this repo (see AGENTS.md).
+# .mcp.json, AGENTS.md, CLAUDE.md and .agents/ ARE committed: they are the shared
+# agent instructions for this repo (see AGENTS.md). .claude/commands/ used to be
+# too, but ELEG-81 moved those to the runnane/agent-userspace bundle, so .claude/
+# now holds nothing but the per-machine files listed below.
 .claude/worktrees/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ Topic deep-dives are in `.agents/` and are **not** auto-loaded — open the rele
 on demand when working in that area:
 
 - `.agents/gates.md` — the gate command (which is what CI runs), why green means very
-  little here, and the printer boundary no gate can enforce
+  little here, the printer boundary no gate can enforce, and why `/auto --parallel N`'s
+  gate split is unnecessary in this repo (no e2e, no port-binding gate)
 - `.agents/architecture.md` — one MQTT connection fanned out to WebSocket / REST /
   `/mcp` / Moonraker / OctoPrint / Telegram; which layer a change belongs in
 - `.agents/deployment.md` — production is systemd `elegooweb.service` running from


### PR DESCRIPTION
Closes ELEG-78.

## The premise changed under this issue, in both halves

ELEG-78 asked to port two `.claude/commands/` changes from RCP PR #433. Checked rather than assumed, and neither half survives:

**1. There is no `.claude/commands/` in this repo any more.** ELEG-81 (`06f6e30`) deleted it:

```
 .claude/commands/auto.md                   | 192 ----------------
 .claude/commands/fix.md                    | 159 -------------
 .claude/commands/plan.md                   |  70 ------
 .claude/commands/research.md               |  58 -----
 .claude/commands/shared/agent-isolation.md |  93 --------
 .claude/commands/shared/gate-failures.md   | 141 ------------
```

There is nowhere here to port a command body *to*. And per the constitution, an agent commits only in the repo it was invoked in — a change to a bundle command is filed against `runnane/agent-userspace`, never applied to a consumer's checkout.

**2. Both requested changes are already live in that bundle.** The `/auto` that ran this pass carries `## 7. --parallel N` and `### Never send a subagent to a large reference skill` verbatim. Nothing is owed on the generic half.

## What was still genuinely owed

The **ELEG-specific** half — which is a repo fact, so by the "where a lesson goes" test it belongs in this repo and not in shared prose. That is the new section in `.agents/gates.md` (the file `.agents/repo.json` names as `gatesDoc`).

RCP's gate split — *subagents run the fast gate, the orchestrator runs the port-binding one serially* — exists because Playwright binds a fixed port and `reuseExistingServer` **adopts** another worktree's server, so concurrent runs silently test each other's build.

**Measured here, that cause is absent:**

- The five gates are `biome ci`, `tsc`, `tsc -p tsconfig.server.json`, `vite build`, `vitest run`. None starts a server, binds a port, or touches a database.
- `package.json` has no `playwright` or `puppeteer`, and there is no e2e or browser-driving test of any kind.

So, the opposite of RCP on all three counts: nothing for an orchestrator to run serially; no fast gate to split off (`.agents/repo.json` has `gates.all` and `gates.fix` and no `gates.quick` — absent means absent, and inventing one would be inventing a manifest field); and N is not capped by test-server adoption.

The section is deliberately **not** "parallelism is free here". It also records what does *not* relax: the printer boundary is per-agent and does not scale with concurrency, this repo is public so more concurrent writers is more chances to leak, and green proves as little run N times as it does run once.

## Also here

- `.gitignore`'s comment still told the reader that `.claude/commands/` is committed. Stale since ELEG-81; corrected, and it now says where those files went.
- `CLAUDE.md`'s `.agents/gates.md` bullet points at the new section, since `CLAUDE.md` is the file that loads every session.

## Verification

`pnpm gates` green — all five checks, 238 tests passing (unchanged from `main`).

**No failing-direction check, and that is not an omission.** This change is documentation and one comment line; it adds no guard, so there is no implementation to mutate and nothing that could go red. Claiming a mutation test here would be theatre. `biome ci` reports `Checked 0 files` for the diff because it does not reach markdown — that is the measured, documented behaviour in `.agents/gates.md`, not a silent skip.

## Not done, deliberately

I have **not** touched the parent RCP-784 or the `agent-userspace` bundle. Both are other repos; a lesson that belongs in a sibling is ported by filing there, not by editing its checkout from here.