### PR TITLE
feat(ui): relative log timestamps as a toggle, not a replacement (ELEG-45)

### DIFF
--- a/src/__tests__/relative-time-dom.test.ts
+++ b/src/__tests__/relative-time-dom.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ELEG-45. The claim under test is the one the issue warns about: a relative timestamp
+ * written once and never updated is worse than a clock.
+ *
+ * These assert the *refresh* path specifically, and that it works **without a
+ * re-render** — which is what keeps the log's auto-scroll, pause button and expanded
+ * rows intact. `renderLog` also short-circuits when nothing changed, so a
+ * re-render-based approach would silently do nothing at all.
+ */
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+  document.body.innerHTML = '';
+});
+
+/** Mount one timestamp span of the shape the three render sites emit. */
+function mountSpan(ts: number, abs: string) {
+  document.body.innerHTML = `<span class="log-time" data-ts="${ts}" data-abs="${abs}" title="${abs}">${abs}</span>`;
+  return document.querySelector('.log-time') as HTMLElement;
+}
+
+describe('refreshTimestamps', () => {
+  it('leaves the absolute text alone while the setting is off', async () => {
+    const { refreshTimestamps } = await import('../ui/relative-time');
+    const el = mountSpan(NOW - 120_000, '12:34:56.000');
+
+    refreshTimestamps(NOW);
+
+    // Off by default, so this must not have become "2m ago".
+    expect(el.textContent).toBe('12:34:56.000');
+  });
+
+  it('rewrites the text to a relative age once the setting is on', async () => {
+    const { saveUISettings } = await import('../ui/ui-settings');
+    saveUISettings({ relativeTimestamps: true });
+    const { refreshTimestamps } = await import('../ui/relative-time');
+    const el = mountSpan(NOW - 120_000, '12:34:56.000');
+
+    refreshTimestamps(NOW);
+
+    expect(el.textContent).toBe('2m ago');
+  });
+
+  it('advances the age on a later refresh — the whole point of the ticker', async () => {
+    const { saveUISettings } = await import('../ui/ui-settings');
+    saveUISettings({ relativeTimestamps: true });
+    const { refreshTimestamps } = await import('../ui/relative-time');
+    const el = mountSpan(NOW, 'irrelevant');
+
+    refreshTimestamps(NOW + 60_000);
+    expect(el.textContent).toBe('1m ago');
+
+    // A stale "1m ago" is exactly the defect the issue describes, so assert it moves.
+    refreshTimestamps(NOW + 300_000);
+    expect(el.textContent).toBe('5m ago');
+  });
+
+  it('keeps the absolute value in the title in BOTH modes', async () => {
+    const { saveUISettings } = await import('../ui/ui-settings');
+    const { refreshTimestamps } = await import('../ui/relative-time');
+    const el = mountSpan(NOW - 120_000, '12:34:56.000');
+
+    refreshTimestamps(NOW);
+    expect(el.title).toBe('12:34:56.000');
+
+    saveUISettings({ relativeTimestamps: true });
+    refreshTimestamps(NOW);
+    expect(el.textContent).toBe('2m ago');
+    // Hovering must still give the precise value — this is a toggle, not a replacement.
+    expect(el.title).toBe('12:34:56.000');
+  });
+
+  it('can switch back to absolute without a re-render', async () => {
+    const { saveUISettings } = await import('../ui/ui-settings');
+    saveUISettings({ relativeTimestamps: true });
+    const { refreshTimestamps } = await import('../ui/relative-time');
+    const el = mountSpan(NOW - 120_000, '12:34:56.000');
+
+    refreshTimestamps(NOW);
+    expect(el.textContent).toBe('2m ago');
+
+    saveUISettings({ relativeTimestamps: false });
+    refreshTimestamps(NOW);
+    // Restored from data-abs, so the render sites never have to be involved.
+    expect(el.textContent).toBe('12:34:56.000');
+  });
+
+  it('does not replace the element, so listeners and scroll state survive', async () => {
+    const { saveUISettings } = await import('../ui/ui-settings');
+    saveUISettings({ relativeTimestamps: true });
+    const { refreshTimestamps } = await import('../ui/relative-time');
+    const el = mountSpan(NOW - 120_000, '12:34:56.000');
+
+    let clicks = 0;
+    el.addEventListener('click', () => {
+      clicks++;
+    });
+
+    refreshTimestamps(NOW);
+
+    // Identity, not just equality: an innerHTML rebuild would give a different node and
+    // silently drop the listener. This is the property that protects the auto-scroll.
+    expect(document.querySelector('.log-time')).toBe(el);
+    el.click();
+    expect(clicks).toBe(1);
+  });
+
+  it('ignores elements without the timestamp attributes', async () => {
+    const { refreshTimestamps } = await import('../ui/relative-time');
+    document.body.innerHTML = `<span class="log-time">untouched</span>`;
+
+    refreshTimestamps(NOW);
+
+    expect((document.querySelector('.log-time') as HTMLElement).textContent).toBe('untouched');
+  });
+});

