### PR TITLE
chore(build): use import.meta.dirname in vite.config.ts (ELEG-87)

### DIFF
--- a/.agents/gates.md
+++ b/.agents/gates.md
@@ -226,6 +226,45 @@ your change should add none, and because the count is currently zero you can see
 glance instead of diffing against a baseline. (This is the opposite of the VTK sibling,
 which made warnings hard errors; do not paste either repo's framing into the other.)
 
+### `vite build` exits 0 on its own warnings too — and one of them is dated (ELEG-87)
+
+biome is not the only gate that warns without failing. **`vite build` exits 0 while
+printing warnings about your config**, so a green `pnpm gates` says nothing about
+whether `vite.config.ts` still loads under the loader vite is moving to:
+
+```
+(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`,
+    which is planned to become the default in a future major version of Vite:
+  - `__dirname` (vite.config.ts:25:29). Use `import.meta.dirname` instead
+```
+
+The useful part is that **you do not have to wait for the default to flip to find
+out.** vite 8.2.1 has a CLI flag for it, so the future default is testable today:
+
+```bash
+npx vite build --configLoader native    # exit 1 today = a red build after the bump
+```
+
+That turns "this will break later" from a forecast into a measurement, and it is the
+only check that actually proves a config fix. ELEG-87 used it in both directions:
+`__dirname` gave `ReferenceError: __dirname is not defined` and exit 1, and
+`import.meta.dirname` built clean with **byte-identical output hashes** to the bundle
+loader — which is the stronger claim, because it shows both loaders resolve the
+config the same way rather than merely not crashing.
+
+Two traps worth keeping:
+
+- **The warning names only the first occurrence.** `vite.config.ts` had two
+  `__dirname` uses; fixing the one the warning pointed at just moved the warning to
+  the other line, and the native build still failed. **Grep the file, do not trust
+  the line number.**
+- **Never reach for `VITE_CONFIG_NATIVE_IGNORE_WARNING=true`.** It silences the
+  notice and keeps the breakage, so the bump lands with no warning at all.
+
+The general shape, which is the reason this sits in this file: **a gate that exits 0
+while printing a dated notice is a gate that will go red on a day nobody connects to
+the change that caused it.** Read the build log, not just the exit code.
+
 ## biome does not reach the instruction files — measured
 
 **The original reason for this section is gone; the measurement is worth keeping.** It used

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,15 +20,18 @@ export function allowedHostsFrom(raw: string | undefined): string[] {
 }
 
 export default defineConfig(({ mode }) => {
-  // envDir is __dirname rather than process.cwd() so the value is the same
-  // whichever directory vite was invoked from.
-  const env = loadEnv(mode, __dirname, 'VITE_');
+  // envDir is import.meta.dirname rather than process.cwd() so the value is the same
+  // whichever directory vite was invoked from. Not `__dirname`: that is undefined
+  // under `configLoader: 'native'`, which vite plans to make the default, and both
+  // uses in this file have to change together — the warning only names the first
+  // (ELEG-87).
+  const env = loadEnv(mode, import.meta.dirname, 'VITE_');
 
   return {
     resolve: {
       alias: {
         // Ensure only one copy of three.js is loaded (gcode-preview peer dep)
-        three: path.resolve(__dirname, 'node_modules/three'),
+        three: path.resolve(import.meta.dirname, 'node_modules/three'),
       },
       dedupe: ['three'],
     },


### PR DESCRIPTION
Closes ELEG-87.

`vite.config.ts` used `__dirname` in two places. Under `configLoader: 'native'` —
which vite plans to make the default — `__dirname` does not exist, so the config
fails to load. Today vite only *warns*, and `vite build` exits 0 either way, which
is exactly what makes this the kind of thing that resurfaces as a red build on an
unrelated dependency bump.

Both uses are now `import.meta.dirname`.

## Both lines had to change

The warning names only the **first** occurrence, so fixing line 25 alone looks like
it worked and does not. Verified rather than assumed — with line 25 fixed and line
31 left alone, the warning simply moved:

```
- `__dirname` (vite.config.ts:31:29). Use `import.meta.dirname` instead
```

…and `vite build --configLoader native` still failed at `31:29`.

## Verification

vite 8.2.1 ships a `--configLoader native` CLI flag, so the future default is
testable **now**. That makes this a measurement in both directions rather than a
prediction.

| run | `--configLoader native` | result |
| --- | --- | --- |
| `__dirname` (both lines, i.e. `main` today) | yes | ❌ exit 1 — `ReferenceError: __dirname is not defined` at `vite.config.ts:25:29` |
| `__dirname` on line 31 only (the half-fix) | yes | ❌ exit 1 — same error, now at `31:29` |
| `import.meta.dirname` (this PR) | yes | ✅ exit 0, built in 392ms |
| `import.meta.dirname` (this PR) | no (current default) | ✅ exit 0, **no `configLoader` line in the log** |

The `native` build produces **byte-identical output hashes** to the bundle loader
(`index-CGfufFKu.js`, `index-CwAUaPCI.css`), so this is not merely "it doesn't
crash" — the two loaders agree on the resolved config, which is what the three.js
dedupe alias depends on.

**The typecheck question in the issue is settled too.** `tsconfig.json` includes
`vite.config.ts` (ELEG-79), so `import.meta.dirname` had to typecheck under
`module: ESNext` / `target: ES2022`. It does — and to confirm that claim isn't
vacuous, I appended `const _probe: number = import.meta.dirname;` and `tsc`
correctly failed with:

```
vite.config.ts:64:7 - error TS2322: Type 'string' is not assignable to type 'number'.
```

Two things follow: `tsc` really is checking this file, and `import.meta.dirname` is
typed `string` — not `string | undefined` — so `path.resolve()` and `loadEnv()`
receive a proper string with no non-null assertion needed. The probe was removed.

`VITE_CONFIG_NATIVE_IGNORE_WARNING=true` was deliberately **not** used, per the
issue: suppressing the notice leaves the breakage and removes the warning that
would have flagged it.

## Gates

`pnpm gates` green — biome, both typechecks, knip, vite build, 285 tests in 25
files. No tests added: this is a build-time config change with no runtime surface,
and the existing `allowedHostsFrom` test is unaffected.

## Scope

Dev/build-time only. No printer interaction and no deploy — production serves from
`/opt/elegooweb` and never runs vite, so this cannot reach the machine.
