### PR TITLE
docs(agents): stop citing protocol references that are not in a clone (ELEG-66)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -158,6 +158,35 @@ app, with the full method table, the `hh` error-code enum and per-method payload
 they disagree with the running code — and they do, for 1062 and the 2006/2007 pair —
 neither wins on authority, because the reference may describe a different firmware.
 
+**Both are local-only. Neither is in a clone (ELEG-66).** `.gitignore` line 7 is a bare
+`data/`, and `git log --all --diff-filter=A -- 'data/*'` returns nothing: no file under
+`data/` has ever been committed. That directory is also the runtime `DATA_DIR` — state
+snapshots, `data/logs/` captures, timelapses — and ignoring *that* content is right,
+since it carries serial numbers, local addresses and operational captures that have no
+place in a public repo. The protocol documents simply live in the same directory and got
+swept up with it.
+
+So check before you cite:
+
+```bash
+ls data/CC2_PROTOCOL_REFERENCE.md data/CC2-OFFICIAL-APP-PATTERNS.md
+```
+
+**If they are absent, say so and use the `Get…` probe below instead.** Do not cite a
+file you cannot open — that is indistinguishable from inventing one, and inventing
+method numbers is the thing this whole section exists to prevent. Do not reconstruct
+them from `METHOD_NAMES` either, for the reason above.
+
+**Anything you learn goes into code, not into `data/`.** A finding recorded only in
+`data/CC2_PROTOCOL_REFERENCE.md` is invisible to everyone else and lost with the
+machine, because that file never commits. ELEG-55 put `error_code 1100` in a comment in
+`src/ui/log-methods.ts` precisely for this reason. Follow it: the comment commits, the
+`data/` edit does not.
+
+Whether these two documents could be committed at all — they are transcribed from the
+vendor's own application and firmware headers, into a **public** repo — is an open
+question tracked separately, and is a call for a human rather than an agent.
+
 Then a **`Get…` method can simply be asked**, which is a read and therefore allowed:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,11 +248,28 @@ Actions minutes (the private siblings do not, hence their self-hosted runners).
   token*), AI detection on 2010/2011 (neither exists), OTA on 1064 (really 1039). All
   three were copied out of `METHOD_NAMES` in `src/ui/log-methods.ts`, which is a
   **display label for the log viewer, not a citation**, and which contradicted itself
-  by listing 1038 *and* 1049 as history delete. Cite
-  [`data/CC2_PROTOCOL_REFERENCE.md`](data/CC2_PROTOCOL_REFERENCE.md) instead, and where
-  the docs and the running code disagree, settle it by **asking the printer** — a
-  `Get…` is a read and is allowed. `.agents/testing.md` has the one-liner. Never fire a
-  `Set…` to find out what it does.
+  by listing 1038 *and* 1049 as history delete.
+
+  **The protocol references are local-only, and are not in a clone (ELEG-66).**
+  `data/` is gitignored in full and no file under it has ever been committed, so
+  `data/CC2_PROTOCOL_REFERENCE.md` and `data/CC2-OFFICIAL-APP-PATTERNS.md` exist only on
+  a machine where someone generated them. Check before citing:
+
+  ```bash
+  ls data/CC2_PROTOCOL_REFERENCE.md data/CC2-OFFICIAL-APP-PATTERNS.md
+  ```
+
+  If you have them, cite them — they remain the authority, and `.agents/testing.md`
+  says how to weigh them against the running code. **If you do not, say so rather than
+  citing them anyway**: a citation of a file you cannot open is indistinguishable from
+  an invented one, which is the exact failure this rule exists to stop. Fall back to
+  **asking the printer** — a `Get…` is a read and is allowed; `.agents/testing.md` has
+  the one-liner. Never fire a `Set…` to find out what it does.
+
+  **Record what you learn in code, not only in `data/`.** A protocol finding written
+  into a `data/` file is lost to everyone else, because that file never commits. ELEG-55
+  put `error_code 1100` in a comment in `src/ui/log-methods.ts` for exactly this reason.
+  Do the same.
 - **Capture durable learnings — don't relearn them.** A gotcha, a workflow step, a
   project constraint: write it down in the same change. Project facts → this file or
   the relevant [`.agents/`](.agents/) deep-dive; gate particulars →


### PR DESCRIPTION
Closes ELEG-66. Files the deferred half as ELEG-83.

## The problem, re-confirmed rather than assumed

`.gitignore` line 7 is a bare `data/`, `git ls-files data/` is empty, and no file under `data/` has ever been committed. Meanwhile:

- `AGENTS.md` told every agent to cite `data/CC2_PROTOCOL_REFERENCE.md` — **as a markdown link**, which renders as a 404 on GitHub.
- `.agents/testing.md` named both references as *"the citable sources"*.

So the rule that exists specifically to stop agents inventing method numbers — a rule three issues had already been burned by — pointed at a file anyone cloning this repo does not have. As the issue put it, the current state was the worst one: the guidance and the repo disagreed, invisibly.

## The decision

The issue lists three options. **Taking option 3** (fix the guidance), and filing option 1/2 as **ELEG-83** for a human. Two reasons, and the second is the one I did not expect:

**1. Provenance is a human's call, as the issue says.** The files' own headers describe them as extracted from the de-minified official Elegoo web app and from **CC2 firmware source headers** (`elegoo/common/method.h`). Whether a structured transcription of a vendor's application and firmware may be published in a public repo is an intellectual-property question, not a hygiene one. An unattended pass should not decide it, and the issue explicitly says so.

**2. There is a second, independent blocker that option 1 would have walked straight into.** `CC2_PROTOCOL_REFERENCE.md:1059` contains a real private LAN address in an example payload, and `GAPS-AND-ISSUES.md` names a specific firmware build twice. Committing these as-is would reintroduce — in a docs file — exactly the class of disclosure that **PR #79 removed from `vite.config.ts` earlier in this same pass**. And `.agents/security.md` is explicit that the remedy is *generate, do not sanitise*, because sanitising fails silently once; a 1121-line file scrubbed by hand is precisely where that fails.

I also found a **third** file the issue does not mention — `data/GAPS-AND-ISSUES.md`, 385 lines, same provenance. ELEG-83 covers all three so it is not discovered late.

## What changed

Both citation sites now:

- state the files are **local-only and not in a clone**, with the one-line `ls` check;
- say what to do when they are absent — use the `Get…` probe, and **say so rather than citing them anyway**, because a citation of a file you cannot open is indistinguishable from an invented one, which is the exact failure the rule guards against;
- explain *why* `data/` is ignored (it is the runtime `DATA_DIR`, carrying serials, addresses and captures), so the ignore does not read as a mistake someone should "fix";
- record that **protocol findings go in code comments, not in `data/`**, since a `data/` edit never commits. ELEG-55 already did this for `error_code 1100`; this promotes it from one person's good instinct to the documented rule.

The markdown link in `AGENTS.md` is gone — a link that 404s is worse than plain text.

## Verification

`pnpm gates` green — all five checks, 238 tests (unchanged from `main`).

**No failing-direction check, deliberately.** This is documentation only; it adds no guard, so there is no implementation to mutate and nothing that could go red. `biome ci` reports `Checked 0 files` on this diff because markdown is outside its scope — measured, documented behaviour, not a silent skip.

The claim that actually needed checking here was not a test but the premise, and it was checked directly: `git ls-files data/` empty, the three files present locally, both citation sites located by grep across `AGENTS.md`, `.agents/`, `README.md` and `MCP.md`.