### PR TITLE
fix(ui): trap keyboard focus in the camera overlay (ELEG-41)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -118,9 +118,28 @@ another; the two things it establishes:
   approach for reason 1 in that file's header (the memoisation), which is independent of
   storage and unchanged.
 
+- **Keyboard focus *is* testable here** (ELEG-41). jsdom implements `focus()`,
+  `document.activeElement` and event dispatch, so a focus trap can be asserted properly:
+  `src/__tests__/focus-trap.test.ts` dispatches Tab and Shift+Tab and checks where focus
+  lands, including the case that matters — focus that has reached the page behind being
+  pulled back. Several older issues assume focus needs a real browser; it does not, and
+  that assumption is worth checking before deferring one.
+
+  **Where it stops:** jsdom does not implement the *native behaviour* of `inert`. A test
+  can assert the attribute is applied and removed — and should — but that a browser
+  actually honours it is not verifiable here. Say which of the two you checked; they are
+  not the same claim.
+
 What jsdom still does not give you: layout, paint, real fonts, or `getContext('2d')`.
 Colour, overlap and appearance are still `pnpm dev:web` and eyes, and there is still no
 browser or screenshot in any gate.
+
+One consequence worth knowing before writing a focus or visibility test: **do not filter
+focusable elements on geometry.** `offsetParent` and `getClientRects()` are the usual
+visibility check in a browser, but jsdom has no layout engine and reports every element
+as having none — so a geometry filter matches nothing under test and the code looks
+broken exactly where it is being verified. Filter on explicit hiding (`inert`,
+`aria-hidden`, `hidden`, this repo's `.hidden` class) instead.
 
 ## The typechecks are the real safety net, and one of them is easy to miss
 

--- a/src/__tests__/focus-trap.test.ts
+++ b/src/__tests__/focus-trap.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFocusTrap, focusableWithin } from '../ui/focus-trap';
+
+/**
+ * ELEG-41.
+ *
+ * The issue says "focus behaviour needs a browser; there is no jsdom here". That was
+ * true when it was filed and is not any more — ELEG-61 added the jsdom environment and
+ * ELEG-64 finished it off. jsdom implements `focus()`, `document.activeElement` and
+ * event dispatch, which is everything these assertions need.
+ *
+ * What jsdom does NOT implement is the *native* behaviour of the `inert` attribute, so
+ * the inert tests assert that the attribute is applied and removed, not that the browser
+ * honours it. That distinction is stated rather than glossed: honouring it is the
+ * browser's job and is checked by hand.
+ */
+
+/**
+ * The real shape: a dashboard containing a button that commands the machine, and a modal
+ * that is a sibling deeper in the tree — not a direct child of body, which is why the
+ * trap walks the whole ancestor chain.
+ */
+function mountLayout() {
+  document.body.innerHTML = `
+    <div id="app">
+      <div id="dashboard">
+        <button id="opener">Expand camera</button>
+        <button id="danger-home">Home</button>
+        <button id="danger-stop">Stop print</button>
+      </div>
+      <div id="camera-modal" tabindex="-1">
+        <img id="camera-modal-img" alt="Camera">
+        <button id="camera-modal-close">close</button>
+        <button id="camera-modal-snapshot">snapshot</button>
+      </div>
+    </div>
+  `;
+  return {
+    modal: document.getElementById('camera-modal') as HTMLElement,
+    opener: document.getElementById('opener') as HTMLButtonElement,
+    close: document.getElementById('camera-modal-close') as HTMLButtonElement,
+    snapshot: document.getElementById('camera-modal-snapshot') as HTMLButtonElement,
+    home: document.getElementById('danger-home') as HTMLButtonElement,
+    dashboard: document.getElementById('dashboard') as HTMLElement,
+  };
+}
+
+/** Dispatch a Tab keypress the way the trap listens for it. */
+function pressTab(shift = false): KeyboardEvent {
+  const e = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: shift,
+    bubbles: true,
+    cancelable: true,
+  });
+  document.dispatchEvent(e);
+  return e;
+}
+
+let release: (() => void) | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  release?.();
+  release = null;
+});
+
+describe('focusableWithin', () => {
+  it('finds the focusable children in order', () => {
+    const { modal } = mountLayout();
+    // The modal itself is tabindex="-1" and must NOT be listed: it is programmatically
+    // focusable but not in the tab order, so wrapping to it would strand the user.
+    expect(focusableWithin(modal).map((el) => el.id)).toEqual([
+      'camera-modal-close',
+      'camera-modal-snapshot',
+    ]);
+  });
+
+  it('excludes disabled controls', () => {
+    const { modal, snapshot } = mountLayout();
+    snapshot.disabled = true;
+    expect(focusableWithin(modal).map((el) => el.id)).toEqual(['camera-modal-close']);
+  });
+
+  it('excludes anything marked inert or aria-hidden', () => {
+    const { modal, snapshot } = mountLayout();
+    snapshot.setAttribute('inert', '');
+    expect(focusableWithin(modal).map((el) => el.id)).toEqual(['camera-modal-close']);
+
+    snapshot.removeAttribute('inert');
+    snapshot.setAttribute('aria-hidden', 'true');
+    expect(focusableWithin(modal).map((el) => el.id)).toEqual(['camera-modal-close']);
+  });
+});
+
+describe('createFocusTrap', () => {
+  it('moves focus into the overlay when opened', () => {
+    const { modal, opener, close } = mountLayout();
+    opener.focus();
+    release = createFocusTrap(modal);
+    expect(document.activeElement).toBe(close);
+  });
+
+  it('wraps Tab from the last element back to the first', () => {
+    const { modal, close, snapshot } = mountLayout();
+    release = createFocusTrap(modal);
+
+    snapshot.focus();
+    const e = pressTab();
+
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(close);
+  });
+
+  it('wraps Shift+Tab from the first element back to the last', () => {
+    const { modal, close, snapshot } = mountLayout();
+    release = createFocusTrap(modal);
+
+    close.focus();
+    const e = pressTab(true);
+
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(snapshot);
+  });
+
+  it('pulls focus back if it has somehow reached the page behind', () => {
+    // The core safety property. `danger-home` commands a physical machine, and it is
+    // behind an overlay the user cannot see past.
+    const { modal, home, close } = mountLayout();
+    release = createFocusTrap(modal);
+
+    home.focus();
+    expect(document.activeElement).toBe(home);
+
+    pressTab();
+
+    expect(document.activeElement).toBe(close);
+    expect(modal.contains(document.activeElement)).toBe(true);
+  });
+
+  it('marks the background inert and aria-hidden, and unmarks it on release', () => {
+    // jsdom does not implement inert's behaviour, so this asserts the attribute
+    // contract only; that a browser honours it is checked by hand.
+    const { modal, dashboard } = mountLayout();
+    release = createFocusTrap(modal);
+
+    expect(dashboard.hasAttribute('inert')).toBe(true);
+    expect(dashboard.getAttribute('aria-hidden')).toBe('true');
+    // The overlay's own subtree must never be marked.
+    expect(modal.hasAttribute('inert')).toBe(false);
+
+    release();
+    release = null;
+
+    expect(dashboard.hasAttribute('inert')).toBe(false);
+    expect(dashboard.hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  it('does not clobber an element that was already aria-hidden', () => {
+    // Restoring such an element to "not hidden" on close would be a new bug.
+    const { modal, dashboard } = mountLayout();
+    dashboard.setAttribute('aria-hidden', 'true');
+
+    release = createFocusTrap(modal);
+    release();
+    release = null;
+
+    expect(dashboard.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('calls onEscape and does not act on other keys', () => {
+    const { modal } = mountLayout();
+    let escapes = 0;
+    release = createFocusTrap(modal, { onEscape: () => escapes++ });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    expect(escapes).toBe(0);
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+    expect(escapes).toBe(1);
+  });
+
+  it('restores focus to the opener on release', () => {
+    const { modal, opener } = mountLayout();
+    opener.focus();
+    release = createFocusTrap(modal);
+    expect(document.activeElement).not.toBe(opener);
+
+    release();
+    release = null;
+
+    // Otherwise a keyboard user is dumped at the top of the document.
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('stops trapping once released', () => {
+    const { modal, home } = mountLayout();
+    release = createFocusTrap(modal);
+    release();
+    release = null;
+
+    home.focus();
+    pressTab();
+
+    // No longer pulled back — the trap must not outlive the overlay.
+    expect(document.activeElement).toBe(home);
+  });
+
+  it('keeps focus on the container when the overlay has nothing focusable', () => {
+    document.body.innerHTML = `<div id="app"><div id="other">x</div><div id="m" tabindex="-1"></div></div>`;
+    const modal = document.getElementById('m') as HTMLElement;
+    release = createFocusTrap(modal);
+
+    const e = pressTab();
+
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(modal);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,7 @@ import { installThumbnailFallback } from './ui/helpers';
 import { initTheme } from './ui/theme';
 import { maybeAlertForEvent } from './ui/alert-sound';
 import { startTimestampTicker } from './ui/relative-time';
+import { createFocusTrap } from './ui/focus-trap';
 import type { PrinterStatus, PrinterAttributes, CanvasInfo, FileEntry } from './types';
 import {
   COMMAND_METHOD_NAMES,
@@ -225,24 +226,36 @@ function showDashboard(): void {
     const cameraModal = $('camera-modal');
     const cameraModalImg = $('camera-modal-img') as HTMLImageElement;
     const cameraFeed = $('camera-feed') as HTMLImageElement;
+    // ELEG-41. The overlay covers the dashboard but the dashboard stays interactive, so
+    // without a trap Tab walks focus onto the move, temperature and stop controls the
+    // user cannot see — controls that drive a physical machine. The trap also owns
+    // Escape and restores focus to the opener on close.
+    let releaseCameraTrap: (() => void) | null = null;
+
+    const closeModal = () => {
+      // Guard: the click handler on the overlay fires for the close button too, so this
+      // can run twice. Releasing a trap twice would restore focus to the wrong element.
+      if (cameraModal.classList.contains('hidden')) return;
+      cameraModal.classList.add('hidden');
+      cameraModalImg.src = '';
+      releaseCameraTrap?.();
+      releaseCameraTrap = null;
+    };
+
     cameraWrap.addEventListener('click', () => {
       if (!cameraFeed.src || cameraFeed.alt === 'Camera off') return;
       cameraModalImg.src = cameraFeed.src;
       cameraModal.classList.remove('hidden');
-      cameraModal.focus();
+      // Created after `.hidden` is removed: the trap reads the focusable children, and
+      // this repo's `.hidden` class is one of the things it treats as not focusable.
+      releaseCameraTrap = createFocusTrap(cameraModal, { onEscape: closeModal });
     });
-    const closeModal = () => {
-      cameraModal.classList.add('hidden');
-      cameraModalImg.src = '';
-    };
+
     $('camera-modal-close').addEventListener('click', (e) => {
       e.stopPropagation();
       closeModal();
     });
     cameraModal.addEventListener('click', closeModal);
-    cameraModal.addEventListener('keydown', (e) => {
-      if ((e as KeyboardEvent).key === 'Escape') closeModal();
-    });
 
     // Camera expand toggle
     const cameraCard = $('camera-card');

--- a/src/ui/focus-trap.ts
+++ b/src/ui/focus-trap.ts
@@ -1,0 +1,170 @@
+/**
+ * Keyboard focus trap for modal overlays (ELEG-41).
+ *
+ * ## Why this is not merely a tidiness fix
+ *
+ * The camera fullscreen overlay covers the dashboard, but the dashboard is still there
+ * and still interactive. Without a trap, Tab walks focus out of the overlay and onto the
+ * move, temperature and stop controls — which the user **cannot see**, and which
+ * **command a physical machine with heaters and motors**. A keyboard user could press
+ * one without ever knowing it was there.
+ *
+ * That is the whole reason this is filed as a bug rather than an accessibility nicety,
+ * and it is why the background is made `inert` rather than merely visually covered.
+ */
+
+/**
+ * Selector for things that can hold focus.
+ *
+ * `:not([disabled])` and the negative-tabindex exclusion matter: a disabled button and a
+ * `tabindex="-1"` container are both programmatically focusable but are **not** in the
+ * Tab order, so including them would make the wrap land somewhere the user cannot reach
+ * by tabbing — which looks exactly like a broken trap.
+ */
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/**
+ * The focusable elements inside `root`, in Tab order.
+ *
+ * Filters on **explicit** hiding only — `inert`, `aria-hidden`, the `hidden` attribute,
+ * and the repo's own `.hidden` class — deliberately *not* on geometry. `offsetParent`
+ * and `getClientRects()` are the usual visibility test, but jsdom has no layout engine
+ * and reports every element as having none, so a geometry check would exclude
+ * everything under test and the trap would look broken exactly where it is verified.
+ *
+ * For this overlay the distinction does not arise in practice: the container is the
+ * modal, and its children are visible whenever it is open.
+ */
+export function focusableWithin(root: ParentNode): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((el) => {
+    if (el.hasAttribute('inert') || el.hasAttribute('hidden')) return false;
+    if (el.getAttribute('aria-hidden') === 'true') return false;
+    if (el.closest('.hidden')) return false;
+    return true;
+  });
+}
+
+/** Ancestors of `el` up to and including `document.body`. */
+function ancestorChain(el: HTMLElement): HTMLElement[] {
+  const chain: HTMLElement[] = [];
+  let node: HTMLElement | null = el;
+  while (node && node !== document.body) {
+    chain.push(node);
+    node = node.parentElement;
+  }
+  return chain;
+}
+
+/**
+ * Mark everything outside `container` as inert, and return the undo.
+ *
+ * Walks the ancestor chain and marks each ancestor's *other* children, so the overlay's
+ * own subtree stays reachable however deeply it is nested. Marking only `body`'s
+ * children would not work here — the camera modal is not a direct child of `body`.
+ *
+ * Both `inert` and `aria-hidden` are set: `inert` removes it from the tab order in
+ * browsers that support it, and `aria-hidden` makes assistive technology agree with what
+ * the eye sees, which is the pair the issue asks for.
+ */
+function makeBackgroundInert(container: HTMLElement): () => void {
+  const chain = ancestorChain(container);
+  const marked: HTMLElement[] = [];
+
+  for (const node of chain) {
+    const parent = node.parentElement;
+    if (!parent) continue;
+    for (const sibling of Array.from(parent.children)) {
+      if (sibling === node || !(sibling instanceof HTMLElement)) continue;
+      // Never clobber an element that was already inert or aria-hidden for its own
+      // reasons — restoring it to "not hidden" on close would be a new bug.
+      if (sibling.hasAttribute('inert') || sibling.hasAttribute('aria-hidden')) continue;
+      sibling.setAttribute('inert', '');
+      sibling.setAttribute('aria-hidden', 'true');
+      marked.push(sibling);
+    }
+  }
+
+  return () => {
+    for (const el of marked) {
+      el.removeAttribute('inert');
+      el.removeAttribute('aria-hidden');
+    }
+  };
+}
+
+export interface FocusTrapOptions {
+  /** Called on Escape. The trap does not close anything itself. */
+  onEscape?: () => void;
+}
+
+/**
+ * Trap Tab and Shift+Tab inside `container` until the returned release function runs.
+ *
+ * Release also restores focus to whatever had it when the trap was created — otherwise a
+ * keyboard user is dumped at the top of the document and has to tab all the way back to
+ * where they were.
+ */
+export function createFocusTrap(
+  container: HTMLElement,
+  options: FocusTrapOptions = {},
+): () => void {
+  const opener = document.activeElement as HTMLElement | null;
+  const undoInert = makeBackgroundInert(container);
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      options.onEscape?.();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+
+    const focusable = focusableWithin(container);
+    if (focusable.length === 0) {
+      // Nothing to tab to — keep focus on the container rather than letting it escape
+      // to the controls behind, which is the case this whole module exists to prevent.
+      e.preventDefault();
+      container.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (e.shiftKey) {
+      // Wrapping backwards off the first element, or from the container itself.
+      if (active === first || active === container || !container.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+
+    if (active === last || !container.contains(active)) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  // Listening on the document in the capture phase, not on the container: once focus has
+  // somehow reached the background, a container-scoped listener would never see the
+  // keypress and could not pull focus back.
+  document.addEventListener('keydown', onKeydown, true);
+
+  const first = focusableWithin(container)[0];
+  (first ?? container).focus();
+
+  return function release(): void {
+    document.removeEventListener('keydown', onKeydown, true);
+    undoInert();
+    opener?.focus?.();
+  };
+}


### PR DESCRIPTION
Closes ELEG-41.

## The bug

The camera fullscreen overlay covers the dashboard, but the dashboard is still there and still interactive. Tab walked focus out of the overlay and onto the move, temperature and stop controls — which the user **cannot see**, and which **command a physical machine with heaters and motors**. That is what makes this a bug rather than an accessibility nicety, and it is exactly how the issue framed it.

**A detail found while reading, not stated in the issue:** Escape was already broken by the same defect. It hung off a `keydown` listener on the modal *element*, so once Tab moved focus into the page behind, the modal stopped receiving keys and Escape stopped working. The bug disabled its own escape hatch. The trap now listens on the document in the capture phase, so Escape works wherever focus has got to.

## What the trap does

All four things the issue asks for, plus the recovery case:

- **Tab and Shift+Tab wrap** within the overlay.
- **Focus already in the background is pulled back**, not merely wrapped at the edges. This is the property the issue actually reports, and a trap that only wraps at the boundaries does not fix it.
- **Escape closes**, from anywhere.
- **The background is marked `inert` *and* `aria-hidden`**, so assistive technology agrees with what the eye sees. It walks the whole ancestor chain rather than just `body`'s children, because `#camera-modal` is **not** a direct child of `body` — marking only the top level would have left the rest of the dashboard reachable.
- **Focus returns to the opener** on close, rather than dumping a keyboard user at the top of the document.

Two guards worth calling out:

- Elements that were **already** `inert` or `aria-hidden` for their own reasons are skipped, because un-hiding them on close would be a new bug.
- `closeModal` is idempotent. The overlay's click handler fires for the close button too, so it can run twice, and releasing a trap twice would restore focus to the wrong element.

## The issue's verification note is out of date

> *"Focus behaviour needs a browser; there is no jsdom here, so this is `pnpm dev:web` and a keyboard, not a gate."*

True when filed, not now — **ELEG-61** added the jsdom environment and **ELEG-64** (merged earlier in this pass) finished it. jsdom implements `focus()`, `document.activeElement` and event dispatch, which is everything needed. So this ships with **13 tests**, including the one that matters:

```js
it('pulls focus back if it has somehow reached the page behind', () => {
  home.focus();                      // a button that commands the machine
  pressTab();
  expect(document.activeElement).toBe(close);
  expect(modal.contains(document.activeElement)).toBe(true);
});
```

**What jsdom does not give**, stated rather than glossed: it does not implement the *native behaviour* of `inert`. The inert tests assert the attribute is applied and removed — a real contract, and the one this code controls — but **not** that a browser honours it. Those are two different claims and only the first is covered here.

## Verification

`pnpm gates` green, six checks. Test count re-measured against `main`: **272 → 285**, exactly the 13 added.

**Failing-direction check.** Mutated the implementation to the realistic partial version — wrap only at the edges, dropping the `!container.contains(active)` recovery clause:

```
     × pulls focus back if it has somehow reached the page behind
      Tests  1 failed | 12 passed (13)
```

Exactly the named test, and only it. That is worth noting: a trap with that clause missing passes twelve of thirteen tests, wraps correctly at both edges, and **still has the reported bug**. Restored from a copy taken immediately before the patch; full suite re-run green.

## Still needs a keyboard and a browser

The issue's manual check remains the right one and is **not** replaced by these tests:

- Tab through the whole overlay in both directions in a real browser and confirm focus never reaches the dashboard behind.
- Confirm the browser honours `inert` (jsdom cannot tell you this).

`pnpm dev:web`, click the camera feed, and Tab. No printer interaction is required to check any of it — the overlay is frontend-only, and the point is precisely that the controls behind it should **not** be reachable.

## Also here

`.agents/testing.md` records two durable facts: that focus behaviour is testable in jsdom (several older issues assume otherwise, and that assumption is worth checking before deferring one), and that focusable-element filters must **not** use geometry — `offsetParent`/`getClientRects()` report nothing under jsdom, so a geometry filter matches nothing and the code looks broken exactly where it is verified. I hit that while writing this and it cost a rewrite.
