### PR TITLE
feat(ui): audible alert on print completion and critical errors (ELEG-46)

### DIFF
--- a/src/__tests__/alert-sound.test.ts
+++ b/src/__tests__/alert-sound.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { alertForEvent } from '../ui/alert-sound';
+import { CRITICAL_EXCEPTIONS } from '../types';
+
+/**
+ * ELEG-46. Only the decision half is testable — whether a sound actually reaches
+ * speakers needs a browser, a user gesture and an `AudioContext`, and no gate here has
+ * any of those. What IS testable is which events should sound, and that is where the
+ * rules that could silently drift live.
+ */
+describe('alertForEvent', () => {
+  it('sounds a success for a completed print', () => {
+    expect(alertForEvent({ type: 'print_completed', filename: 'a.gcode' })).toBe('success');
+  });
+
+  it('sounds a failure for a failed print', () => {
+    expect(alertForEvent({ type: 'print_failed', filename: 'a.gcode', reason: 'x' })).toBe(
+      'failure',
+    );
+  });
+
+  it('sounds a failure for an error carrying a critical exception code', () => {
+    // 101 is in CRITICAL_EXCEPTIONS; asserted below so this cannot drift silently.
+    expect(CRITICAL_EXCEPTIONS.has(101)).toBe(true);
+    expect(alertForEvent({ type: 'error', codes: [101], names: ['Nozzle temp abnormal'] })).toBe(
+      'failure',
+    );
+  });
+
+  it('stays silent for an error whose codes are all non-critical', () => {
+    // 9999 is deliberately not a real exception; asserted so the test cannot pass
+    // merely because the set happened to change.
+    expect(CRITICAL_EXCEPTIONS.has(9999)).toBe(false);
+    expect(alertForEvent({ type: 'error', codes: [9999], names: ['Something minor'] })).toBeNull();
+  });
+
+  it('sounds if any one code in a mixed batch is critical', () => {
+    expect(alertForEvent({ type: 'error', codes: [9999, 801], names: [] })).toBe('failure');
+  });
+
+  it('reuses CRITICAL_EXCEPTIONS rather than a second severity list', () => {
+    // The issue is explicit that a second severity rule must not be invented. This
+    // asserts the coupling directly: every critical code produces a failure alert.
+    for (const code of CRITICAL_EXCEPTIONS) {
+      expect(alertForEvent({ type: 'error', codes: [code], names: [] })).toBe('failure');
+    }
+  });
+
+  it('stays silent for routine events', () => {
+    for (const type of [
+      'connected',
+      'disconnected',
+      'print_started',
+      'print_progress',
+      'layer_change',
+      'first_layer_complete',
+      'status_change',
+      'sub_status_change',
+    ]) {
+      expect(alertForEvent({ type })).toBeNull();
+    }
+  });
+
+  it('stays silent rather than throwing when an error event has no codes array', () => {
+    // Defensive: the field is typed on the server, but this runs on whatever the socket
+    // delivered, and a throw here would break the event log render.
+    expect(alertForEvent({ type: 'error', names: ['x'] })).toBeNull();
+    expect(alertForEvent({ type: 'error', codes: 'not-an-array' })).toBeNull();
+  });
+
+  it('stays silent for an unknown event type', () => {
+    expect(alertForEvent({ type: 'something_new' })).toBeNull();
+    expect(alertForEvent({})).toBeNull();
+  });
+});

--- a/src/__tests__/ui-settings-persistence.test.ts
+++ b/src/__tests__/ui-settings-persistence.test.ts
@@ -97,3 +97,26 @@ describe('ui-settings persistence', () => {
     expect(loadUISettings().theme).toBe('auto');
   });
 });
