### PR TITLE
test(ui): give jsdom a working localStorage and assert real persistence (ELEG-64)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -93,10 +93,30 @@ another; the two things it establishes:
   the re-rendered container and asserts focus **is** lost. A test that cannot go red is
   not coverage, so the failure mode is encoded permanently rather than demonstrated once
   by hand. Verified: moving the bar inside turns three of the focus tests red.
-- **There is no `localStorage`** — `bare`, `window.` and `globalThis.` are all
-  `undefined` under jsdom 30 on Node 26. `ui-settings.ts` catches and falls back to
-  defaults, so a persistence test would **pass for the wrong reason**. Give each case a
-  unique list id instead, and do not assert persistence until **ELEG-64** lands.
+- **`localStorage` works now, and the reason it did not is worth knowing** (ELEG-64).
+  `src/__tests__/setup/jsdom-localstorage.ts` installs one; `ui-settings-persistence.test.ts`
+  asserts real round-trips across a simulated reload.
+
+  The cause was **not** the obvious one. jsdom does refuse `localStorage` on an opaque
+  origin — `new JSDOM('')` throws `SecurityError`, reproducibly — but inside vitest the
+  origin is already `http://localhost:3000`, so `environmentOptions.jsdom.url` fixes
+  nothing. The real cause is **Node 26's own experimental `localStorage`**, installed on
+  `globalThis` as an accessor whose getter returns `undefined` without
+  `--localstorage-file` (hence the `ExperimentalWarning` on every jsdom file). Since
+  `window === globalThis` under vitest, it **shadows jsdom's**. The descriptor is
+  `configurable: true`, so the setup file replaces it with an in-memory `Storage`.
+
+  **The trap it created has not gone away.** `ui-settings.ts` still wraps every access in
+  try/catch and still degrades silently to defaults, so a persistence test whose expected
+  value equals the default still passes for the wrong reason. Never assert a default:
+  use `'dark'` (not `'auto'`) for theme, a populated object for `listSort`. And re-import
+  the module rather than calling `loadUISettings()` twice — it memoises in a module-level
+  `cached`, so a second call returns the cache without touching storage, testing the
+  variable rather than the persistence.
+
+  Existing DOM tests still give each case a unique list id. That was always the better
+  approach for reason 1 in that file's header (the memoisation), which is independent of
+  storage and unchanged.
 
 What jsdom still does not give you: layout, paint, real fonts, or `getContext('2d')`.
 Colour, overlap and appearance are still `pnpm dev:web` and eyes, and there is still no

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["index.html", "src/main.ts", "src/server/index.ts", "src/__tests__/**/*.test.ts"],
+  "entry": [
+    "index.html",
+    "src/main.ts",
+    "src/server/index.ts",
+    "src/__tests__/**/*.test.ts",
+    "src/__tests__/setup/*.ts"
+  ],
   "project": ["src/**/*.ts", "*.config.ts"],
   "include": ["files"]
 }

