### PR TITLE
fix(moonraker): use 'local' storage_media for print start

### DIFF
--- a/src/server/moonraker-server.ts
+++ b/src/server/moonraker-server.ts
@@ -631,7 +631,7 @@ export class MoonrakerServer {
       case 'printer.print.start': {
         const filename = params.filename as string;
         if (filename) {
-          this.bridge.sendCommand(1020, { filename, storage_media: 'udisk' });
+          this.bridge.sendCommand(1020, { filename, storage_media: 'local' });
         }
         client.ws.send(rpcResult(msg.id, 'ok'));
         break;
@@ -1341,14 +1341,14 @@ export class MoonrakerServer {
     if (urlPath === '/printer/print/start' && method === 'POST') {
       const filename = query.filename;
       if (filename) {
-        this.bridge.sendCommand(1020, { filename, storage_media: 'udisk' });
+        this.bridge.sendCommand(1020, { filename, storage_media: 'local' });
         jsonResult(res, 'ok');
       } else {
         readBody(req)
           .then((body) => {
             const parsed = JSON.parse(body);
             if (parsed.filename) {
-              this.bridge.sendCommand(1020, { filename: parsed.filename, storage_media: 'udisk' });
+              this.bridge.sendCommand(1020, { filename: parsed.filename, storage_media: 'local' });
               jsonResult(res, 'ok');
             } else {
               jsonError(res, 'filename required');
@@ -2324,11 +2324,11 @@ export class MoonrakerServer {
         }
 
         // Refresh file list from printer
-        this.bridge.sendCommand(1044, { storage_media: 'udisk' });
+        this.bridge.sendCommand(1044, { storage_media: 'local' });
 
         // Start print if requested
         if (startPrint) {
-          this.bridge.sendCommand(1020, { filename: fileName, storage_media: 'udisk' });
+          this.bridge.sendCommand(1020, { filename: fileName, storage_media: 'local' });
         }
 
         jsonResult(res, {


### PR DESCRIPTION
The Moonraker compat layer sent storage_media: 'udisk' with method 1020 (print start, query and JSON-body forms) and in the upload proxy's print=true path. The printer only recognises 'local' and 'u-disk' — the values the UI's own start dialog and files.ts use — so POST /printer/print/start returned ok but the printer never started.

Tested on CC2 firmware 02.01.00.00 with elegoo-web 0.2.1: after the change, /printer/print/start?filename=... starts the print.

Repro: curl -X POST http://host:7125/printer/print/start?filename=x.gcode → {"result":"ok"}, printer idle. Same call after the fix → print starts.