+
+describe('audible alert settings (ELEG-46)', () => {
+  it('is OFF by default', async () => {
+    // An explicit requirement of ELEG-46, and the one most likely to be broken by a
+    // careless edit to the defaults object — a dashboard that starts making noise on
+    // first load is the failure this asserts against.
+    const { loadUISettings } = await import('../ui/ui-settings');
+    expect(loadUISettings().alertSound).toBe(false);
+    expect(loadUISettings().alertVolume).toBe(0.5);
+  });
+
+  it('persists the toggle and volume across a reload', async () => {
+    const first = await import('../ui/ui-settings');
+    first.saveUISettings({ alertSound: true, alertVolume: 0.2 });
+
+    vi.resetModules();
+    const second = await import('../ui/ui-settings');
+
+    // Both differ from the defaults, so absent storage fails this rather than passing.
+    expect(second.loadUISettings().alertSound).toBe(true);
+    expect(second.loadUISettings().alertVolume).toBe(0.2);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ import {
 import { renderLog, bindLogControls } from './ui/log';
 import { installThumbnailFallback } from './ui/helpers';
 import { initTheme } from './ui/theme';
+import { maybeAlertForEvent } from './ui/alert-sound';
 import type { PrinterStatus, PrinterAttributes, CanvasInfo, FileEntry } from './types';
 import {
   COMMAND_METHOD_NAMES,
@@ -650,6 +651,10 @@ function connectToService(): void {
     },
     onEventLog(entry) {
       handleEventLog(entry);
+      // ELEG-46. This is the LIVE event path; `loadEventLogHistory` below restores the
+      // history on connect and deliberately does NOT sound, so reconnecting never
+      // replays a sound for a print that finished an hour ago.
+      maybeAlertForEvent(entry.event);
     },
     onLayerTime(entry) {
       state.addLayerTime(entry);

--- a/src/ui/alert-sound.ts
+++ b/src/ui/alert-sound.ts
@@ -1,0 +1,175 @@
+/**
+ * Audible alerts for print completion and errors (ELEG-46).
+ *
+ * Split deliberately in two halves, as the issue asked:
+ *
+ *  - `alertForEvent` is **pure** — event in, alert kind or null out — and is the half a
+ *    unit test can reach. Every rule about *which* events sound lives there.
+ *  - Everything below `--- playback ---` needs a browser: an `AudioContext`, a user
+ *    gesture, and speakers. No gate can test it.
+ *
+ * Sound is **off by default** (`ui-settings.ts`), because a dashboard that starts making
+ * noise is a bad first impression, and because the autoplay policy below means it would
+ * often not work anyway until the user clicked something.
+ */
+
+import { CRITICAL_EXCEPTIONS } from '../types';
+import { loadUISettings } from './ui-settings';
+
+export type AlertKind = 'success' | 'failure';
+
+/**
+ * Decide whether an event should make a sound, and which.
+ *
+ * Pure: no DOM, no audio, no settings. The settings check lives in the caller so that
+ * this stays a statement about the *events* alone and can be tested without stubbing
+ * storage.
+ *
+ * `CRITICAL_EXCEPTIONS` is reused rather than a second severity rule being invented —
+ * the issue is explicit about that, and a second list would drift from the first.
+ */
+export function alertForEvent(event: Record<string, unknown>): AlertKind | null {
+  switch (event.type) {
+    case 'print_completed':
+      return 'success';
+    case 'print_failed':
+      return 'failure';
+    case 'error': {
+      // The server sends `codes: number[]` alongside `names: string[]`; the codes are
+      // what CRITICAL_EXCEPTIONS is keyed on. A non-critical exception is a warning and
+      // deliberately silent — otherwise the alert becomes noise and gets turned off,
+      // which is the same as not having it.
+      const codes = event.codes;
+      if (!Array.isArray(codes)) return null;
+      return codes.some((c) => typeof c === 'number' && CRITICAL_EXCEPTIONS.has(c))
+        ? 'failure'
+        : null;
+    }
+    default:
+      return null;
+  }
+}
+
+// --- playback -------------------------------------------------------------------
+// Everything below here needs a real browser.
+
+/** Why a sound did not play, for the UI to report rather than failing silently. */
+export type PlaybackState = 'ok' | 'blocked' | 'unsupported';
+
+let ctx: AudioContext | null = null;
+let lastState: PlaybackState = 'ok';
+
+type AudioContextCtor = new () => AudioContext;
+
+function audioContextCtor(): AudioContextCtor | null {
+  const w = globalThis as unknown as {
+    AudioContext?: AudioContextCtor;
+    webkitAudioContext?: AudioContextCtor;
+  };
+  return w.AudioContext ?? w.webkitAudioContext ?? null;
+}
+
+function context(): AudioContext | null {
+  if (ctx) return ctx;
+  const Ctor = audioContextCtor();
+  if (!Ctor) {
+    lastState = 'unsupported';
+    return null;
+  }
+  ctx = new Ctor();
+  return ctx;
+}
+
+/**
+ * Whether the browser is currently refusing to play audio.
+ *
+ * Browsers block audio until the user has interacted with the page — and a dashboard
+ * left open on a second monitor and never clicked is *exactly* the case this feature is
+ * for, and also exactly the case where autoplay is refused. So this is surfaced in the
+ * settings UI rather than left to fail silently.
+ */
+export function playbackState(): PlaybackState {
+  if (lastState === 'unsupported') return 'unsupported';
+  return ctx?.state === 'suspended' ? 'blocked' : lastState;
+}
+
+/** Tone pairs chosen to be distinguishable across a room without being alarming. */
+const TONES: Record<AlertKind, Array<{ hz: number; ms: number }>> = {
+  // Rising major third — reads as "finished".
+  success: [
+    { hz: 660, ms: 140 },
+    { hz: 880, ms: 220 },
+  ],
+  // Falling, lower, three times — reads as "something is wrong".
+  failure: [
+    { hz: 440, ms: 160 },
+    { hz: 350, ms: 160 },
+    { hz: 260, ms: 320 },
+  ],
+};
+
+/**
+ * Play the alert for `kind`, honouring the saved volume.
+ *
+ * Returns the resulting `PlaybackState` so a caller (the test button) can tell the user
+ * that the browser refused, instead of leaving them wondering whether it is broken.
+ */
+export async function playAlert(kind: AlertKind): Promise<PlaybackState> {
+  const audio = context();
+  if (!audio) return 'unsupported';
+
+  // resume() is what converts "blocked" into "playing" once a gesture has happened. It
+  // rejects if there has been no gesture at all, which is the blocked case.
+  if (audio.state === 'suspended') {
+    try {
+      await audio.resume();
+    } catch {
+      lastState = 'blocked';
+      return 'blocked';
+    }
+  }
+  if (audio.state === 'suspended') {
+    lastState = 'blocked';
+    return 'blocked';
+  }
+
+  const volume = Math.min(1, Math.max(0, loadUISettings().alertVolume));
+  let at = audio.currentTime;
+
+  for (const tone of TONES[kind]) {
+    const osc = audio.createOscillator();
+    const gain = audio.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = tone.hz;
+
+    const seconds = tone.ms / 1000;
+    // Ramped rather than square, so it does not click on start and stop.
+    gain.gain.setValueAtTime(0, at);
+    gain.gain.linearRampToValueAtTime(volume * 0.3, at + 0.02);
+    gain.gain.linearRampToValueAtTime(0, at + seconds);
+
+    osc.connect(gain);
+    gain.connect(audio.destination);
+    osc.start(at);
+    osc.stop(at + seconds);
+    at += seconds;
+  }
+
+  lastState = 'ok';
+  return 'ok';
+}
+
+/**
+ * Sound an event if the user has alerts switched on.
+ *
+ * **Only ever call this for events arriving live.** The event log is restored on
+ * connect, and firing a sound for a print that finished an hour ago would be a genuinely
+ * bad first impression — so `main.ts` calls this from the live-event path and never from
+ * `loadEventLogHistory`.
+ */
+export function maybeAlertForEvent(event: Record<string, unknown>): void {
+  if (!loadUISettings().alertSound) return;
+  const kind = alertForEvent(event);
+  if (!kind) return;
+  void playAlert(kind);
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -6,6 +6,8 @@ import { toast } from './toast';
 import { renderSpoolCalc } from './spool-calc';
 import { renderHelp } from './help';
 import { getThemeChoice, setThemeChoice, isThemeChoice } from './theme';
+import { playAlert } from './alert-sound';
+import { loadUISettings, saveUISettings } from './ui-settings';
 
 const STORAGE_KEY = 'elegoo-web-card-layout';
 
@@ -203,6 +205,23 @@ function buildSettingsHTML(content: HTMLElement): void {
     </section>
 
     <section class="settings-section">
+      <h3>Alerts</h3>
+      <p class="settings-hint">Play a sound when a print finishes, fails, or hits a critical error. Off by default. Only events arriving live make a sound — reconnecting never replays old ones.</p>
+      <div class="settings-row">
+        <label for="settings-alert-sound">Audible alerts</label>
+        <input type="checkbox" id="settings-alert-sound">
+      </div>
+      <div class="settings-row">
+        <label for="settings-alert-volume">Volume</label>
+        <input type="range" id="settings-alert-volume" min="0" max="100" step="5">
+      </div>
+      <div class="settings-actions">
+        <button id="settings-alert-test" class="btn btn-sm btn-ghost">Test sound</button>
+      </div>
+      <div id="settings-alert-status" class="settings-hint"></div>
+    </section>
+
+    <section class="settings-section">
       <h3>Panel Layout</h3>
       <p class="settings-hint">Assign cards to the sidebar (always-visible) or main area. Reorder within each panel.</p>
       <h4 class="settings-panel-heading">Sidebar</h4>
@@ -313,6 +332,42 @@ function buildSettingsHTML(content: HTMLElement): void {
     themeSelect.value = getThemeChoice();
     themeSelect.addEventListener('change', () => {
       if (isThemeChoice(themeSelect.value)) setThemeChoice(themeSelect.value);
+    });
+  }
+
+  // ---- Audible alerts (ELEG-46) ----
+  const alertToggle = content.querySelector('#settings-alert-sound') as HTMLInputElement | null;
+  const alertVolume = content.querySelector('#settings-alert-volume') as HTMLInputElement | null;
+  const alertTest = content.querySelector('#settings-alert-test') as HTMLButtonElement | null;
+  const alertStatus = content.querySelector('#settings-alert-status') as HTMLElement | null;
+
+  if (alertToggle && alertVolume) {
+    const settings = loadUISettings();
+    alertToggle.checked = settings.alertSound;
+    alertVolume.value = String(Math.round(settings.alertVolume * 100));
+
+    alertToggle.addEventListener('change', () => {
+      saveUISettings({ alertSound: alertToggle.checked });
+    });
+    alertVolume.addEventListener('change', () => {
+      saveUISettings({ alertVolume: Number(alertVolume.value) / 100 });
+    });
+  }
+
+  if (alertTest && alertStatus) {
+    alertTest.addEventListener('click', async () => {
+      // The test button exists because otherwise the only way to find out whether this
+      // works is to wait for a failed print (ELEG-46). It reports the blocked state
+      // explicitly rather than appearing to do nothing.
+      const state = await playAlert('success');
+      if (state === 'blocked') {
+        alertStatus.textContent =
+          'The browser is blocking audio for this page. Interact with the page (click anywhere), then try again.';
+      } else if (state === 'unsupported') {
+        alertStatus.textContent = 'This browser has no Web Audio support, so alerts cannot play.';
+      } else {
+        alertStatus.textContent = 'Played.';
+      }
     });
   }
 

--- a/src/ui/ui-settings.ts
+++ b/src/ui/ui-settings.ts
@@ -21,6 +21,10 @@ export interface UISettings {
   listSort: Record<string, { key: string; dir: string }>;
   /** Per-list dropdown filter selections, keyed by `<listId>.<selectId>` (ELEG-49) */
   listSelect: Record<string, string>;
+  /** Play a sound on print completion and critical errors (ELEG-46). Off by default. */
+  alertSound: boolean;
+  /** Alert volume, 0..1 (ELEG-46) */
+  alertVolume: number;
 }
 
 const defaults: UISettings = {
@@ -33,6 +37,10 @@ const defaults: UISettings = {
   theme: 'auto',
   listSort: {},
   listSelect: {},
+  // Off by default: a dashboard that starts making noise is a bad first impression,
+  // and the autoplay policy means it would often be refused anyway (ELEG-46).
+  alertSound: false,
+  alertVolume: 0.5,
 };
 
 let cached: UISettings | null = null;


### PR DESCRIPTION
Closes ELEG-46. Files the Notifications API half as ELEG-84.

## What this does

A short sound on **print completed**, **print failed**, and **error events carrying a critical exception code**. Off by default, with a toggle, a volume slider and a **Test sound** button in Settings → Alerts.

`CRITICAL_EXCEPTIONS` from `src/types.ts` is reused rather than a second severity rule being invented — the issue is explicit about that, and there is now a test that walks the whole set and asserts every member produces an alert, so the two cannot drift apart silently. A **non-critical** exception is deliberately silent: an alert that fires on warnings becomes noise and gets switched off, which is the same as not having one.

## The two hazards the issue named

**Autoplay blocking.** Browsers refuse audio until the user has interacted with the page — and a dashboard left open on a second monitor and never clicked is precisely the case this feature exists for. `playAlert` returns a `PlaybackState` (`ok` / `blocked` / `unsupported`) and the settings panel reports it:

> *The browser is blocking audio for this page. Interact with the page (click anywhere), then try again.*

rather than the button appearing to do nothing.

**No history replay.** This falls out of an existing seam rather than needing new bookkeeping: `main.ts` calls the alert from `onEventLog` (live events) and **never** from `loadEventLogHistory` (the log restored on connect). So reconnecting cannot fire a sound for a print that finished an hour ago. The reason is commented at the call site and in the module, because it is the kind of thing a later refactor would helpfully "unify".

## Implementation notes

- **Tones are synthesised via the Web Audio API**, not shipped as audio files. No binary asset enters this public repo, the build is unchanged, and volume is applied directly to the gain node. Success is a rising major third; failure is three falling, lower tones.
- **`alertForEvent` is pure** — event in, `'success' | 'failure' | null` out. No DOM, no audio, no settings; the enabled-check lives in the caller so the decision can be tested without stubbing storage. That is the split the issue asked for.
- **Settings** are `alertSound` (false) and `alertVolume` (0.5) in `ui-settings.ts`, alongside the other UI preferences as specified.

## Verification

`pnpm gates` green, six checks. Test count re-measured against `main`: **245 → 256**, a delta of exactly the 11 added (9 decision + 2 settings).

**Failing-direction check.** The severity rule is the claim worth proving, so the *implementation* was mutated — the `CRITICAL_EXCEPTIONS` filter replaced with `codes.length > 0`, i.e. sound on any error at all:

```
     × stays silent for an error whose codes are all non-critical
      Tests  1 failed | 8 passed (9)
```

Exactly the named test, and only that one. Restored from a copy taken immediately before the patch; full suite re-run green.

Two of the tests deliberately assert the *premise* as well as the behaviour — `expect(CRITICAL_EXCEPTIONS.has(101)).toBe(true)` and `.has(9999)).toBe(false)` — so they cannot start passing for the wrong reason if the exception set is edited later.

The **off-by-default** requirement now has its own assertion, which is only possible because ELEG-64 (merged earlier in this pass) gave jsdom a working `localStorage`. Both alert settings are also asserted to round-trip across a reload, using values that differ from the defaults so absent storage fails rather than passes.

## What is NOT covered, stated plainly

**Whether a sound actually reaches speakers.** That needs a browser, a user gesture and an `AudioContext`; no gate here has any of those, and I am not claiming otherwise. Specifically unverified by CI:

- that the tones are audible and distinguishable across a room;
- that the volume slider maps sensibly;
- that the blocked-state message appears in a browser that is actually blocking.

These need `pnpm dev:web`, the Settings tab, and the Test sound button. No printer interaction is involved either way — this is frontend-only and touches nothing that commands the machine.

## Deliberately not done

The **Notifications API**, which the issue raised as "as well or instead". Filed as **ELEG-84** rather than folded in: it is a genuinely separate surface with its own permission model, its own secure-context constraint (which may rule it out for plain-HTTP LAN setups — worth checking before building), and its own de-duplication question against the audio path. ELEG-84 records all three, and points at `alertForEvent` so a second severity rule is not written.