--- a/src/__tests__/relative-time.test.ts
+++ b/src/__tests__/relative-time.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { formatRelative } from '../ui/relative-time';
+
+/**
+ * ELEG-45. The formatting is pure and `now` is a parameter, so the boundaries are
+ * directly assertable — and the boundaries are exactly where these read wrong.
+ *
+ * Every case is expressed as an offset from a fixed `NOW` so the arithmetic is visible
+ * in the test rather than hidden in a literal.
+ */
+const NOW = 1_700_000_000_000;
+const S = 1000;
+const M = 60 * S;
+const H = 60 * M;
+const D = 24 * H;
+
+/** `n` units ago, as an absolute timestamp. */
+const ago = (ms: number) => NOW - ms;
+
+describe('formatRelative', () => {
+  it('says "just now" for anything under ten seconds', () => {
+    expect(formatRelative(ago(0), NOW)).toBe('just now');
+    expect(formatRelative(ago(9 * S), NOW)).toBe('just now');
+  });
+
+  it('switches to seconds exactly at ten seconds', () => {
+    expect(formatRelative(ago(10 * S), NOW)).toBe('10s ago');
+  });
+
+  it('holds seconds right up to the minute boundary', () => {
+    // The 59s/60s boundary the issue calls out.
+    expect(formatRelative(ago(59 * S), NOW)).toBe('59s ago');
+    expect(formatRelative(ago(60 * S), NOW)).toBe('1m ago');
+  });
+
+  it('rounds down rather than up within a minute', () => {
+    // 119s is 1m59s. Reporting "2m ago" would claim more time has passed than has.
+    expect(formatRelative(ago(119 * S), NOW)).toBe('1m ago');
+    expect(formatRelative(ago(120 * S), NOW)).toBe('2m ago');
+  });
+
+  it('holds minutes right up to the hour boundary', () => {
+    expect(formatRelative(ago(59 * M), NOW)).toBe('59m ago');
+    expect(formatRelative(ago(60 * M), NOW)).toBe('1h ago');
+  });
+
+  it('reports 90 minutes as one hour, not ninety minutes', () => {
+    // The other boundary the issue names explicitly.
+    expect(formatRelative(ago(90 * M), NOW)).toBe('1h ago');
+  });
+
+  it('holds hours right up to the day boundary', () => {
+    expect(formatRelative(ago(23 * H), NOW)).toBe('23h ago');
+    expect(formatRelative(ago(24 * H), NOW)).toBe('1d ago');
+  });
+
+  it('reports days beyond that', () => {
+    expect(formatRelative(ago(3 * D), NOW)).toBe('3d ago');
+    expect(formatRelative(ago(400 * D), NOW)).toBe('400d ago');
+  });
+
+  it('reads a future timestamp as "just now" rather than a negative age', () => {
+    // Clock skew between the service and the browser is real; "-3s ago" is nonsense
+    // and "in 3 seconds" is not worth the complexity for a log line.
+    expect(formatRelative(NOW + 5 * S, NOW)).toBe('just now');
+    expect(formatRelative(NOW + 60 * M, NOW)).toBe('just now');
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ import { renderLog, bindLogControls } from './ui/log';
 import { installThumbnailFallback } from './ui/helpers';
 import { initTheme } from './ui/theme';
 import { maybeAlertForEvent } from './ui/alert-sound';
+import { startTimestampTicker } from './ui/relative-time';
 import type { PrinterStatus, PrinterAttributes, CanvasInfo, FileEntry } from './types';
 import {
   COMMAND_METHOD_NAMES,
@@ -701,6 +702,10 @@ installThumbnailFallback();
 // Re-assert the stored theme (the inline script in index.html already set it before
 // paint) and follow the OS while the choice is "auto" (ELEG-34).
 initTheme();
+// ELEG-45. Rewrites the text of existing timestamp spans once a second; it does NOT
+// re-render the logs, so the auto-scroll, the pause button and expanded rows are all
+// unaffected. A no-op while the setting is off.
+startTimestampTicker();
 
 // Auto-connect on page load
 connectToService();

--- a/src/ui/event-log.ts
+++ b/src/ui/event-log.ts
@@ -1,6 +1,7 @@
 /** Event Log panel — shows important printer events (start, error, milestones, layer changes) */
 
 import { $, escapeHtml } from './helpers';
+import { timestampSpan } from './relative-time';
 
 interface EventLogEntry {
   ts: number;
@@ -156,7 +157,7 @@ export function renderEventLog(): void {
       const desc = eventDescription(entry.event);
       return `<div class="event-log-row ${meta.cls}">
       <span class="event-log-icon">${meta.icon}</span>
-      <span class="event-log-time">${fmtTime(entry.ts)}</span>
+      ${timestampSpan('event-log-time', entry.ts, fmtTime(entry.ts))}
       <span class="event-log-desc" title="${desc}">${desc}</span>
     </div>`;
     })

--- a/src/ui/log.ts
+++ b/src/ui/log.ts
@@ -1,6 +1,7 @@
 import type { LogStore, LogEntry } from '../log-store';
 import { $, escapeHtml } from './helpers';
 import { exportLogEntries } from './log-export';
+import { timestampSpan } from './relative-time';
 import { toast } from './toast';
 
 let autoScroll = true;
@@ -63,7 +64,7 @@ export function renderLog(store: LogStore): void {
     const isExpanded = expandedEntries.has(e.timestamp);
 
     html += `<div class="log-row ${dirClass}" data-idx="${i}" data-ts="${e.timestamp}">`;
-    html += `<span class="log-time">${formatTimestamp(e.timestamp)}</span>`;
+    html += timestampSpan('log-time', e.timestamp, formatTimestamp(e.timestamp));
     html += `<span class="log-dir">${dirArrow}</span>`;
     html += `<span class="log-topic">${escapeHtml(shortTopic(e.topic))}</span>`;
     html += `<span class="log-method">${escapeHtml(methodLabel(e))}</span>`;

--- a/src/ui/relative-time.ts
+++ b/src/ui/relative-time.ts
@@ -1,0 +1,122 @@
+/**
+ * Relative timestamps for the log panels — "2m ago" as a toggle (ELEG-45).
+ *
+ * **A toggle, never a replacement.** Absolute time is what you need when correlating
+ * with `journalctl`, the printer's own display, or somebody else's screenshot — and that
+ * is the case where getting it wrong costs the most. So the default is absolute, and the
+ * absolute value stays reachable in the `title` attribute even when relative is on.
+ *
+ * ## Why this updates spans in place instead of re-rendering
+ *
+ * "2m ago" written once and never updated is worse than a clock: it is a clock that
+ * lies. But re-rendering the log on a timer is not the way to fix it, for two reasons
+ * that are specific to this repo:
+ *
+ *  1. **`renderLog` deliberately short-circuits.** It returns early when the last
+ *     timestamp and the entry count are both unchanged, so a periodic
+ *     `renderLog()` call would do *nothing* — the relative times would sit there stale
+ *     and the bug would look like the timer was broken.
+ *  2. **A re-render assigns `innerHTML`**, which destroys and rebuilds every row. That
+ *     is what fights the auto-scroll and the expand/collapse state, and it is the same
+ *     class of problem ELEG-49…52 solved for the list views.
+ *
+ * So the render sites emit `<span class="…-time" data-ts="…" title="…">`, and `tick()`
+ * walks those spans and rewrites their text only. No `innerHTML`, no rebuilt rows,
+ * nothing for the auto-scroll or the pause button to fight with.
+ */
+
+import { loadUISettings } from './ui-settings';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * Format `then` relative to `now`, both epoch milliseconds.
+ *
+ * Pure, and `now` is a parameter rather than a call to `Date.now()` precisely so the
+ * boundaries can be tested — they are where these read wrong.
+ *
+ * Rounds **down** throughout: at 119 seconds this says "1m ago", not "2m ago". Reading
+ * a slightly conservative age is better than one that claims more time has passed than
+ * actually has, which is the direction that misleads when you are watching something
+ * happen.
+ */
+export function formatRelative(then: number, now: number): string {
+  const delta = now - then;
+
+  // A clock skew or an event stamped very slightly in the future should read as "now"
+  // rather than as a negative age.
+  if (delta < 10 * SECOND) return 'just now';
+  if (delta < MINUTE) return `${Math.floor(delta / SECOND)}s ago`;
+  if (delta < HOUR) return `${Math.floor(delta / MINUTE)}m ago`;
+  if (delta < DAY) return `${Math.floor(delta / HOUR)}h ago`;
+  return `${Math.floor(delta / DAY)}d ago`;
+}
+
+/** Whether the relative rendering is currently switched on. */
+export function relativeEnabled(): boolean {
+  return loadUISettings().relativeTimestamps;
+}
+
+/**
+ * Rewrite the text of every timestamp span on the page.
+ *
+ * Each span carries `data-ts` (epoch ms) and `data-abs` (the absolute string the site
+ * would otherwise have shown), so this can switch either way without the render sites
+ * being involved.
+ */
+export function refreshTimestamps(now: number = Date.now()): void {
+  const relative = relativeEnabled();
+  for (const el of document.querySelectorAll<HTMLElement>('[data-ts][data-abs]')) {
+    const ts = Number(el.dataset.ts);
+    const abs = el.dataset.abs ?? '';
+    if (!Number.isFinite(ts)) continue;
+    el.textContent = relative ? formatRelative(ts, now) : abs;
+    // The absolute value stays available on hover in both modes — that is the whole
+    // point of not making this a replacement.
+    el.title = abs;
+  }
+}
+
+/**
+ * Build the markup for one timestamp cell.
+ *
+ * Called by the three render sites so the attribute contract lives in one place; the
+ * ticker below depends on it.
+ */
+export function timestampSpan(cls: string, ts: number, absolute: string): string {
+  const text = relativeEnabled() ? formatRelative(ts, Date.now()) : absolute;
+  return `<span class="${cls}" data-ts="${ts}" data-abs="${escapeAttr(absolute)}" title="${escapeAttr(absolute)}">${escapeAttr(text)}</span>`;
+}
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the once-a-second refresh.
+ *
+ * Cheap by construction: it touches only `textContent` on the timestamp spans, and only
+ * while relative mode is on. Idempotent, so calling it again does not stack timers.
+ */
+export function startTimestampTicker(): void {
+  if (timer) return;
+  timer = setInterval(() => {
+    if (relativeEnabled()) refreshTimestamps();
+  }, SECOND);
+}
+
+/** Stop the ticker. Exists for symmetry and for tests. */
+export function stopTimestampTicker(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -7,6 +7,7 @@ import { renderSpoolCalc } from './spool-calc';
 import { renderHelp } from './help';
 import { getThemeChoice, setThemeChoice, isThemeChoice } from './theme';
 import { playAlert } from './alert-sound';
+import { refreshTimestamps } from './relative-time';
 import { loadUISettings, saveUISettings } from './ui-settings';
 
 const STORAGE_KEY = 'elegoo-web-card-layout';
@@ -202,6 +203,11 @@ function buildSettingsHTML(content: HTMLElement): void {
           <option value="light">Light</option>
         </select>
       </div>
+      <p class="settings-hint">Relative log timestamps read as &ldquo;2m ago&rdquo; instead of a clock. The exact time stays on hover. Absolute is the default, because it is what you need when comparing against <code>journalctl</code>, the printer&rsquo;s display or someone else&rsquo;s screenshot.</p>
+      <div class="settings-row">
+        <label for="settings-relative-time">Relative log timestamps</label>
+        <input type="checkbox" id="settings-relative-time">
+      </div>
     </section>
 
     <section class="settings-section">
@@ -332,6 +338,19 @@ function buildSettingsHTML(content: HTMLElement): void {
     themeSelect.value = getThemeChoice();
     themeSelect.addEventListener('change', () => {
       if (isThemeChoice(themeSelect.value)) setThemeChoice(themeSelect.value);
+    });
+  }
+
+  // ---- Relative log timestamps (ELEG-45) ----
+  const relTime = content.querySelector('#settings-relative-time') as HTMLInputElement | null;
+  if (relTime) {
+    relTime.checked = loadUISettings().relativeTimestamps;
+    relTime.addEventListener('change', () => {
+      saveUISettings({ relativeTimestamps: relTime.checked });
+      // Apply immediately rather than waiting up to a second for the next tick — and
+      // note this rewrites the existing spans in place, so the log is not re-rendered
+      // and the scroll position and expanded rows survive the switch.
+      refreshTimestamps();
     });
   }
 

--- a/src/ui/structured-log.ts
+++ b/src/ui/structured-log.ts
@@ -4,6 +4,7 @@ import type { LogStore, LogEntry } from '../log-store';
 import { $, escapeHtml } from './helpers';
 import { METHOD_NAMES } from './log-methods';
 import { loadUISettings, saveUISettings } from './ui-settings';
+import { timestampSpan } from './relative-time';
 import { exportLogEntries } from './log-export';
 import { toast } from './toast';
 
@@ -187,7 +188,7 @@ function renderSlogRow(e: LogEntry, prevStatusRaw: unknown): string {
   row += `<div class="slog-row ${dirClass} ${typeClass} ${isPinned ? 'slog-pinned' : ''}" data-ts="${e.timestamp}">`;
   row += `<div class="slog-row-header">`;
   row += `<span class="slog-icon">${icon}</span>`;
-  row += `<span class="slog-time">${formatTimestamp(e.timestamp)}</span>`;
+  row += timestampSpan('slog-time', e.timestamp, formatTimestamp(e.timestamp));
   row += `<span class="slog-dir">${e.direction === 'sent' ? '→' : '←'}</span>`;
   row += `<span class="slog-method">${highlightMatch(method)}</span>`;
   row += `<span class="slog-topic">${highlightMatch(shortTopic(e.topic))}</span>`;

--- a/src/ui/ui-settings.ts
+++ b/src/ui/ui-settings.ts
@@ -25,6 +25,8 @@ export interface UISettings {
   alertSound: boolean;
   /** Alert volume, 0..1 (ELEG-46) */
   alertVolume: number;
+  /** Show log timestamps as "2m ago" rather than a clock (ELEG-45). Off by default. */
+  relativeTimestamps: boolean;
 }
 
 const defaults: UISettings = {
@@ -41,6 +43,9 @@ const defaults: UISettings = {
   // and the autoplay policy means it would often be refused anyway (ELEG-46).
   alertSound: false,
   alertVolume: 0.5,
+  // Absolute by default: it is what you need when correlating with journalctl, the
+  // printer's display or someone else's screenshot (ELEG-45).
+  relativeTimestamps: false,
 };
 
 let cached: UISettings | null = null;


### PR DESCRIPTION
Closes ELEG-45.

## What this does

A **toggle** in Settings → Appearance renders log timestamps as "2m ago" instead of a clock, across all three panels the issue names: the raw MQTT log, the structured log and the event log.

**Absolute is the default**, and the absolute value stays in the `title` attribute in *both* modes — this is a toggle, not a replacement, for the reason the issue gives: absolute time is what you need when correlating with `journalctl`, the printer's own display, or someone else's screenshot, and that is the case where getting it wrong costs the most.

## The substantive decision: it re-renders without re-rendering

The issue is right that "2m ago" written once and never updated is worse than a clock. But driving that from a re-render would have been wrong here, for two reasons specific to this repo — both found by reading the code rather than assumed:

1. **`renderLog` deliberately short-circuits.** It returns early when the last timestamp *and* the entry count are both unchanged. A periodic `renderLog()` would therefore have done **nothing at all**, and the stale timestamps would have looked like a broken timer rather than a no-op render.
2. **A re-render assigns `innerHTML`**, destroying and rebuilding every row — which is precisely what fights the auto-scroll, the pause button and the expanded-row state. This is the same class of problem ELEG-49…52 solved for the list views, and re-introducing it here would have been a regression.

So the three render sites emit `<span data-ts="…" data-abs="…" title="…">`, and a once-a-second ticker walks those spans and rewrites **only their `textContent`**. No `innerHTML`, no rebuilt rows, nothing for the auto-scroll or pause button to fight with. Switching the toggle also refreshes in place, so it applies immediately without waiting for the next tick.

`data-abs` carries the absolute string, which is what lets the toggle switch *back* without the render sites being involved at all.

## Two corrections to the issue

- **The setting is persisted in `ui-settings.ts`, not `src/persistence.ts`.** That module was unreachable dead code and was deleted in **ELEG-65** earlier in this pass; `ui-settings.ts` is now the only client-side preference store. (`AGENTS.md` already warned that `persistence.ts` was the wrong home for preferences, since it was cleared when the print changed.)
- `formatClock` in `helpers.ts` is named as where the sibling lives, but the three log panels do not use it — they each had their own local `formatTimestamp` / `fmtTime` with different precision. Those are left exactly as they are and passed in as the absolute string, so this change does not quietly alter anyone's timestamp format.

## Verification

`pnpm gates` green, six checks. Test count re-measured against `main`: **256 → 272**, a delta of exactly the 16 added (9 boundary + 7 DOM).

`formatRelative` is pure with `now` as a **parameter** rather than a `Date.now()` call, which is what makes the boundaries directly assertable. Both boundaries the issue calls out are covered — 59s/60s, and 90 minutes reading as `1h ago` — plus round-down within a minute (119s is `1m ago`, not `2m`) and a future timestamp reading `just now` rather than a negative age, since clock skew between service and browser is real.

**Failing-direction check, twice**, mutating the *implementation* both times.

Rounding, the classic off-by-one here (`Math.floor` → `Math.round`):

```
     × rounds down rather than up within a minute
      Tests  1 failed | 15 passed (16)
```

And the actual defect the issue is about — writing the text once and never updating it:

```
     × advances the age on a later refresh — the whole point of the ticker
     × keeps the absolute value in the title in BOTH modes
     × can switch back to absolute without a re-render
      Tests  3 failed | 4 passed (7)
```

Both restored from a copy taken immediately before each patch, then re-verified green.

One DOM test asserts **node identity** across a refresh (`expect(document.querySelector('.log-time')).toBe(el)`) and that a registered click listener still fires afterwards. That is the assertion that actually proves the auto-scroll and expand state are safe — an `innerHTML` rebuild would give a different node and silently drop the listener, and an equality-only test would not notice.

## Caught by the gates, worth noting

The `structured-log.ts` import was missing after I wired the three sites. **All 272 tests passed** — nothing covers that render path — and `typecheck: browser half` caught it:

```
src/ui/structured-log.ts:190:10 - error TS2304: Cannot find name 'timestampSpan'.
```

A live demonstration of `.agents/gates.md`'s standing point that the typechecks, not the tests, are the real safety net in this repo.

## Not covered

That the ticker looks right over time in a browser, and that the relative text does not visually jitter the log layout as widths change. Those need `pnpm dev:web` and eyes. No printer interaction anywhere in this change.