--- a/src/__tests__/list-controls-dom.test.ts
+++ b/src/__tests__/list-controls-dom.test.ts
@@ -55,12 +55,16 @@ const COLUMNS = [
  *  1. `ui-settings.ts` memoises the whole settings object in a module-level `cached`, so
  *     clearing storage between tests would not reset it — a persisted sort from one test
  *     would leak into the next.
- *  2. **There is no `localStorage` in this environment at all.** Measured: `localStorage`,
- *     `window.localStorage` and `globalThis.localStorage` are all `undefined` under
- *     jsdom 30 on Node 26. `ui-settings.ts` wraps every access in try/catch, so it
- *     degrades silently to defaults rather than throwing — which means a test that
- *     *appeared* to assert persistence would be vacuous. Do not write one until the
- *     environment actually provides storage (ELEG-64).
+ *  2. There **used** to be no `localStorage` in this environment at all, so a test that
+ *     appeared to assert persistence was vacuous. **ELEG-64 fixed that** — a setup file
+ *     now installs one, and `ui-settings-persistence.test.ts` asserts real round-trips.
+ *     Reason 1 above still stands entirely on its own, which is why unique ids remain
+ *     the right approach here.
+ *
+ *     If you do write a persistence test, follow that file: never assert a value equal
+ *     to the module's default, because `ui-settings.ts` still wraps every access in
+ *     try/catch and still degrades silently to defaults. The environment is fixed; the
+ *     way such a test can pass for the wrong reason is not.
  *
  * Distinct ids sidestep both, and are cheaper and less brittle than resetting modules.
  */

--- a/src/__tests__/setup/jsdom-localstorage.ts
+++ b/src/__tests__/setup/jsdom-localstorage.ts
@@ -1,0 +1,102 @@
+/**
+ * Give jsdom tests a working `localStorage` (ELEG-64).
+ *
+ * ## What was wrong
+ *
+ * Under the `@vitest-environment jsdom` docblock, all access paths to `localStorage`
+ * were `undefined` — bare, via `window`, and via `globalThis`. Because
+ * `src/ui/ui-settings.ts` wraps every storage access in try/catch and falls back to
+ * defaults, nothing threw and nothing was logged. A test asserting "the sort choice is
+ * persisted and restored" would have exercised the catch branch, got defaults back, and
+ * **passed for the wrong reason** whenever its expectations matched those defaults —
+ * which for `listSort` (`{}`) and `listSelect` (`'all'`) they very often would.
+ *
+ * ## The cause, measured — and it is NOT the one that looks obvious
+ *
+ * The natural suspicion is jsdom's opaque-origin rule: jsdom throws
+ * `SecurityError: localStorage is not available for opaque origins`, and a bare
+ * `new JSDOM('')` does exactly that because its document is `about:blank`. That is real,
+ * and it is reproducible:
+ *
+ *     new JSDOM('')                             -> SecurityError on .localStorage
+ *     new JSDOM('', { url: 'http://localhost:3000/' })  -> works, round-trips
+ *
+ * **But it is not what was happening here.** Probed inside the vitest jsdom environment,
+ * the origin is already fine:
+ *
+ *     href = "http://localhost:3000/"   origin = "http://localhost:3000"
+ *     typeof window.localStorage = "undefined"
+ *
+ * So setting `environmentOptions.jsdom.url` fixes nothing — it is already that value.
+ *
+ * The actual cause is Node itself. Node 26 ships an experimental built-in
+ * `localStorage`, and prints on every jsdom test file:
+ *
+ *     ExperimentalWarning: localStorage is not available because
+ *     --localstorage-file was not provided.
+ *
+ * It is installed on `globalThis` as an **accessor** whose getter returns `undefined`
+ * when that flag is absent:
+ *
+ *     Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
+ *       -> { get, set, enumerable, configurable: true }   // getter yields undefined
+ *
+ * and under vitest `window === globalThis`, so Node's accessor **shadows jsdom's own
+ * property**. Reading `window.localStorage` reads Node's, not jsdom's, which is why
+ * every path was undefined despite a perfectly good origin.
+ *
+ * ## The fix
+ *
+ * The descriptor is `configurable: true`, so it can be replaced. This installs a small
+ * in-memory `Storage` on top. A stub rather than jsdom's implementation because jsdom's
+ * `Storage` instance is not reachable from inside the environment once shadowed, and
+ * rather than `--localstorage-file` because that would make the suite depend on a node
+ * flag and write a real file.
+ *
+ * Only the API `ui-settings.ts` and `list-controls.ts` actually use is needed, but the
+ * whole `Storage` surface is implemented so a future caller does not silently hit a
+ * missing method — which is the same class of quiet failure this whole issue is about.
+ *
+ * Node-environment tests are untouched: the guard below is why.
+ */
+
+class MemoryStorage implements Storage {
+  #map = new Map<string, string>();
+
+  get length(): number {
+    return this.#map.size;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.#map.keys())[index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.#map.get(String(key)) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.#map.set(String(key), String(value));
+  }
+
+  removeItem(key: string): void {
+    this.#map.delete(String(key));
+  }
+
+  clear(): void {
+    this.#map.clear();
+  }
+
+  [name: string]: unknown;
+}
+
+// Only for the jsdom environment. In the `node` environment there is no document and no
+// browser code under test, so leaving Node's own global alone is correct.
+if (typeof document !== 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: new MemoryStorage(),
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+}

--- a/src/__tests__/ui-settings-persistence.test.ts
+++ b/src/__tests__/ui-settings-persistence.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ELEG-64. These tests exist to prove that jsdom persistence is REAL here, and they are
+ * written so that they cannot pass if it is not.
+ *
+ * The hazard being guarded against: `ui-settings.ts` wraps every storage access in
+ * try/catch and falls back to defaults. Before ELEG-64, jsdom's default document was
+ * `about:blank` — an opaque origin, for which jsdom refuses localStorage — so nothing
+ * threw and nothing was logged, and a test asserting "the sort choice is persisted and
+ * restored" would have exercised the catch branch, got defaults back, and passed for the
+ * wrong reason whenever its expectations matched those defaults.
+ *
+ * Two rules for anything added here:
+ *
+ *  1. Never assert a value equal to the module's default. `theme` defaults to 'auto', so
+ *     these use 'dark'; `listSort` defaults to `{}`, so these use a populated object.
+ *     An assertion that matches the default cannot distinguish working storage from
+ *     absent storage.
+ *  2. Re-import the module rather than calling load twice. `ui-settings.ts` memoises in a
+ *     module-level `cached`, so a second `loadUISettings()` in the same module instance
+ *     returns the cache WITHOUT TOUCHING STORAGE — which would test the variable, not the
+ *     persistence. `vi.resetModules()` + dynamic import is what simulates a page reload.
+ */
+
+const STORAGE_KEY = 'elegoo-web-ui-settings';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+});
+
+describe('the jsdom environment itself', () => {
+  it('provides a real, working localStorage', () => {
+    // The guard the whole file rests on. If this fails, every persistence assertion
+    // below is meaningless, so it must fail loudly rather than be inferred.
+    expect(typeof localStorage).toBe('object');
+    localStorage.setItem('eleg-64-probe', 'stored');
+    expect(localStorage.getItem('eleg-64-probe')).toBe('stored');
+  });
+
+  it('is served from a non-opaque origin, which is what makes that true', () => {
+    expect(window.location.origin).toBe('http://localhost:3000');
+  });
+});
+
+describe('ui-settings persistence', () => {
+  it('writes saved settings through to the storage key', async () => {
+    const { saveUISettings } = await import('../ui/ui-settings');
+    saveUISettings({ theme: 'dark' });
+
+    // Asserting on the raw storage entry, not on a getter — this is what proves the
+    // value left the module and reached storage.
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string).theme).toBe('dark');
+  });
+
+  it('restores a saved value across a module reload', async () => {
+    const first = await import('../ui/ui-settings');
+    first.saveUISettings({ theme: 'dark' });
+
+    // Simulate a page reload: drop the module cache and import a fresh instance, which
+    // must read from storage because its own `cached` starts null.
+    vi.resetModules();
+    const second = await import('../ui/ui-settings');
+
+    // 'dark' is deliberately not the default ('auto'), so absent storage fails here.
+    expect(second.loadUISettings().theme).toBe('dark');
+  });
+
+  it('restores a per-list sort choice across a module reload', async () => {
+    const first = await import('../ui/ui-settings');
+    first.saveListSort('files-list', { key: 'size', dir: 'desc' });
+
+    vi.resetModules();
+    const second = await import('../ui/ui-settings');
+
+    // listSort defaults to {}, so getListSort would return undefined without storage.
+    expect(second.getListSort('files-list')).toEqual({ key: 'size', dir: 'desc' });
+  });
+
+  it('restores a dropdown selection across a module reload', async () => {
+    const first = await import('../ui/ui-settings');
+    first.saveListSelect('files-list.status', 'failed');
+
+    vi.resetModules();
+    const second = await import('../ui/ui-settings');
+
+    // The documented default for an absent selection is 'all'; 'failed' is not it.
+    expect(second.getListSelect('files-list.status')).toBe('failed');
+  });
+
+  it('falls back to defaults when nothing is stored, without throwing', async () => {
+    const { loadUISettings } = await import('../ui/ui-settings');
+    expect(loadUISettings().theme).toBe('auto');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // ELEG-64: restores a working `localStorage` under jsdom. Node 26 shadows jsdom's
+    // own; see the setup file for the measurement and why this is the fix.
+    setupFiles: ['src/__tests__/setup/jsdom-localstorage.ts'],
     include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Closes ELEG-64.

## Reproduced first

The issue's measurement still holds on this tree — `bare=undefined`, `viaWindow=undefined`, Node v26.5.0, plus the `ExperimentalWarning` on every jsdom file.

## The cause is not the one that looks obvious

The issue offered two hypotheses. Both were measured rather than picked.

**Hypothesis 1 — opaque origin — is real, and is *not* what was happening here.** jsdom genuinely refuses `localStorage` on an opaque origin, and it reproduces cleanly:

```
new JSDOM('')                                    -> SecurityError: localStorage is not
                                                    available for opaque origins
new JSDOM('', { url: 'http://localhost:3000/' }) -> object, and round-trips
```

But probed *inside* the vitest jsdom environment, the origin is already fine:

```
href = "http://localhost:3000/"   origin = "http://localhost:3000"
typeof window.localStorage = "undefined"
```

So `environmentOptions.jsdom.url` fixes nothing — it is already that value. I had written that change before probing; it was a no-op and has been removed rather than left in to look like a fix.

**Hypothesis 2 — Node 26 shadowing — is the cause.** Node ships an experimental built-in `localStorage` installed on `globalThis` as an accessor whose getter returns `undefined` when `--localstorage-file` is absent:

```
Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
  -> { get, set, enumerable, configurable: true }    // getter yields undefined
window === globalThis  -> true
```

Since `window === globalThis` under vitest, Node's accessor **shadows jsdom's own property**, which is why every access path was undefined despite a perfectly good origin.

## The fix

The descriptor is `configurable: true`, so `src/__tests__/setup/jsdom-localstorage.ts` replaces it with an in-memory `Storage`, guarded on `typeof document !== 'undefined'` so node-environment tests are untouched.

A stub rather than jsdom's own implementation, because jsdom's `Storage` is not reachable from inside the environment once shadowed; and rather than `--localstorage-file`, which would make the suite depend on a node flag and write a real file. The full `Storage` surface is implemented, not just the four methods currently used, so a future caller does not silently hit a missing method — the same class of quiet failure this issue is about.

## The acceptance check, written as the issue specified

> *"a test that stores a value, re-reads it, and fails if storage is absent — not one that could pass against defaults."*

Seven tests in `src/__tests__/ui-settings-persistence.test.ts`. Two design rules, documented in the file so they are not undone:

1. **Never assert a value equal to a module default.** `theme` uses `'dark'` (default is `'auto'`); `listSort` uses a populated object (default `{}`); `listSelect` uses `'failed'` (documented default `'all'`). An assertion matching the default cannot distinguish working storage from absent storage — which is the whole hazard.
2. **Re-import rather than calling load twice.** `ui-settings.ts` memoises in a module-level `cached`, so a second `loadUISettings()` returns the cache **without touching storage** — testing the variable, not the persistence. `vi.resetModules()` + dynamic import is what simulates a reload.

One test asserts on the **raw storage key**, not a getter, which is what proves the value actually left the module.

## Verification

`pnpm gates` green, six checks. Test count re-measured against `main`: **238 → 245**, a delta of exactly the 7 added.

**Failing-direction check** — and this is the one the issue actually asked for. The setup file's install was disabled (`if (typeof document !== 'undefined')` → `if (false)`), returning the environment to its broken state:

```
     × provides a real, working localStorage
     × is served from a non-opaque origin, which is what makes that true
     × writes saved settings through to the storage key
     × restores a saved value across a module reload
     × restores a per-list sort choice across a module reload
     × restores a dropdown selection across a module reload
     × falls back to defaults when nothing is stored, without throwing
      Tests  7 failed (7)
```

All seven go red when storage is absent — so none of them can pass vacuously, which was the acceptance bar. Restored from a copy taken immediately before the patch, `git status` re-checked, gates re-run green.

## knip caught the setup file, correctly

The dead-code gate added in ELEG-65 (merged earlier in this pass) failed on the first full run:

```
  ✗ dead code (knip)
Unused files (1)
src/__tests__/setup/jsdom-localstorage.ts
```

That is a true positive by knip's rules — a `setupFiles` entry is reachable only through the vitest config, not through any import. Declared as an entry point in `knip.json`. Worth noting as evidence the new gate behaves as intended on real work rather than only on a synthetic probe.

## Docs corrected

`.agents/testing.md` and the header of `src/__tests__/list-controls-dom.test.ts` both told readers **not** to write persistence tests until this landed. Both now describe the fix, the refuted hypothesis, and — importantly — that **the trap has not gone away**: `ui-settings.ts` still catches and falls back to defaults, so a test whose expected value equals a default still passes for the wrong reason. The environment is fixed; the way such a test can be vacuous is not.

The existing DOM tests keep their unique-list-id approach, which was always the right answer for the *memoisation* reason and is independent of storage.

## Scope note

`persistence.ts` — which the issue names as "presumably affected the same way, but that was not measured" — no longer exists: it was unreachable and was deleted in ELEG-65 earlier in this pass. So there is nothing left to measure there, and no follow-up issue is owed for it.
